### PR TITLE
feat: Add automatic project board assignment workflow

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Add to project
         id: add-to-project
         continue-on-error: true
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           # NOTE: A fine-grained Personal Access Token is required here because GITHUB_TOKEN
           # lacks organization-level project permissions.
@@ -70,7 +70,7 @@ jobs:
 
       - name: Comment if project add failed
         if: steps.add-to-project.outcome == 'failure'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const body = [
@@ -117,26 +117,36 @@ jobs:
           BLOCKER="${{ contains(github.event.issue.labels.*.name, 'priority: blocker') }}"
 
           if [[ "$CORE_FEATURE" == "true" ]]; then
-            echo "status=📋 Backlog" >> "$GITHUB_OUTPUT"
+            echo "status=📋 Planned" >> "$GITHUB_OUTPUT"
+            echo "description=Core feature - scheduled for implementation" >> "$GITHUB_OUTPUT"
           elif [[ "$BLOCKER" == "true" ]]; then
-            echo "status=🎯 Ready" >> "$GITHUB_OUTPUT"
+            echo "status=📥 Backlog" >> "$GITHUB_OUTPUT"
+            echo "description=High priority - needs immediate attention" >> "$GITHUB_OUTPUT"
           else
             echo "status=💡 Ideas" >> "$GITHUB_OUTPUT"
+            echo "description=New idea - needs discussion and evaluation" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Comment on issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const status = '${{ steps.status.outputs.status }}';
+            const description = '${{ steps.status.outputs.description }}';
             const projectAdded = '${{ needs.add-to-project.outputs.project-add-outcome }}' === 'success';
             const message = projectAdded
-              ? `✅ This issue has been automatically added to the [SecPal Feature Roadmap](https://github.com/orgs/SecPal/projects/1) with status: **${status}**`
-              : `📋 Suggested status for [SecPal Feature Roadmap](https://github.com/orgs/SecPal/projects/1): **${status}**`;
+              ? `✅ This issue has been automatically added to the [SecPal Feature Roadmap](https://github.com/orgs/SecPal/projects/1) with status: **${status}**\n\n_${description}_`
+              : `📋 Suggested status for [SecPal Feature Roadmap](https://github.com/orgs/SecPal/projects/1): **${status}**\n\n_${description}_`;
+
+            const statusFlow = `
+            **Status Flow:**
+            💡 Ideas → 💬 Discussion → 📥 Backlog → 📋 Planned → 🚧 In Progress → 👀 In Review → ✅ Done
+
+            _Note: Ideas that won't be implemented should be moved to 🚫 Won't Do with a reason._`;
 
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `${message}\n\nNext steps:\n- Review and refine the issue description\n- Add relevant labels (area, priority)\n- Link related issues/PRs\n- Move to appropriate project column as needed`
+              body: `${message}\n${statusFlow}\n\n**Next steps:**\n- Review and refine the issue description\n- Add relevant labels (area, priority)\n- Discuss feasibility and approach\n- Move through status flow as work progresses`
             });


### PR DESCRIPTION
## ⏸️ Paused - Waiting for .github completion

This PR is temporarily closed while we finalize and test the workflow in the `.github` repository first.

**Reason:** Avoid duplicate work across repos. Once the workflow is fully functional and tested in `.github`, we'll reopen and update this PR with the final version.

**Related:**
- SecPal/.github#106 - Adding automatic status field updates
- Will reopen after successful testing in `.github` repo

**Original Description:**
Adds automatic project board assignment for issues with `enhancement` or `core-feature` labels.