### PR TITLE
fix: use secrets inherit for cross-repo workflow calls

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -28,5 +28,4 @@ jobs:
   project-automation:
     name: Project automation
     uses: SecPal/.github/.github/workflows/project-automation-core.yml@main
-    secrets:
-      PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+    secrets: inherit


### PR DESCRIPTION
## Problem

After adding permissions to the caller workflow, the project automation still fails with `Bad credentials` error when called cross-repo from api/frontend/contracts.

## Root Cause

**Cross-repo workflow calls don't properly receive explicitly passed secrets.** 

The syntax:
```yaml
secrets:
  PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
```

...doesn't work reliably for cross-repository workflow calls due to GitHub Actions security scoping.

## Solution

Use `secrets: inherit` instead:

```yaml
secrets: inherit
```

This ensures all organization-level and repository-level secrets are available to the reusable workflow.

## Testing

This should fix the "Bad credentials" error. Will test by creating a new issue after merge.

## Related

- SecPal/.github#136 (permissions fix)
- SecPal/api#17 (previous permissions fix)