### PR TITLE
chore: standardize dependabot labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,7 @@ updates:
       include: "scope"
     labels:
       - "dependencies"
-      - "php"
+      - "composer"
       - "dependabot"
     open-pull-requests-limit: 10
     rebase-strategy: "auto"
@@ -60,7 +60,7 @@ updates:
       include: "scope"
     labels:
       - "dependencies"
-      - "javascript"
+      - "npm"
       - "dependabot"
     open-pull-requests-limit: 10
     rebase-strategy: "auto"


### PR DESCRIPTION
## 🏷️ Standardize Dependabot Labels

Standardizes Dependabot labels to be consistent across all repositories.

### Changes
- **composer**: Changed from `php` to `composer` (ecosystem-specific)
- **npm**: Changed from `javascript` to `npm` (ecosystem-specific)
- **github-actions**: Consistent with other repos

### Affected Files
- `.github/dependabot.yml`

### Related
Part of organization-wide Dependabot configuration standardization.

**Other repos:**
- ✅ `.github` - Already standardized (PR #151)
- ✅ `frontend` - PR #46
- ✅ `contracts` - Already correct