### PR TITLE
chore(boost): update AI guidelines to sync with package versions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -196,7 +196,7 @@ protected function isAccessible(User $user, ?string $path = null): bool
 
 - When creating models for tests, use the factories for the models. Check if the factory has custom states that can be used before manually setting up the model.
 - Faker: Use methods such as `$this->faker->word()` or `fake()->randomDigit()`. Follow existing conventions whether to use `$this->faker` or `fake()`.
-- When creating tests, make use of `php artisan make:test [options] {name}` to create a feature test, and pass `--unit` to create a unit test. Most tests should be feature tests.
+- When creating tests, use `php artisan make:test ExampleTest` to create a feature test, and `php artisan make:test ExampleTest --unit` to create a unit test. Most tests should be feature tests.
 
 ### Vite Error
 


### PR DESCRIPTION
## Summary
Manual Boost update to sync AI guidelines with current package versions after recent dependency updates.

## Changes
- Updated `.github/copilot-instructions.md` via `php artisan boost:update`
- Applied required linting fixes via `npx markdownlint-cli2 --fix`
- Applied Prettier formatting

## Process
As per DEVELOPMENT.md best practices:
1. `ddev exec php artisan boost:update` - Generate guidelines (requires DB access)
2. `npx markdownlint-cli2 --fix .github/copilot-instructions.md` - Fix linting violations
3. `npx prettier --write .github/copilot-instructions.md` - Fix formatting

## Context
This is a manual update following Laravel 12.39 and Boost 1.8.1 dependency updates. Ensures Copilot has accurate context about current package versions and Laravel best practices.

## Testing
- ✅ All 419 tests passing
- ✅ PHPStan level max clean  
- ✅ Linting and formatting checks passed

## Related
- Follows up on merged PRs #193, #194 (Laravel/Boost updates)
- Separate from PR #197 (DDEV automation) per "One Topic" principle