### PR TITLE
feat: add Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   auto-merge:
-    uses: SecPal/.github/.github/workflows/reusable-dependabot-auto-merge.yml@main
+    uses: SecPal/.github/.github/workflows/reusable-dependabot-auto-merge.yml@v1
     with:
       phase: "1" # Phase 1: Only PATCH updates auto-merge
       merge-method: "squash" # Use squash merge for cleaner history


### PR DESCRIPTION
## 🤖 Add Dependabot Auto-Merge Workflow

This PR adds automated Dependabot PR merging for **PATCH updates** to the API repository.

### 📝 Changes

**New File:**
- `.github/workflows/dependabot-auto-merge.yml`
  - Caller workflow using the reusable workflow from `.github` repo
  - Phase 1 policy: Auto-merge PATCH updates only
  - Squash merge strategy for cleaner history

### 🔧 Configuration

```yaml
phase: "1"           # PATCH only
merge-method: "squash"  # Squash commits
```

**Auto-merge Policy (Phase 1):**
- ✅ **PATCH** updates (1.2.3 → 1.2.4): Auto-merge after CI passes
- 🔍 **MINOR** updates (1.2.0 → 1.3.0): Manual review required
- ⚠️ **MAJOR** updates (1.x → 2.0.0): Manual review required

### 🔗 Dependencies

**Requires:**
- SecPal/.github#75 (reusable workflow) must be merged first

### ✅ Benefits

- 🚀 **Automated updates**: No manual intervention for low-risk PATCH updates
- 🛡️ **Risk mitigation**: Manual review for potentially breaking changes
- 📊 **Consistency**: Same policy across all SecPal repositories
- 🔄 **Maintainability**: Changes to policy managed centrally

### 🧪 Testing

Once PR #75 is merged in `.github` repo, this workflow will:
1. Trigger on Dependabot PRs
2. Parse version numbers from PR title
3. Auto-merge PATCH updates when CI passes
4. Add informative comments on all Dependabot PRs

### 📚 Related

- Part of organization-wide Dependabot automation (SecPal/.github#75)
- Uses fix from SecPal/.github#74 (flexible version parsing)