### PR TITLE
fix(organizational-units): block deletion when children exist (409 Conflict)

### DIFF
--- a/app/Http/Controllers/Api/V1/OrganizationalUnitController.php
+++ b/app/Http/Controllers/Api/V1/OrganizationalUnitController.php
@@ -10,6 +10,7 @@ use App\Http\Requests\Api\StoreOrganizationalUnitRequest;
 use App\Http\Requests\Api\UpdateOrganizationalUnitRequest;
 use App\Http\Resources\OrganizationalUnitResource;
 use App\Models\OrganizationalUnit;
+use App\Models\OrganizationalUnitClosure;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
@@ -208,10 +209,29 @@ class OrganizationalUnitController extends Controller
 
     /**
      * Remove the specified organizational unit (soft delete).
+     *
+     * Uses blocking mode: deletion is prevented if the unit has child units.
+     * This prevents accidental data loss and enforces explicit restructuring.
+     *
+     * @see https://github.com/SecPal/api/issues/284 Edge-case decision: blocking mode
      */
     public function destroy(OrganizationalUnit $organizational_unit): JsonResponse
     {
         $this->authorize('delete', $organizational_unit);
+
+        // Check for children (Blocking Mode - Issue #284)
+        // We count direct children only (depth=1), as moving them is sufficient
+        $childCount = OrganizationalUnitClosure::where('ancestor_id', $organizational_unit->id)
+            ->where('depth', 1)
+            ->count();
+
+        if ($childCount > 0) {
+            return response()->json([
+                'message' => "Cannot delete: {$childCount} child unit(s) exist",
+                'child_count' => $childCount,
+                'hint' => 'Delete or move child units first',
+            ], Response::HTTP_CONFLICT);
+        }
 
         $organizational_unit->delete();
 

--- a/tests/Feature/Controllers/Api/V1/OrganizationalUnitControllerTest.php
+++ b/tests/Feature/Controllers/Api/V1/OrganizationalUnitControllerTest.php
@@ -313,7 +313,7 @@ describe('OrganizationalUnitController - Update', function () {
 });
 
 describe('OrganizationalUnitController - Delete', function () {
-    test('user can delete organizational unit', function () {
+    test('user can delete organizational unit without children', function () {
         // Arrange: Create a unit as child of root (user has scope on root)
         $unitToDelete = OrganizationalUnit::factory()->create([
             'tenant_id' => $this->tenant->id,
@@ -339,6 +339,93 @@ describe('OrganizationalUnitController - Delete', function () {
         // Verify soft delete
         $this->assertSoftDeleted('organizational_units', [
             'id' => $unitToDelete->id,
+        ]);
+    });
+
+    test('delete is blocked when unit has children (409 Conflict)', function () {
+        // Arrange: Create a unit with children
+        $parentUnit = OrganizationalUnit::factory()->create([
+            'tenant_id' => $this->tenant->id,
+            'name' => 'Parent Unit',
+            'type' => 'region',
+        ]);
+        $parentUnit->setParent($this->rootUnit);
+
+        // Create 3 child units
+        for ($i = 1; $i <= 3; $i++) {
+            $child = OrganizationalUnit::factory()->create([
+                'tenant_id' => $this->tenant->id,
+                'name' => "Child Unit {$i}",
+                'type' => 'branch',
+            ]);
+            $child->setParent($parentUnit);
+        }
+
+        // Give user explicit scope on the parent unit
+        UserInternalOrganizationalScope::create([
+            'tenant_id' => $this->tenant->id,
+            'user_id' => $this->user->id,
+            'organizational_unit_id' => $parentUnit->id,
+            'access_level' => 'admin',
+            'include_descendants' => true,
+        ]);
+
+        // Act
+        $response = deleteJson("/v1/organizational-units/{$parentUnit->id}");
+
+        // Assert: Should return 409 Conflict
+        $response->assertStatus(409)
+            ->assertJson([
+                'message' => 'Cannot delete: 3 child unit(s) exist',
+                'child_count' => 3,
+                'hint' => 'Delete or move child units first',
+            ]);
+
+        // Verify unit is NOT deleted
+        $this->assertDatabaseHas('organizational_units', [
+            'id' => $parentUnit->id,
+            'deleted_at' => null,
+        ]);
+    });
+
+    test('delete succeeds after children are removed', function () {
+        // Arrange: Create a unit with one child
+        $parentUnit = OrganizationalUnit::factory()->create([
+            'tenant_id' => $this->tenant->id,
+            'name' => 'Parent Unit',
+            'type' => 'region',
+        ]);
+        $parentUnit->setParent($this->rootUnit);
+
+        $child = OrganizationalUnit::factory()->create([
+            'tenant_id' => $this->tenant->id,
+            'name' => 'Child Unit',
+            'type' => 'branch',
+        ]);
+        $child->setParent($parentUnit);
+
+        // Give user admin scope
+        UserInternalOrganizationalScope::create([
+            'tenant_id' => $this->tenant->id,
+            'user_id' => $this->user->id,
+            'organizational_unit_id' => $parentUnit->id,
+            'access_level' => 'admin',
+            'include_descendants' => true,
+        ]);
+
+        // First attempt: Should be blocked
+        $response = deleteJson("/v1/organizational-units/{$parentUnit->id}");
+        $response->assertStatus(409);
+
+        // Move child to root (reparent)
+        $child->setParent($this->rootUnit);
+
+        // Second attempt: Should succeed now
+        $response = deleteJson("/v1/organizational-units/{$parentUnit->id}");
+        $response->assertNoContent();
+
+        $this->assertSoftDeleted('organizational_units', [
+            'id' => $parentUnit->id,
         ]);
     });
 });


### PR DESCRIPTION
## Summary

Implements blocking mode for organizational unit deletion as decided in #284.

## Problem

Previously, deleting an organizational unit with children would succeed silently, potentially orphaning children or causing data integrity issues.

## Solution

The DELETE endpoint now checks for direct children (depth=1 in closure table) and returns HTTP 409 Conflict if children exist.

### Response Format (when blocked)

```json
{
  "message": "Cannot delete: 3 child unit(s) exist",
  "child_count": 3,
  "hint": "Delete or move child units first"
}
```

## Why Blocking Mode?

As discussed in #284, blocking mode was chosen because:
- **Safe**: Prevents accidental data loss
- **Predictable**: Explicit behavior, no surprises
- **Reversible**: User can explicitly reparent or delete children first
- **Simple**: Easy to understand and implement

Other options considered but rejected:
- ❌ Cascade delete (dangerous, accidental data loss risk)
- ❌ Orphan children (may create invalid hierarchy)
- ❌ Require target parent (more complex API)

## Changes

- `OrganizationalUnitController::destroy()`: Added child count check
- New tests for blocking behavior

## Tests

- ✅ User can delete unit without children (existing, renamed)
- ✅ Delete blocked when unit has children (409 Conflict)  
- ✅ Delete succeeds after children are removed/reparented

## Quality Gates

- [x] PHPStan: No errors
- [x] Pint: No style issues
- [x] All 973 tests pass
- [x] REUSE compliant

## Checklist

- [x] TDD: Tests written and passing
- [x] SOLID: Single responsibility maintained
- [x] KISS: Simple, focused implementation (~20 LOC)
- [x] Documentation: PHPDoc updated with @see reference

Fixes #284