### PR TITLE
fix: add route-level authorization middleware to Phase 4 RBAC endpoints

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -47,20 +47,30 @@ Route::prefix('v1')->group(function () {
         Route::get('/me', [AuthController::class, 'me']);
 
         // Role Management CRUD API
-        // Authorization handled by RoleManagementPolicy
-        Route::get('/roles', [RoleManagementController::class, 'index']);
-        Route::post('/roles', [RoleManagementController::class, 'store']);
-        Route::get('/roles/{id}', [RoleManagementController::class, 'show']);
-        Route::patch('/roles/{id}', [RoleManagementController::class, 'update']);
-        Route::delete('/roles/{id}', [RoleManagementController::class, 'destroy']);
+        // Authorization: Route-level permission middleware + Policy (defense-in-depth)
+        Route::get('/roles', [RoleManagementController::class, 'index'])
+            ->middleware('permission:roles.read');
+        Route::post('/roles', [RoleManagementController::class, 'store'])
+            ->middleware('permission:roles.create');
+        Route::get('/roles/{id}', [RoleManagementController::class, 'show'])
+            ->middleware('permission:roles.read');
+        Route::patch('/roles/{id}', [RoleManagementController::class, 'update'])
+            ->middleware('permission:roles.update');
+        Route::delete('/roles/{id}', [RoleManagementController::class, 'destroy'])
+            ->middleware('permission:roles.delete');
 
         // Permission Management CRUD API
-        // Authorization handled by PermissionManagementPolicy
-        Route::get('/permissions', [PermissionManagementController::class, 'index']);
-        Route::post('/permissions', [PermissionManagementController::class, 'store']);
-        Route::get('/permissions/{id}', [PermissionManagementController::class, 'show']);
-        Route::patch('/permissions/{id}', [PermissionManagementController::class, 'update']);
-        Route::delete('/permissions/{id}', [PermissionManagementController::class, 'destroy']);
+        // Authorization: Route-level permission middleware + Policy (defense-in-depth)
+        Route::get('/permissions', [PermissionManagementController::class, 'index'])
+            ->middleware('permission:permissions.read');
+        Route::post('/permissions', [PermissionManagementController::class, 'store'])
+            ->middleware('permission:permissions.create');
+        Route::get('/permissions/{id}', [PermissionManagementController::class, 'show'])
+            ->middleware('permission:permissions.read');
+        Route::patch('/permissions/{id}', [PermissionManagementController::class, 'update'])
+            ->middleware('permission:permissions.update');
+        Route::delete('/permissions/{id}', [PermissionManagementController::class, 'destroy'])
+            ->middleware('permission:permissions.delete');
 
         // Role management endpoints
         Route::post('/users/{user}/roles', [RoleController::class, 'store'])
@@ -73,10 +83,14 @@ Route::prefix('v1')->group(function () {
             ->middleware('permission:role.assign');
 
         // User Direct Permission Assignment API (RBAC Phase 4)
-        // Authorization handled by UserPermissionPolicy (viewPermissions, assignPermission, revokePermission)
+        // Authorization: Policy-based (users can view own, Admin can view all/modify)
         Route::get('/users/{user}/permissions', [UserPermissionController::class, 'index']);
-        Route::post('/users/{user}/permissions', [UserPermissionController::class, 'store']);
-        Route::delete('/users/{user}/permissions/{permission}', [UserPermissionController::class, 'destroy']);
+        // Authorization: Route-level permission middleware + Policy (Admin only)
+        Route::post('/users/{user}/permissions', [UserPermissionController::class, 'store'])
+            ->middleware('permission:permissions.assign_direct');
+        Route::delete('/users/{user}/permissions/{permission}', [UserPermissionController::class, 'destroy'])
+            ->middleware('permission:permissions.revoke_direct');
+        // Authorization: Policy-based (users can view own, Admin can view all)
         Route::get('/users/{user}/permissions/direct', [UserPermissionController::class, 'direct']);
 
         // Tenant-scoped Person endpoints

--- a/tests/Feature/UserPermissionAssignmentApiTest.php
+++ b/tests/Feature/UserPermissionAssignmentApiTest.php
@@ -28,12 +28,20 @@ beforeEach(function (): void {
     Permission::create(['name' => 'employees.export', 'guard_name' => 'sanctum']);
     Permission::create(['name' => 'reports.generate', 'guard_name' => 'sanctum']);
     Permission::create(['name' => 'shifts.read', 'guard_name' => 'sanctum']);
+    Permission::create(['name' => 'permissions.read', 'guard_name' => 'sanctum']);
+    Permission::create(['name' => 'permissions.assign_direct', 'guard_name' => 'sanctum']);
+    Permission::create(['name' => 'permissions.revoke_direct', 'guard_name' => 'sanctum']);
 
     // Create roles with permissions
     $managerRole = Role::create(['name' => 'Manager', 'guard_name' => 'sanctum']);
     $managerRole->givePermissionTo(['employees.read', 'shifts.read']);
 
     $adminRole = Role::create(['name' => 'Admin', 'guard_name' => 'sanctum']);
+    $adminRole->givePermissionTo([
+        'permissions.read',
+        'permissions.assign_direct',
+        'permissions.revoke_direct',
+    ]);
 });
 
 afterEach(function (): void {


### PR DESCRIPTION
## Summary
Added route-level authorization middleware to Phase 4 RBAC endpoints (Role Management, Permission Management, and User Direct Permission Assignment).

## Changes
- **Role Management API** (5 routes): Added permission middleware for roles.read, roles.create, roles.update, roles.delete
- **Permission Management API** (5 routes): Added permission middleware for permissions.read, permissions.create, permissions.update, permissions.delete
- **User Direct Permission Assignment** (2 write routes): Added permission middleware for permissions.assign_direct and permissions.revoke_direct
- **User Permission View routes** (2 read routes): Kept Policy-based authorization only (users can view own permissions without requiring permissions.read permission)

## Authorization Architecture
- **Write operations**: Route middleware (early rejection) + Policy (business logic) = Defense-in-depth
- **Read operations**: Policy-based only for view-own routes (users can see their own permissions)
- **Admin operations**: Full middleware + Policy protection

## Tests
- ✅ All 277 tests passing (1 skipped)
- Fixed UserPermissionAssignmentApiTest.php to include required permissions in Admin role setup
- RoleManagementApiTest.php and PermissionManagementApiTest.php already grant permissions per-test

Fixes #161