### PR TITLE
fix(auth): Set sanctum as default guard in config/auth.php

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Auth Configuration: Set sanctum as default guard** (#134)
+  - Changed default guard from `'web'` to `'sanctum'` in `config/auth.php`
+  - Added explicit `sanctum` guard configuration to guards array
+  - Updated documentation comments to explain API-only, token-based architecture
+  - Aligns configuration with actual authentication mechanism (all routes use `auth:sanctum`)
+  - Self-documenting: Config now clearly shows SecPal is API-only (React PWA frontend)
+  - Consistent with User model `$guard_name = 'sanctum'` property (#129)
+  - No behavior change: All 207 tests passing
+
 ### Fixed
 
 - **Permission System Guard Migration** - Migrated from 'web' to 'sanctum' guard (#126, #127, #128, #129)

--- a/config/auth.php
+++ b/config/auth.php
@@ -10,14 +10,17 @@ return [
     | Authentication Defaults
     |--------------------------------------------------------------------------
     |
-    | This option defines the default authentication "guard" and password
-    | reset "broker" for your application. You may change these values
-    | as required, but they're a perfect start for most applications.
+    | SecPal is an API-only application (React PWA frontend) using stateless
+    | token-based authentication via Laravel Sanctum. The default guard is
+    | set to 'sanctum' to reflect this architecture.
+    |
+    | The 'web' guard is kept for Laravel's password reset flow (stateless
+    | token-based verification), but is NOT used for actual authentication.
     |
     */
 
     'defaults' => [
-        'guard' => env('AUTH_GUARD', 'web'),
+        'guard' => env('AUTH_GUARD', 'sanctum'),
         'passwords' => env('AUTH_PASSWORD_BROKER', 'users'),
     ],
 
@@ -26,21 +29,24 @@ return [
     | Authentication Guards
     |--------------------------------------------------------------------------
     |
-    | Next, you may define every authentication guard for your application.
-    | Of course, a great default configuration has been defined for you
-    | which utilizes session storage plus the Eloquent user provider.
+    | SecPal uses Laravel Sanctum for API token authentication. All API routes
+    | are protected with the 'sanctum' guard (stateless Bearer tokens).
     |
-    | All authentication guards have a user provider, which defines how the
-    | users are actually retrieved out of your database or other storage
-    | system used by the application. Typically, Eloquent is utilized.
+    | The 'web' guard remains configured for Laravel's password reset email
+    | verification flow only. It is NOT used for actual user authentication.
     |
-    | Supported: "session"
+    | Supported drivers: "session", "sanctum"
     |
     */
 
     'guards' => [
         'web' => [
             'driver' => 'session',
+            'provider' => 'users',
+        ],
+
+        'sanctum' => [
+            'driver' => 'sanctum',
             'provider' => 'users',
         ],
     ],


### PR DESCRIPTION
## Summary

Updates `config/auth.php` to set `sanctum` as the default guard instead of `web`, aligning configuration with SecPal's API-only, token-based architecture.

## Changes

- ✅ Changed default guard: `'web'` → `'sanctum'`
- ✅ Added explicit `sanctum` guard configuration to guards array
- ✅ Updated documentation comments explaining API-only architecture
- ✅ Self-documenting: Config now clearly shows React PWA + Bearer token architecture

## Why This Matters

**Before:** Config defaulted to `web` guard (semantically incorrect for API-only app)  
**After:** Config defaults to `sanctum` guard (matches actual authentication mechanism)

**Benefits:**
- Self-documenting configuration (future developers immediately see "API-only, token-based")
- Consistent with User model `$guard_name = 'sanctum'` (#129)
- Aligns config with actual authentication mechanism (all routes use `auth:sanctum`)
- Prevents confusion about authentication mechanism

## Review Notes: Guard Usage in Routes

**Question:** Are explicit `auth:sanctum` guard specifications in routes still necessary after this change?

**Answer:** ✅ **YES - They should REMAIN.**

**Reasoning:**
1. **Best Practice:** Explicit guard specification is recommended in Laravel
2. **Self-Documenting:** Makes the intent clear (API token-based authentication)
3. **No Ambiguity:** Prevents accidental fallback to wrong guard
4. **Future-Proof:** If we add other guards, explicit specification prevents confusion

**Current Routes (CORRECT):**
```php
Route::middleware('auth:sanctum')->group(function () {
    // Protected API endpoints
});
```

**Don't Change To:**
```php
Route::middleware('auth')->group(function () {  // ❌ Implicit - less clear
    // Protected API endpoints
});
```

**Conclusion:** Keep explicit `auth:sanctum` in routes. This PR only aligns the config with reality - it doesn't change the explicit route specifications (which are best practice).

## Testing

- ✅ All 207 tests passing (no behavior change)
- ✅ PHPStan Level Max: 0 errors
- ✅ Laravel Pint: Clean
- ✅ REUSE 3.3: Compliant
- ✅ Preflight script: Passed

### Specific Tests Verified

```bash
# Full test suite
ddev exec php artisan test
# Result: 207 passed (623 assertions)

# RoleApiTest (uses permissions with sanctum guard)
ddev exec php artisan test --filter=RoleApiTest
# Result: 24 passed

# AuthTest (token generation)
ddev exec php artisan test --filter=AuthTest
# Result: 18 passed
```

## Related Issues

- Fixes #134
- Part of: #125 (EPIC: Migrate Permission System to sanctum guard)
- Depends on: #129 (User model already declares `sanctum` guard) ✅
- Follows: #133 (Tests and User model already use sanctum) ✅

## Implementation Notes

**Why keep `web` guard?**
- Laravel requires it for default password reset flow
- We only use it for password reset email verification (stateless token-based)
- NOT used for actual authentication sessions

**No Breaking Changes:**
- Config change only - no code behavior change
- All authentication already uses `auth:sanctum` middleware
- User model already has `$guard_name = 'sanctum'`
- Tests already create permissions with `guard_name='sanctum'`

## Checklist

- [x] TDD: Tests written first (no new tests needed - config aligns with existing tests)
- [x] All tests pass (207 tests, 623 assertions)
- [x] PHPStan Level Max: 0 errors
- [x] Laravel Pint: Clean
- [x] REUSE 3.3: Compliant
- [x] CHANGELOG.md updated (in same commit)
- [x] Documentation comments updated
- [x] No `--no-verify` bypass used
- [x] One topic only (configuration change)
- [x] Self-reviewed using 4-pass review strategy

## PR Size

- **Lines Changed:** 39 lines (config + CHANGELOG)
- **Complexity:** Low (configuration alignment)
- **Risk:** Very low (aligns config with existing code)

---

**Category:** Configuration / Architecture  
**Effort:** 15 minutes  
**Impact:** Self-documenting configuration, architectural clarity