### PR TITLE
fix: Return 401 JSON for unauthenticated API requests (#253)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Unauthenticated API Request Handling** (#253)
+  - Fixed 500 "Route [login] not defined" error for unauthenticated requests to protected endpoints
+  - API now returns proper 401 JSON response `{"message": "Unauthenticated."}` instead of attempting redirect
+  - Added exception handler for `AuthenticationException` in `bootstrap/app.php`
+  - Added tests for unauthenticated request scenarios
+
 ### Added
 
 - **Deployment Documentation** (#245)

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -3,9 +3,11 @@
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+use Illuminate\Auth\AuthenticationException;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use Illuminate\Http\Request;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -36,5 +38,9 @@ return Application::configure(basePath: dirname(__DIR__))
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
-        //
+        // Return JSON 401 response for unauthenticated API requests
+        // Prevents "Route [login] not defined" error since this is a pure API without web routes
+        $exceptions->render(function (AuthenticationException $e, Request $request) {
+            return response()->json(['message' => 'Unauthenticated.'], 401);
+        });
     })->create();

--- a/tests/Feature/AuthTest.php
+++ b/tests/Feature/AuthTest.php
@@ -283,3 +283,21 @@ describe('Token Security', function () {
         expect(strlen($tokenRecord->token))->toBe(64);
     });
 });
+
+describe('Unauthenticated Request Handling', function () {
+    test('unauthenticated request to protected endpoint returns 401 JSON response', function () {
+        // Issue #253: API should return 401 JSON, not 500 "Route [login] not defined"
+        $response = $this->getJson('/v1/secrets');
+
+        $response->assertUnauthorized()
+            ->assertJson(['message' => 'Unauthenticated.']);
+    });
+
+    test('request with invalid token returns 401 JSON response', function () {
+        $response = $this->withHeader('Authorization', 'Bearer invalid-token-12345')
+            ->getJson('/v1/secrets');
+
+        $response->assertUnauthorized()
+            ->assertJson(['message' => 'Unauthenticated.']);
+    });
+});


### PR DESCRIPTION
## Summary

Fixes #253 - API was returning 500 "Route [login] not defined" for unauthenticated requests instead of proper 401 JSON response.

## Problem

When unauthenticated requests were made to protected API endpoints (e.g., `/v1/secrets`), the API returned a 500 Internal Server Error because Laravel's default `Authenticate` middleware attempted to redirect to a `login` route, which doesn't exist in a pure API application.

## Solution

Added an exception handler for `AuthenticationException` in `bootstrap/app.php` that returns a proper 401 JSON response:

```json
{"message": "Unauthenticated."}
```

## Changes

- `bootstrap/app.php`: Added exception handler for `AuthenticationException`
- `tests/Feature/AuthTest.php`: Added 2 tests for unauthenticated request scenarios
- `CHANGELOG.md`: Documented the fix

## Testing

- ✅ 522 tests pass (1590 assertions)
- ✅ PHPStan: No errors
- ✅ Pint: Code style OK
- ✅ REUSE: Compliant

## Verification

Before fix:
```
GET /v1/secrets → 500 Internal Server Error
Symfony\Component\Routing\Exception\RouteNotFoundException: Route [login] not defined.
```

After fix:
```
GET /v1/secrets → 401 Unauthorized
{"message": "Unauthenticated."}
```

## Checklist

- [x] Add exception handler for `AuthenticationException`
- [x] Return proper 401 JSON response
- [x] Add tests for unauthenticated request handling
- [x] Update CHANGELOG.md