### PR TITLE
fix(htaccess): add RewriteBase for Uberspace compatibility

### DIFF
--- a/public/.htaccess
+++ b/public/.htaccess
@@ -8,6 +8,7 @@
     </IfModule>
 
     RewriteEngine On
+    RewriteBase /
 
     # Handle Authorization Header
     RewriteCond %{HTTP:Authorization} .


### PR DESCRIPTION
## Summary

Fixes Apache 500 Internal Server Error (infinite redirect loop) on Uberspace hosting.

## Problem

After the previous PR #258 was merged, the API started returning 500 errors:

```
AH00124: Request exceeded the limit of 10 internal redirects due to probable configuration error
```

The Laravel development server worked fine, but Apache on Uberspace failed.

## Root Cause

On Uberspace, the DocumentRoot is a symlink:
```
api.secpal.dev → /var/www/virtual/secpal/api/public
```

Without an explicit `RewriteBase /` directive, Apache's mod_rewrite couldn't determine the correct base path for URL rewriting, causing an infinite redirect loop.

## Solution

Added `RewriteBase /` to `.htaccess` after `RewriteEngine On`.

## Testing

- ✅ Health endpoint returns 200 OK: `curl https://api.secpal.dev/health/ready`
- ✅ CORS headers correctly set
- ✅ All existing tests pass locally

## Notes

This is a standard fix for Laravel on shared hosting with symlinked DocumentRoots. The hotfix was already applied to production to restore service.