### PR TITLE
fix: add markdownlint exclude patterns and disable MD060 (#187)

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -4,5 +4,6 @@
   "MD013": false,
   "MD024": false,
   "MD033": false,
-  "MD041": false
+  "MD041": false,
+  "MD060": false
 }

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -47,7 +47,7 @@ git fetch origin "$BASE" 2>/dev/null || true
 FORMAT_EXIT=0
 if command -v npx >/dev/null 2>&1; then
   npx --yes prettier --check '**/*.{md,yml,yaml,json,ts,tsx,js,jsx}' || FORMAT_EXIT=1
-  npx --yes markdownlint-cli2 '**/*.md' || FORMAT_EXIT=1
+  npx --yes markdownlint-cli2 '**/*.md' '#node_modules' '#vendor' '#storage' '#build' || FORMAT_EXIT=1
 fi
 # Workflow linting (part of documented gates)
 # NOTE: actionlint is disabled in local preflight due to known hanging issues


### PR DESCRIPTION
## Summary

Part of retroactive compliance fix for Issue SecPal/.github#187.

## Changes

- ✅ **scripts/preflight.sh**: Added exclude patterns to markdownlint-cli2 (`#node_modules #vendor #storage #build`)
- ✅ **.markdownlint.json**: Disabled MD060 rule to prevent prettier/markdownlint table alignment conflict

## Why

storage/logs/laravel.log contains PHP stack traces with `#0`, `#1` markers that markdownlint incorrectly flagged as markdown headings → blocked push → required emergency exception.

## Testing

```bash
bash scripts/preflight.sh  # ✅ PASS
```

Part of SecPal/.github#187