### PR TITLE
feat(api): Standardize API error responses to use 'message' key

### DIFF
--- a/app/Http/Controllers/Api/V1/OrganizationalScopeController.php
+++ b/app/Http/Controllers/Api/V1/OrganizationalScopeController.php
@@ -117,7 +117,6 @@ class OrganizationalScopeController extends Controller
 
         if ($scopeModel === null) {
             return response()->json([
-                'error' => 'Not found',
                 'message' => 'Scope not found',
             ], 404);
         }
@@ -125,7 +124,6 @@ class OrganizationalScopeController extends Controller
         // Verify scope belongs to this unit
         if ($scopeModel->organizational_unit_id !== $organizational_unit->id) {
             return response()->json([
-                'error' => 'Not found',
                 'message' => 'Scope not found for this organizational unit',
             ], 404);
         }
@@ -160,7 +158,6 @@ class OrganizationalScopeController extends Controller
 
         if ($scopeModel === null) {
             return response()->json([
-                'error' => 'Not found',
                 'message' => 'Scope not found',
             ], 404);
         }
@@ -168,7 +165,6 @@ class OrganizationalScopeController extends Controller
         // Verify scope belongs to this unit
         if ($scopeModel->organizational_unit_id !== $organizational_unit->id) {
             return response()->json([
-                'error' => 'Not found',
                 'message' => 'Scope not found for this organizational unit',
             ], 404);
         }

--- a/app/Http/Controllers/PersonController.php
+++ b/app/Http/Controllers/PersonController.php
@@ -67,7 +67,7 @@ class PersonController extends Controller
 
         if (! $email) {
             return response()->json([
-                'error' => 'Email query parameter is required',
+                'message' => 'Email query parameter is required',
             ], Response::HTTP_BAD_REQUEST);
         }
 
@@ -78,7 +78,7 @@ class PersonController extends Controller
 
         if (! $person) {
             return response()->json([
-                'error' => 'Person not found',
+                'message' => 'Person not found',
             ], Response::HTTP_NOT_FOUND);
         }
 

--- a/app/Http/Controllers/RoleController.php
+++ b/app/Http/Controllers/RoleController.php
@@ -185,7 +185,7 @@ class RoleController extends Controller
 
         if (! $assignment) {
             return response()->json([
-                'error' => 'Role not assigned to user',
+                'message' => 'Role not assigned to user',
             ], Response::HTTP_NOT_FOUND);
         }
 
@@ -232,7 +232,7 @@ class RoleController extends Controller
 
         if (! $assignment) {
             return response()->json([
-                'error' => 'Role not assigned to user',
+                'message' => 'Role not assigned to user',
             ], Response::HTTP_NOT_FOUND);
         }
 

--- a/app/Http/Middleware/CheckCustomerScope.php
+++ b/app/Http/Middleware/CheckCustomerScope.php
@@ -160,7 +160,6 @@ class CheckCustomerScope
     private function unauthorizedResponse(string $message): Response
     {
         return response()->json([
-            'error' => 'Unauthorized',
             'message' => $message,
         ], 401);
     }
@@ -171,7 +170,6 @@ class CheckCustomerScope
     private function forbiddenResponse(string $message): Response
     {
         return response()->json([
-            'error' => 'Access denied',
             'message' => $message,
         ], 403);
     }
@@ -182,7 +180,6 @@ class CheckCustomerScope
     private function notFoundResponse(string $message): Response
     {
         return response()->json([
-            'error' => 'Not found',
             'message' => $message,
         ], 404);
     }

--- a/app/Http/Middleware/CheckOrganizationalScope.php
+++ b/app/Http/Middleware/CheckOrganizationalScope.php
@@ -110,7 +110,6 @@ class CheckOrganizationalScope
     private function unauthorizedResponse(string $message): Response
     {
         return response()->json([
-            'error' => 'Unauthorized',
             'message' => $message,
         ], 401);
     }
@@ -121,7 +120,6 @@ class CheckOrganizationalScope
     private function forbiddenResponse(string $requiredLevel): Response
     {
         return response()->json([
-            'error' => 'Access denied',
             'message' => "Insufficient access level. Required: {$requiredLevel}",
         ], 403);
     }
@@ -132,7 +130,6 @@ class CheckOrganizationalScope
     private function notFoundResponse(string $message): Response
     {
         return response()->json([
-            'error' => 'Not found',
             'message' => $message,
         ], 404);
     }

--- a/app/Http/Middleware/InjectTenantId.php
+++ b/app/Http/Middleware/InjectTenantId.php
@@ -45,7 +45,7 @@ class InjectTenantId
 
         if ($tenantId === null) {
             return response()->json([
-                'error' => 'No tenant keys available. Please ensure at least one tenant key is configured.',
+                'message' => 'No tenant keys available. Please ensure at least one tenant key is configured.',
             ], Response::HTTP_SERVICE_UNAVAILABLE);
         }
 

--- a/app/Http/Middleware/SetTenant.php
+++ b/app/Http/Middleware/SetTenant.php
@@ -31,16 +31,14 @@ class SetTenant
 
         if ($tenantId === null) {
             return response()->json([
-                'error' => 'Tenant ID is required',
-                'message' => 'Please provide tenant ID in path (/tenants/{tenant}) or X-Tenant header',
+                'message' => 'Tenant ID is required. Please provide tenant ID in path (/tenants/{tenant}) or X-Tenant header.',
             ], 400);
         }
 
         // Verify tenant exists
         if (! TenantKey::where('id', $tenantId)->exists()) {
             return response()->json([
-                'error' => 'Tenant not found',
-                'message' => 'The specified tenant does not exist',
+                'message' => 'Tenant not found. The specified tenant does not exist.',
             ], 404);
         }
 

--- a/tests/Feature/Middleware/CheckOrganizationalScopeTest.php
+++ b/tests/Feature/Middleware/CheckOrganizationalScopeTest.php
@@ -194,8 +194,8 @@ describe('CheckOrganizationalScope Middleware', function () {
 
             $content = json_decode($response->getContent(), true);
 
-            expect($content)->toHaveKey('error');
-            expect($content['error'])->toBe('Access denied');
+            expect($content)->toHaveKey('message');
+            expect($content['message'])->toContain('Insufficient access level');
         });
     });
 

--- a/tests/Feature/Middleware/InjectTenantIdMiddlewareTest.php
+++ b/tests/Feature/Middleware/InjectTenantIdMiddlewareTest.php
@@ -63,7 +63,7 @@ describe('InjectTenantId Middleware', function () {
 
         $response->assertStatus(Response::HTTP_SERVICE_UNAVAILABLE)
             ->assertJson([
-                'error' => 'No tenant keys available. Please ensure at least one tenant key is configured.',
+                'message' => 'No tenant keys available. Please ensure at least one tenant key is configured.',
             ]);
     });
 

--- a/tests/Feature/PersonApiTest.php
+++ b/tests/Feature/PersonApiTest.php
@@ -189,7 +189,7 @@ describe('GET /v1/tenants/{tenant}/persons/by-email', function () {
 
         $response->assertStatus(400)
             ->assertJson([
-                'error' => 'Email query parameter is required',
+                'message' => 'Email query parameter is required',
             ]);
     });
 
@@ -201,7 +201,7 @@ describe('GET /v1/tenants/{tenant}/persons/by-email', function () {
 
         $response->assertStatus(404)
             ->assertJson([
-                'error' => 'Person not found',
+                'message' => 'Person not found',
             ]);
     });
 

--- a/tests/Feature/SetTenantMiddlewareTest.php
+++ b/tests/Feature/SetTenantMiddlewareTest.php
@@ -36,8 +36,7 @@ describe('SetTenant Middleware', function (): void {
 
         $response->assertStatus(400)
             ->assertJson([
-                'error' => 'Tenant ID is required',
-                'message' => 'Please provide tenant ID in path (/tenants/{tenant}) or X-Tenant header',
+                'message' => 'Tenant ID is required. Please provide tenant ID in path (/tenants/{tenant}) or X-Tenant header.',
             ]);
     });
 
@@ -46,8 +45,7 @@ describe('SetTenant Middleware', function (): void {
 
         $response->assertStatus(404)
             ->assertJson([
-                'error' => 'Tenant not found',
-                'message' => 'The specified tenant does not exist',
+                'message' => 'Tenant not found. The specified tenant does not exist.',
             ]);
     });
 


### PR DESCRIPTION
## Summary

Standardizes all API error responses to use the `'message'` key instead of `'error'`, aligning with Laravel conventions and the global exception handler format.

## Changes

### Controllers (4 files)
- **PersonController.php**: 2 occurrences replaced
- **RoleController.php**: 2 occurrences replaced
- **OrganizationalScopeController.php**: 4 redundant `'error'` keys removed

### Middleware (4 files)
- **InjectTenantId.php**: 1 occurrence replaced
- **SetTenant.php**: 2 redundant keys removed, messages combined
- **CheckOrganizationalScope.php**: 3 redundant keys removed from helper methods
- **CheckCustomerScope.php**: 3 redundant keys removed from helper methods

### Tests (4 files)
- **PersonApiTest.php**: 2 assertions updated
- **SetTenantMiddlewareTest.php**: 2 assertions updated
- **InjectTenantIdMiddlewareTest.php**: 1 assertion updated
- **CheckOrganizationalScopeTest.php**: 1 assertion updated

## Pattern Applied

**Before (inconsistent):**
```php
// Some files used 'error' only
return response()->json(['error' => 'Error message'], 400);

// Some files used both redundantly
return response()->json([
    'error' => 'Error type',
    'message' => 'Detailed message',
], 400);
```

**After (standardized):**
```php
// All files now use 'message' only
return response()->json(['message' => 'Clear, combined message.'], 400);
```

## Quality Gates

- ✅ All 973 tests pass
- ✅ PHPStan level max: No errors
- ✅ Laravel Pint: Code style compliant
- ✅ REUSE: License compliance verified

## Breaking Change Note

⚠️ **API clients** that parse the `'error'` key from responses need to update to use `'message'` instead.

This is intentional to establish a consistent API contract going forward.

Closes #291