### PR TITLE
🔧 Improve pre-push error message for PR size violations

### DIFF
--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -270,18 +270,38 @@ else
       echo "Preflight OK · Changed lines: 0 (after exclusions)"
       exit 0
     else
-      # Use --numstat for locale-independent parsing (sum insertions + deletions)
-      CHANGED=$(echo "$DIFF_OUTPUT" | awk '{ins+=$1; del+=$2} END {print ins+del+0}')
-      [ -z "$CHANGED" ] && CHANGED=0
+      # Use --numstat for locale-independent parsing
+      INSERTIONS=$(echo "$DIFF_OUTPUT" | awk '{ins+=$1} END {print ins+0}')
+      DELETIONS=$(echo "$DIFF_OUTPUT" | awk '{del+=$2} END {print del+0}')
+      CHANGED=$((INSERTIONS + DELETIONS))
 
       if [ "$CHANGED" -gt 600 ]; then
         # Check for override file (similar to GitHub label for exceptional cases)
         if [ -f "$ROOT_DIR/.preflight-allow-large-pr" ]; then
           echo "⚠️  Large PR override active ($CHANGED > 600 lines). Remove .preflight-allow-large-pr when done." >&2
         else
-          echo "PR too large ($CHANGED > 600 lines). Please split into smaller slices." >&2
-          echo "Tip: Lock files and license files are already excluded. See .preflight-exclude for details." >&2
-          echo "For exceptional cases, create .preflight-allow-large-pr to override this check." >&2
+          echo "" >&2
+          echo "═══════════════════════════════════════════════════════════════" >&2
+          echo "❌ PRE-PUSH CHECK FAILED: PR TOO LARGE" >&2
+          echo "═══════════════════════════════════════════════════════════════" >&2
+          echo "" >&2
+          echo "Your changes: $CHANGED lines ($INSERTIONS insertions, $DELETIONS deletions)" >&2
+          echo "Maximum allowed: 600 lines per PR" >&2
+          echo "" >&2
+          echo "Action required: Split changes into smaller, focused PRs" >&2
+          echo "" >&2
+          echo "💡 Available options:" >&2
+          echo "  1. Split PR: Recommended approach" >&2
+          echo "  2. Override check: touch .preflight-allow-large-pr" >&2
+          echo "  3. Bypass hook: git push --no-verify (not recommended)" >&2
+          echo "" >&2
+          echo "Note: Lock files and license files are already excluded" >&2
+          echo "      See .preflight-exclude for custom exclusion patterns" >&2
+          echo "" >&2
+          echo "═══════════════════════════════════════════════════════════════" >&2
+          echo "Push aborted. Fix the issue above and try again." >&2
+          echo "═══════════════════════════════════════════════════════════════" >&2
+          echo "" >&2
           exit 2
         fi
       else


### PR DESCRIPTION
## Problem

When pushing changes that exceed the 600-line limit, the pre-push hook showed an unclear error:

```
PR too large (644 > 600 lines). Please split into smaller slices.
error: failed to push some refs to 'github.com:SecPal/api.git'
```

Users couldn't easily see:
- The exact breakdown (insertions vs deletions)
- What action to take
- Available bypass options

## Solution

Enhanced error message with clear visual structure:

```
═══════════════════════════════════════════════════════════════
❌ PRE-PUSH CHECK FAILED: PR TOO LARGE
═══════════════════════════════════════════════════════════════

Your changes: 644 lines (636 insertions, 8 deletions)
Maximum allowed: 600 lines per PR

Action required: Split changes into smaller, focused PRs

💡 Available options:
  1. Split PR: Recommended approach
  2. Override check: touch .preflight-allow-large-pr
  3. Bypass hook: git push --no-verify (not recommended)

═══════════════════════════════════════════════════════════════
Push aborted. Fix the issue above and try again.
═══════════════════════════════════════════════════════════════
```

## Changes

- Added visual separators for attention
- Show exact breakdown (insertions + deletions separately)
- Numbered options (1-3) for clarity
- Clear "Push aborted" message before Git's error
- Better spacing for readability

## Testing

Manually tested error output format. The message now appears **before** Git's generic error, making the cause immediately clear.

Fixes #80