### PR TITLE
chore: Fix Git hooks setup documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,23 +51,17 @@ Create a dedicated directory for all SecPal repositories. This mirrors the GitHu
    cd <repository>
    ```
 
-2. **Set up Git hooks (automatic):**
+2. **Set up Git hooks:**
 
-   Git hooks are automatically configured via `.githooks/` directory:
-
-   ```bash
-   git config core.hooksPath .githooks
-   ```
-
-3. **Install pre-commit (optional, for additional checks):**
+   Install both pre-commit and pre-push hooks:
 
    ```bash
-   # Install pre-commit
-   pip install pre-commit
-   # or: brew install pre-commit
+   # Install pre-commit (requires pre-commit to be installed first)
+   pip install --user pre-commit
+   ./scripts/setup-pre-commit.sh
 
-   # Install hooks
-   pre-commit install
+   # Install pre-push hook
+   ./scripts/setup-pre-push.sh
    ```
 
 ### Local Development Workflow


### PR DESCRIPTION
## Changes

- Update CONTRIBUTING.md with correct hook installation instructions

## Context

After a fresh installation/clone of the repositories, the Git hooks setup documentation was outdated. The previous instructions referenced `.githooks` with `core.hooksPath`, which is incompatible with the Python pre-commit framework.

## Solution

Documentation now correctly describes the setup process:
- Hooks are installed via `setup-pre-commit.sh` and `setup-pre-push.sh` scripts
- Hooks are created as symlinks in `.git/hooks/`
- Compatible with both pre-push (symlink) and pre-commit (Python framework) systems

## Testing

- ✅ Hooks verified as correctly installed
- ✅ Documentation reviewed for accuracy

## Related

- SecPal/.github#215 (master issue with workspace setup)