### PR TITLE
📋 Add Explicit Org-Wide Instructions Reminder

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,24 @@
 <!-- @EXTENDS: ../../.github/.github/copilot-instructions.md -->
 <!-- INHERITANCE: Core Principles + Org Rules from parent, Laravel-specific rules below -->
 
+<!--
+🚨 AI MUST READ ORGANIZATION-WIDE INSTRUCTIONS FIRST:
+   File: SecPal/.github/.github/copilot-instructions.md
+
+   Contains CRITICAL rules about:
+   - Copilot Review Protocol (GraphQL only, NO comment tools!)
+   - Pre-Commit/Pre-Push/CI Quality Gates
+   - Branch Protection & PR Rules
+   - TDD Mandatory Policy
+   - CHANGELOG Maintenance
+
+   ALWAYS check org instructions before taking actions on:
+   - Pull Request comments/reviews
+   - Commits and pushes
+   - Merges
+   - Quality gate decisions
+-->
+
 <laravel-boost-guidelines>
 === foundation rules ===
 


### PR DESCRIPTION
## 📋 Meta: Improve AI Instruction Compliance

**Context:** During PR #75, AI violated org-wide Copilot Review Protocol by attempting to use MCP comment tools instead of required GraphQL mutations.

### 🎯 What This Fixes

**Root Cause:**
- AI read **local** `api/.github/copilot-instructions.md` 
- But missed **org-wide** `SecPal/.github/.github/copilot-instructions.md`
- Org instructions have **stricter protocols** (e.g., GraphQL-only for Copilot reviews)

**Solution:**
- Added prominent HTML comment block at top of local instructions
- Explicitly reminds AI to read org-wide instructions FIRST
- Lists critical topics that require org-level compliance

### 📝 Changes

**File:** `.github/copilot-instructions.md`

**Added (lines 4-19):**
```html
<!--
🚨 AI MUST READ ORGANIZATION-WIDE INSTRUCTIONS FIRST:
   File: SecPal/.github/.github/copilot-instructions.md

   Contains CRITICAL rules about:
   - Copilot Review Protocol (GraphQL only, NO comment tools!)
   - Pre-Commit/Pre-Push/CI Quality Gates
   - Branch Protection & PR Rules
   - TDD Mandatory Policy
   - CHANGELOG Maintenance

   ALWAYS check org instructions before taking actions on:
   - Pull Request comments/reviews
   - Commits and pushes
   - Merges
   - Quality gate decisions
-->
```

### 🔒 Impact

**Prevents:**
- ❌ Using `mcp_github_github_add_issue_comment` on Copilot reviews
- ❌ Using `mcp_github_github_add_comment_to_pending_review` incorrectly
- ❌ Bypassing quality gates defined in org instructions
- ❌ Violating TDD or CHANGELOG policies

**Enables:**
- ✅ Explicit checklist for AI before PR/commit/merge actions
- ✅ Makes `@EXTENDS` inheritance actionable (not just documentation)
- ✅ Reduces risk of protocol violations in future PRs

### ✅ Quality Checks

- [x] Prettier formatted
- [x] Markdownlint clean  
- [x] REUSE compliant
- [x] All tests passing (127/127)

### 🔗 Related

- **Trigger:** PR #75 Copilot feedback handling
- **Org Instructions:** `SecPal/.github/.github/copilot-instructions.md`
- **Learning:** Always check parent instructions for stricter protocols

---

**Review Focus:** Verify reminder is prominent and covers critical org-wide topics. Should prevent future instruction misses.