### PR TITLE
fix: include email parameter in onboarding magic link URL

### DIFF
--- a/app/Mail/OnboardingInvitationMail.php
+++ b/app/Mail/OnboardingInvitationMail.php
@@ -64,7 +64,7 @@ class OnboardingInvitationMail extends Mailable implements ShouldQueue
             throw new \RuntimeException('Frontend URL or employee email not configured');
         }
 
-        $onboardingUrl = $frontendUrl.'/onboarding/complete?token='.urlencode($token);
+        $onboardingUrl = $frontendUrl.'/onboarding/complete?token='.urlencode($token).'&email='.urlencode($email);
 
         return new Content(
             markdown: 'emails.employees.onboarding-invitation',

--- a/tests/Feature/Mail/EmployeeLifecycleMailTest.php
+++ b/tests/Feature/Mail/EmployeeLifecycleMailTest.php
@@ -68,6 +68,30 @@ test('onboarding invitation mail has correct content', function () {
     expect($content->markdown)->toBe('emails.employees.onboarding-invitation');
 });
 
+test('onboarding invitation URL includes token and email parameters', function () {
+    $employee = Employee::factory()->create([
+        'tenant_id' => $this->tenant->id,
+        'organizational_unit_id' => $this->orgUnit->id,
+        'email' => 'test.onboarding@example.com',
+        'status' => Employee::STATUS_ACTIVE,
+    ]);
+
+    $user = User::factory()->create([
+        'name' => 'Test User',
+        'email' => 'test.onboarding@example.com',
+        'password' => bcrypt('password'),
+    ]);
+
+    $mail = new OnboardingInvitationMail($employee, $user);
+    $content = $mail->content();
+    $onboardingUrl = $content->with['onboardingUrl'];
+
+    // URL must contain both token and email parameters
+    expect($onboardingUrl)
+        ->toContain('?token=')
+        ->toContain('&email='.urlencode('test.onboarding@example.com'));
+});
+
 test('onboarding invitation mail generates password reset token', function () {
     $employee = Employee::factory()->create([
         'tenant_id' => $this->tenant->id,


### PR DESCRIPTION
## Problem

The `OnboardingInvitationMail` was generating magic link URLs without the required `email` parameter, causing the frontend to display "Missing email address. Please use the link from your email." error.

The email address was extracted from `$this->employee->email` but never included in the URL construction.

## Changes

### Backend Fix
- **File**: `app/Mail/OnboardingInvitationMail.php`
- **Line 68**: Added `&email=` parameter to the URL

```php
// Before (Bug):
$onboardingUrl = $frontendUrl.'/onboarding/complete?token='.urlencode($token);

// After (Fix):
$onboardingUrl = $frontendUrl.'/onboarding/complete?token='.urlencode($token).'&email='.urlencode($email);
```

### Test Coverage
- **File**: `tests/Feature/Mail/EmployeeLifecycleMailTest.php`
- **Added test**: `onboarding invitation URL includes token and email parameters`

This test validates that the generated URL contains both:
- `?token=` parameter
- `&email=` parameter with properly URL-encoded email address

## Impact

✅ Magic links now have the complete format: `/onboarding/complete?token=xxx&email=user@example.com`  
✅ Frontend can properly parse both parameters and complete onboarding  
✅ Test coverage ensures this regression won't happen again

## Testing

The test validates URL format:
```php
expect($onboardingUrl)
    ->toContain('?token=')
    ->toContain('&email='.urlencode('test.onboarding@example.com'));
```

## Related

- Frontend PR: SecPal/frontend#421 (Magic Link Onboarding Complete)
- The frontend already has proper error handling for missing email parameter
- This fix resolves the root cause on the backend side

---

**Type**: Bug Fix  
**Priority**: High (blocks onboarding flow)  
**Breaking Changes**: None