### PR TITLE
fix: Use absolute GitHub URLs for cross-repo documentation links

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -13,7 +13,7 @@ Quick start guide for SecPal API development.
 
 ### 📚 Read the Full Principles Guide
 
-👉 **[Development Principles & Best Practices](../../.github/docs/development-principles.md)**
+👉 **[Development Principles & Best Practices](https://github.com/SecPal/.github/blob/main/docs/development-principles.md)**
 
 This guide covers:
 

--- a/docs/COPILOT_REMINDER_PATTERNS.md
+++ b/docs/COPILOT_REMINDER_PATTERNS.md
@@ -7,7 +7,7 @@ SPDX-License-Identifier: CC0-1.0
 
 Quick prompts to reinforce core principles during development sessions.
 
-> **Note:** Full principles documented in [`.github/docs/development-principles.md`](../../../.github/docs/development-principles.md)
+> **Note:** Full principles documented in [`.github/docs/development-principles.md`](https://github.com/SecPal/.github/blob/main/docs/development-principles.md)
 
 ## 🚀 Quick Reminders
 


### PR DESCRIPTION
## Summary

Addresses Copilot review comments from PR #214 that were merged without the suggested fixes.

## Problem

The merged PR #214 still uses relative paths for cross-repository documentation links:
- `../../.github/docs/development-principles.md`
- `../../../.github/docs/development-principles.md`

These relative paths **do not work** in GitHub's web interface, as they reference a separate repository (`.github`).

## Solution

Replace relative paths with absolute GitHub URLs:
- `https://github.com/SecPal/.github/blob/main/docs/development-principles.md`

This ensures documentation links are accessible to all developers viewing on GitHub.

## Changes

### Modified
- `DEVELOPMENT.md` - Line 16: Absolute URL for principles guide
- `docs/COPILOT_REMINDER_PATTERNS.md` - Line 10: Absolute URL for principles guide

## Related

- Addresses: Copilot review comments in #214
- Related: #214

## Checklist

- [x] Follows Copilot suggestions exactly
- [x] All quality gates passing (480 tests, 1460 assertions)
- [x] Documentation-only change (no functional impact)
- [x] Improves developer experience