### PR TITLE
fix(model): cleanup closure entries on soft delete (Issue #295)

### DIFF
--- a/app/Models/OrganizationalUnit.php
+++ b/app/Models/OrganizationalUnit.php
@@ -103,8 +103,21 @@ class OrganizationalUnit extends Model
             ]);
         });
 
+        // Clean up closure table entries on soft delete (Issue #295)
+        // This ensures the child count check in destroy() works correctly
+        // after a child unit has been soft-deleted.
+        static::deleted(function (OrganizationalUnit $unit): void {
+            // Delete all closure entries where this unit is ancestor or descendant
+            // Note: This removes the unit from the hierarchy but preserves the
+            // soft-deleted record in organizational_units table for potential restore.
+            OrganizationalUnitClosure::where(function ($query) use ($unit) {
+                $query->where('ancestor_id', $unit->id)
+                    ->orWhere('descendant_id', $unit->id);
+            })->delete();
+        });
+
         // Note: Closure table cleanup on force delete is handled by ON DELETE CASCADE
-        // in the database migration, so no explicit handler is needed here.
+        // in the database migration, so no explicit forceDeleted handler is needed.
     }
 
     /**

--- a/tests/Feature/Controllers/Api/V1/OrganizationalUnitControllerTest.php
+++ b/tests/Feature/Controllers/Api/V1/OrganizationalUnitControllerTest.php
@@ -428,6 +428,59 @@ describe('OrganizationalUnitController - Delete', function () {
             'id' => $parentUnit->id,
         ]);
     });
+
+    test('delete succeeds after children are deleted (soft-deleted children should not block)', function () {
+        // Arrange: Create a unit with one child - Issue #295 regression test
+        $parentUnit = OrganizationalUnit::factory()->create([
+            'tenant_id' => $this->tenant->id,
+            'name' => 'Parent Unit',
+            'type' => 'region',
+        ]);
+        $parentUnit->setParent($this->rootUnit);
+
+        $child = OrganizationalUnit::factory()->create([
+            'tenant_id' => $this->tenant->id,
+            'name' => 'Child Unit',
+            'type' => 'branch',
+        ]);
+        $child->setParent($parentUnit);
+
+        // Give user admin scope on parent with descendants
+        UserInternalOrganizationalScope::create([
+            'tenant_id' => $this->tenant->id,
+            'user_id' => $this->user->id,
+            'organizational_unit_id' => $parentUnit->id,
+            'access_level' => 'admin',
+            'include_descendants' => true,
+        ]);
+
+        // First attempt: Should be blocked because child exists
+        $response = deleteJson("/v1/organizational-units/{$parentUnit->id}");
+        $response->assertStatus(409)
+            ->assertJson([
+                'message' => 'Cannot delete: 1 child unit(s) exist',
+                'child_count' => 1,
+            ]);
+
+        // Delete the child unit (soft delete)
+        $response = deleteJson("/v1/organizational-units/{$child->id}");
+        $response->assertNoContent();
+        $this->assertSoftDeleted('organizational_units', ['id' => $child->id]);
+
+        // Verify closure entries were cleaned up (Issue #295 root cause)
+        $this->assertDatabaseMissing('organizational_unit_closures', [
+            'ancestor_id' => $parentUnit->id,
+            'descendant_id' => $child->id,
+        ]);
+
+        // Second attempt: Should succeed now because child was deleted
+        $response = deleteJson("/v1/organizational-units/{$parentUnit->id}");
+        $response->assertNoContent();
+
+        $this->assertSoftDeleted('organizational_units', [
+            'id' => $parentUnit->id,
+        ]);
+    });
 });
 
 describe('OrganizationalUnitController - Permission-Based Filtering (Need-to-Know)', function () {


### PR DESCRIPTION
## Summary

Fixes #295 - Bug: 409 Conflict when deleting organizational unit after child was already deleted

## Problem

When a child organizational unit is soft-deleted, the parent unit cannot be deleted afterwards because the controller's destroy() method still counts the soft-deleted child as existing. This happens because the closure table entries remain even after soft-deletion.

## Root Cause

The `OrganizationalUnit` model's `booted()` method only handled the `created` event for closure table management. On soft-delete, the closure table entries were not cleaned up, causing the child count check in `OrganizationalUnitController::destroy()` to still find the deleted children via the orphaned closure entries.

## Solution

Added a `deleted` event handler in `OrganizationalUnit::booted()` that removes all closure table entries where the soft-deleted unit is referenced (as ancestor or descendant). This ensures the hierarchy accurately reflects the current state of non-deleted units.

## Changes

- **app/Models/OrganizationalUnit.php**: Added `static::deleted()` event handler to clean up closure table entries on soft-delete
- **tests/Feature/Controllers/Api/V1/OrganizationalUnitControllerTest.php**: Added regression test that verifies deleting a parent succeeds after its child has been soft-deleted

## Testing

- ✅ New test case passes (TDD approach - red → green)
- ✅ All 974 tests pass
- ✅ PHPStan level max: No errors
- ✅ Pint: No style issues
- ✅ REUSE: Compliant

## Checklist

- [x] TDD approach followed (test written first, confirmed failure, then fix implemented)
- [x] Self-review completed per project guidelines
- [x] All quality gates pass
- [x] Issue reference included in commit message