### PR TITLE
fix: use core workflow to fix startup_failure

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -22,6 +22,6 @@ on:
 jobs:
   project-automation:
     name: Project automation
-    uses: SecPal/.github/.github/workflows/project-automation-v2.yml@main
+    uses: SecPal/.github/.github/workflows/project-automation-core.yml@main
     secrets:
       PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}


### PR DESCRIPTION
## 🎯 FINALLY Fix startup_failure!

### The Problem
**100% failure rate** - EVERY single workflow run has been `startup_failure` since deployment!

### The Solution
Change workflow reference from `project-automation-v2.yml` to `project-automation-core.yml`

**Before (BROKEN):**
```yaml
uses: SecPal/.github/.github/workflows/project-automation-v2.yml@main
```
❌ Hybrid workflow (workflow_call + direct events) → startup_failure

**After (FIXED):**
```yaml
uses: SecPal/.github/.github/workflows/project-automation-core.yml@main
```
✅ Pure reusable workflow (workflow_call ONLY) → should work!

### Why This Will Work
- The core workflow is a **pure reusable workflow** (no direct events mixed in)
- Matches the proven pattern of ALL other working reusable workflows
- Related refactor: SecPal/.github#133 (just merged)

### Testing
After merge, we'll **immediately** test by creating an issue to verify the automation FINALLY works!

Related: SecPal/.github#133