### PR TITLE
chore: add draft PR reminder workflow

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -29,3 +29,7 @@ jobs:
     name: Project automation
     uses: SecPal/.github/.github/workflows/project-automation-core.yml@main
     secrets: inherit
+
+  draft-reminder:
+    name: Draft PR Reminder
+    uses: SecPal/.github/.github/workflows/draft-pr-reminder.yml@main


### PR DESCRIPTION
## 📋 Summary

Adds the draft PR reminder workflow to this repository to align with the workflow already active in the  repository.

## 🎯 Changes

- Add `draft-reminder` job to `.github/workflows/project-automation.yml`
- Uses the reusable workflow from `SecPal/.github/.github/workflows/draft-pr-reminder.yml@main`

## ✨ Benefits

When new PRs are opened as regular PRs (not drafts), a friendly comment will be posted with these benefits:

- 💰 Saves CI runtime and Copilot review credits
- 🎯 Automatically sets linked issues to "🚧 In Progress" status
- 🚀 Mark "Ready for review" when done to trigger full CI pipeline

## 🔗 Related

This aligns all repositories (api, frontend, contracts) to use the same workflow pattern.