### PR TITLE
feat(api): implement Need-to-Know filtering for organizational units

### DIFF
--- a/app/Http/Controllers/Api/V1/OrganizationalUnitController.php
+++ b/app/Http/Controllers/Api/V1/OrganizationalUnitController.php
@@ -44,8 +44,12 @@ class OrganizationalUnitController extends Controller
         // Determine root unit IDs (units without accessible parents)
         $rootUnitIds = $this->determineRootUnitIds($accessibleUnits);
 
-        // Build query filtered to accessible units only
-        $query = OrganizationalUnit::whereIn('id', $accessibleIds);
+        /** @var string $tenantId */
+        $tenantId = $request->input('tenant_id');
+
+        // Build query filtered to accessible units only AND current tenant (defense-in-depth)
+        $query = OrganizationalUnit::whereIn('id', $accessibleIds)
+            ->where('tenant_id', $tenantId);
 
         // Filter by type if provided
         if ($request->has('type')) {
@@ -101,7 +105,7 @@ class OrganizationalUnitController extends Controller
      * A unit is a "root" in the accessible tree if it has no accessible parent.
      *
      * @param  \Illuminate\Database\Eloquent\Collection<int, OrganizationalUnit>  $accessibleUnits
-     * @return array<int, string>
+     * @return list<string>
      */
     private function determineRootUnitIds($accessibleUnits): array
     {

--- a/tests/Feature/Controllers/Api/V1/OrganizationalUnitControllerTest.php
+++ b/tests/Feature/Controllers/Api/V1/OrganizationalUnitControllerTest.php
@@ -472,6 +472,26 @@ describe('OrganizationalUnitController - Permission-Based Filtering (Need-to-Kno
         $rootUnitIds = $response->json('meta.root_unit_ids');
         expect($rootUnitIds)->toContain($region1->id)->toContain($region2->id);
     });
+
+    test('user cannot access organizational units from different tenant (cross-tenant isolation)', function () {
+        // Arrange: Create a second tenant with its own organizational unit
+        $otherTenantKeys = TenantKey::generateEnvelopeKeys();
+        $otherTenant = TenantKey::create($otherTenantKeys);
+
+        $otherTenantUnit = OrganizationalUnit::factory()->create([
+            'tenant_id' => $otherTenant->id,
+            'name' => 'Other Tenant Unit',
+            'type' => 'company',
+        ]);
+
+        // Act: Attempt to access with current user (who belongs to $this->tenant)
+        $response = getJson('/v1/organizational-units');
+
+        // Assert: Other tenant's unit is NOT visible
+        $response->assertOk();
+        $unitIds = collect($response->json('data'))->pluck('id')->toArray();
+        expect($unitIds)->not->toContain($otherTenantUnit->id);
+    });
 });
 
 describe('OrganizationalUnitController - Hierarchy', function () {


### PR DESCRIPTION
## Summary

Implements permission-based filtering for the organizational units API endpoint, enforcing the **Need-to-Know principle**. Users now only see organizational units they have explicit access to.

## BREAKING CHANGE ⚠️

The `/v1/organizational-units` endpoint now returns **ONLY** units the authenticated user has access to via their organizational scopes. This is intentional and enforces security by design.

**Before:** All tenant units were returned regardless of user permissions.  
**After:** Only accessible units based on `user_internal_organizational_scopes` are returned.

## Changes

### Controller (`OrganizationalUnitController::index()`)
- Uses `User::getAccessibleOrganizationalUnits()` instead of returning all tenant units
- Added `root_unit_ids` to response metadata (units without accessible parents in the user's tree)
- Parent filtering (`?parent_id=X`) now respects accessible scope
- If user requests children of an inaccessible parent, returns empty result

### Tests (`OrganizationalUnitControllerTest.php`)
- Updated `beforeEach` to use `include_descendants = true` for the test user's scope
- List tests now use `setParent()` to create proper closure relationships
- Added comprehensive tests for Need-to-Know filtering scenarios:
  - Branch manager sees only their own branch
  - Regional manager sees region and all branches
  - User with multiple scopes sees union of accessible units
  - `root_unit_ids` correctly identifies tree roots for the user's view

## Test Results

```
Tests: 104 passed (305 assertions) - OrganizationalUnit-related tests
Tests: 968 passed (2771 assertions) - Full test suite
```

## Related Issues

- Closes #279
- Part of Epic #280

## Checklist

- [x] Tests added/updated
- [x] PHPStan passes (`--level=max`)
- [x] Pint formatting passes
- [x] Documentation updated (docblocks)