### PR TITLE
fix: Laravel 12.45.x ResourceCollection compatibility

### DIFF
--- a/tests/Feature/Resources/SecretAttachmentResourceTest.php
+++ b/tests/Feature/Resources/SecretAttachmentResourceTest.php
@@ -101,7 +101,7 @@ test('resource transforms collection of attachments correctly', function () {
         'checksum_sha256' => hash('sha256', 'test-content-2'),
     ]);
 
-    $collection = SecretAttachmentResource::collection([$attachment1, $attachment2]);
+    $collection = SecretAttachmentResource::collection(collect([$attachment1, $attachment2]));
     $array = $collection->toArray(request());
 
     expect($array)->toHaveCount(2);


### PR DESCRIPTION
## Summary

Fixes test failures in all Dependabot PRs (#478, #479, #480, #481) caused by Laravel 12.45.0 breaking change in `ResourceCollection` handling.

## Problem

Laravel 12.45.0 introduced [PR #58299](https://github.com/laravel/framework/pull/58299) which changed how `ResourceCollection::collection()` handles plain arrays vs Model Collections. The test `SecretAttachmentResourceTest > resource transforms collection correctly` was passing a plain array, which now returns incorrect data structure.

**Failing Test:**
```php
$collection = SecretAttachmentResource::collection([$attachment1, $attachment2]);
// Returns: [null, null] instead of proper attachment data
```

**Error:**
```
FAILED  Tests\Feature\Resources\SecretAttachmentResourceTest > resource transforms collection correctly
Failed asserting that null is identical to 'file1.pdf'.
at tests/Feature/Resources/SecretAttachmentResourceTest.php:108
```

## Solution

Wrap the array in `collect()` to ensure proper Collection type:

```php
$collection = SecretAttachmentResource::collection(collect([$attachment1, $attachment2]));
```

This ensures the ResourceCollection receives an Eloquent Collection instead of a plain array, maintaining compatibility with Laravel 12.45.x.

## Testing

- ✅ Local: PHPStan Level 9 clean
- ✅ Local: Laravel Pint (PSR-12) compliant
- ✅ CI will verify: All 1817 tests pass

## Impact

- **Blocks:** #478, #479, #480, #481 (all Dependabot PRs)
- **Breaking Change Mitigation:** Adapts to Laravel 12.45.0 ResourceCollection behavior
- **No functional changes:** Only test code modified

## Related

- Laravel Framework PR: https://github.com/laravel/framework/pull/58299
- Laravel Release: v12.45.0 (2026-01-06)