### PR TITLE
fix(org-units): auto-assign admin scope to creator of root units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Newly Created Root Unit Not Visible** (#299, Part of Epic #283)
+  - Root organizational units created without a parent were not visible to the creator
+  - Creator now automatically receives `admin` scope with `include_descendants=true` on new root units
+  - Child units continue to inherit access from parent's scope settings
+  - Added 3 new tests covering auto-scope assignment and visibility
+
 - **Organizational Unit Eager Loading** (#282, Part of Epic #280)
   - Added missing `parent()` relation to `OrganizationalUnit` model for eager loading support
   - Fixes N+1 query issues when loading organizational units with parent relationships

--- a/app/Http/Controllers/Api/V1/OrganizationalUnitController.php
+++ b/app/Http/Controllers/Api/V1/OrganizationalUnitController.php
@@ -11,6 +11,7 @@ use App\Http\Requests\Api\UpdateOrganizationalUnitRequest;
 use App\Http\Resources\OrganizationalUnitResource;
 use App\Models\OrganizationalUnit;
 use App\Models\OrganizationalUnitClosure;
+use App\Models\UserInternalOrganizationalScope;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
@@ -171,6 +172,18 @@ class OrganizationalUnitController extends Controller
             /** @var OrganizationalUnit $parent */
             $parent = OrganizationalUnit::findOrFail($parentId);
             $unit->setParent($parent);
+        } else {
+            // Root unit created: Auto-assign admin scope to creator
+            // This ensures the creator can see and manage their new unit
+            // Child units inherit access via parent's include_descendants setting
+            /** @var \App\Models\User $user */
+            $user = $request->user();
+            UserInternalOrganizationalScope::create([
+                'user_id' => $user->id,
+                'organizational_unit_id' => $unit->id,
+                'access_level' => 'admin',
+                'include_descendants' => true,
+            ]);
         }
 
         return response()->json([

--- a/tests/Feature/Controllers/Api/V1/OrganizationalUnitControllerTest.php
+++ b/tests/Feature/Controllers/Api/V1/OrganizationalUnitControllerTest.php
@@ -267,6 +267,101 @@ describe('OrganizationalUnitController - Create', function () {
         $response->assertUnprocessable()
             ->assertJsonValidationErrors(['type']);
     });
+
+    test('creator automatically receives admin scope on new root unit', function () {
+        // Arrange: Remove existing scopes so user has no access
+        $this->user->organizationalScopes()->delete();
+
+        // Give user a minimal scope on existing unit (to satisfy viewAny policy)
+        UserInternalOrganizationalScope::create([
+            'user_id' => $this->user->id,
+            'organizational_unit_id' => $this->rootUnit->id,
+            'access_level' => 'read',
+            'include_descendants' => false,
+        ]);
+
+        $data = [
+            'name' => 'New Root Holding',
+            'type' => 'holding',
+        ];
+
+        // Act
+        $response = postJson('/v1/organizational-units', $data);
+
+        // Assert: Unit was created
+        $response->assertCreated();
+        $newUnitId = $response->json('data.id');
+
+        // Assert: Creator automatically has admin scope on new unit
+        $this->assertDatabaseHas('user_internal_organizational_scopes', [
+            'user_id' => $this->user->id,
+            'organizational_unit_id' => $newUnitId,
+            'access_level' => 'admin',
+            'include_descendants' => true,
+        ]);
+    });
+
+    test('newly created root unit is visible in list after creation', function () {
+        // Arrange: Remove existing scopes so user has no access
+        $this->user->organizationalScopes()->delete();
+
+        // Give user a minimal scope on existing unit (to satisfy viewAny policy)
+        UserInternalOrganizationalScope::create([
+            'user_id' => $this->user->id,
+            'organizational_unit_id' => $this->rootUnit->id,
+            'access_level' => 'read',
+            'include_descendants' => false,
+        ]);
+
+        $data = [
+            'name' => 'Brand New Holding',
+            'type' => 'holding',
+        ];
+
+        // Act: Create the unit
+        $createResponse = postJson('/v1/organizational-units', $data);
+        $createResponse->assertCreated();
+        $newUnitId = $createResponse->json('data.id');
+
+        // Act: List units - the new unit should be visible
+        $listResponse = getJson('/v1/organizational-units');
+
+        // Assert: New unit appears in list and in root_unit_ids
+        $listResponse->assertOk();
+        $unitIds = collect($listResponse->json('data'))->pluck('id')->toArray();
+        expect($unitIds)->toContain($newUnitId);
+
+        $rootUnitIds = $listResponse->json('meta.root_unit_ids');
+        expect($rootUnitIds)->toContain($newUnitId);
+    });
+
+    test('child unit inherits access from parent scope with include_descendants', function () {
+        // Arrange: User already has admin scope on rootUnit with include_descendants=true (from beforeEach)
+        $data = [
+            'name' => 'Child Department',
+            'type' => 'department',
+            'parent_id' => $this->rootUnit->id,
+        ];
+
+        // Act: Create child unit
+        $createResponse = postJson('/v1/organizational-units', $data);
+        $createResponse->assertCreated();
+        $childUnitId = $createResponse->json('data.id');
+
+        // Assert: No additional scope was created (access inherited from parent)
+        $this->assertDatabaseMissing('user_internal_organizational_scopes', [
+            'user_id' => $this->user->id,
+            'organizational_unit_id' => $childUnitId,
+        ]);
+
+        // Act: List units - child should be visible via inherited access
+        $listResponse = getJson('/v1/organizational-units');
+
+        // Assert: Child unit appears in list
+        $listResponse->assertOk();
+        $unitIds = collect($listResponse->json('data'))->pluck('id')->toArray();
+        expect($unitIds)->toContain($childUnitId);
+    });
 });
 
 describe('OrganizationalUnitController - Show', function () {


### PR DESCRIPTION
## Summary

Fixes the bug where newly created root organizational units (without a parent) were not visible to the creator in the tree view, despite the API response indicating success.

## Problem

With the Need-to-Know permission filtering implemented in #279, users only see organizational units they have explicit access to. When creating a new root unit, the creator had no scope assigned to it, making the unit invisible.

## Solution

When creating a root unit (no `parent_id`), the controller now automatically assigns an `admin` scope with `include_descendants=true` to the creator. This ensures:

1. ✅ Creators can immediately see their newly created root units
2. ✅ Creators have full management access to their units
3. ✅ Child units continue to inherit access from parent scopes (no change needed)

## Changes

| File | Change |
|------|--------|
| `OrganizationalUnitController.php` | Added auto-scope assignment for root units |
| `OrganizationalUnitControllerTest.php` | Added 3 new tests |
| `CHANGELOG.md` | Added entry under Fixed section |

## Testing

### New Tests Added
- `creator automatically receives admin scope on new root unit`
- `newly created root unit is visible in list after creation`
- `child unit inherits access from parent scope with include_descendants`

### Test Results
```
Tests:    977 passed (2807 assertions)
Duration: 118.03s
```

## Quality Gates

- [x] PHPStan level max: No errors
- [x] Laravel Pint: All files pass
- [x] REUSE 3.3: Compliant
- [x] Prettier: All files formatted
- [x] Markdownlint: No errors

## Acceptance Criteria from Issue

- [x] Newly created root unit (without parent) is immediately displayed in tree
- [x] User automatically has permissions on self-created units
- [x] Tree correctly refreshes after successful creation
- [x] Works for both first unit and additional root units

## Technical Notes

The fix is minimal and focused:
- Only affects root unit creation (units without `parent_id`)
- Child units already inherit access via `include_descendants` from parent scope
- Uses existing `UserInternalOrganizationalScope` model

---

Fixes #299
Part of Epic #283