### PR TITLE
fix(ci): make codecov upload non-blocking for dependabot PRs

### DIFF
--- a/.github/workflows/php-ci.yml
+++ b/.github/workflows/php-ci.yml
@@ -87,4 +87,4 @@ jobs:
           files: ./coverage.xml
           flags: backend
           name: backend-coverage
-          fail_ci_if_error: true
+          fail_ci_if_error: ${{ !contains(fromJSON('["dependabot[bot]", "renovate[bot]"]'), github.actor) }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **CI/CD**: Codecov upload failures no longer block Dependabot PRs
+  - Set `fail_ci_if_error` conditionally: `false` for dependabot/renovate bots, `true` for normal PRs
+  - Allows automated dependency updates without CODECOV_TOKEN access issues
+  - Aligns with frontend implementation (DRY principle)
+
 ### Added
 
 - **User Language Preference** (#86)


### PR DESCRIPTION
## Problem

Dependabot PRs will fail CI with codecov upload errors because they don't have access to `CODECOV_TOKEN` secret for security reasons.

**Root Cause**: `fail_ci_if_error: true` is set unconditionally in `php-ci.yml`, causing the entire CI pipeline to fail even though tests pass.

## Solution

Set `fail_ci_if_error` conditionally based on the actor (dependabot/renovate get `false`, others get `true`) in the Codecov upload step.

- ✅ For normal PRs: Codecov upload failures still fail CI (security preserved)
- ✅ For Dependabot PRs: Codecov upload failures are non-blocking
- ✅ Tests still run and coverage is attempted for all PRs
- ✅ Aligns with frontend implementation (DRY principle, see SecPal/frontend#163)

## Testing

CI will pass with this change. Future Dependabot PRs will no longer be blocked by codecov upload failures.
