### PR TITLE
docs: fix OpenTimestamp PR reference in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- **OpenTimestamp Proof Verification - Secure Implementation** (Issue #412, PR #TBD)
+- **OpenTimestamp Proof Verification - Secure Implementation** (Issue #415, PR #417)
   - **IMPLEMENTED** secure CLI-based verification using official `ots verify` tool
   - Replaces vulnerable "hybrid approach" that was reverted in PR #413
   - Uses vetted OpenTimestamps CLI client for cryptographically sound verification
@@ -70,6 +70,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Installation: `pip install opentimestamps-client`
     - CLI reference: <https://github.com/opentimestamps/opentimestamps-client>
   - **Impact:** Level 3 audit trail verification now FULLY FUNCTIONAL and secure
+  - **Note:** Completes security fix from Issue #412 (revert) → Issue #415 (secure implementation)
 
 - **OpenTimestamp Proof Verification - Security Fix** (Issue #412, PR #413)
   - **REVERTED** unsecure "hybrid approach" implementation after Copilot security review


### PR DESCRIPTION
## Problem

Issue #415 (OpenTimestamp CLI-based verification) was merged via PR #417, but the CHANGELOG.md still contained placeholder text "PR #TBD" from the initial commit.

## Changes

Fixed CHANGELOG.md references:
- ~~`PR #TBD`~~ → `PR #417` (correct PR number)
- ~~`Issue #412`~~ → `Issue #415` (correct Issue number)
- Added clarification note about security fix vs. feature implementation timeline

## Type

Documentation-only fix. No functional changes.

## Validation

- ✅ References verified against GitHub
- ✅ PR #417 merged on 2025-12-24
- ✅ Issue #415 closed by PR #417
- ✅ No other files modified
- ✅ All quality gates passing

## Related

- Issue #415 (OpenTimestamp CLI verification)
- PR #417 (implementation, merged)

---

**Note:** Performance optimization commits moved to separate PR #421 per code review feedback (one PR = one topic).