### PR TITLE
fix: add labeled event trigger to pull_request section

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -16,6 +16,7 @@ on:
       - ready_for_review
       - closed
       - converted_to_draft
+      - labeled
   pull_request_review:
     types:
       - submitted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Project automation now triggers on label changes (labeled event)
+- Project automation now triggers on label changes for issues AND pull requests (labeled event)
 - Pre-push hook no longer fails with exit code 1 when [Unreleased] is the last CHANGELOG section
 
 ### Added


### PR DESCRIPTION
## Problem

Following up on #95 and addressing Copilot review comment from contracts#42: The `pull_request` section was missing the `labeled` event trigger, while `issues` already had it.

## Solution

Add `labeled` event to pull_request types for consistency:

```yaml
pull_request:
  types:
    - opened
    - ready_for_review
    - closed
    - converted_to_draft
    - labeled  # ✅ ADDED
```

## Impact

- ✅ Pull requests with priority labels automatically tracked in project
- ✅ Consistent behavior between issues and PRs
- ✅ Complete project automation coverage

## Related

- #95 - Added `labeled` to issues (merged)
- contracts#42 - Copilot review comment that highlighted this gap
- Same fix being applied to frontend and contracts repos