### PR TITLE
fix: constrain tenant-scoped admin route binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- reject cross-tenant target users on role-assignment and direct-permission administration endpoints with fail-closed 404 responses, including tenant-scoped user route binding and matching policy checks
+- reject cross-tenant target users on role-assignment and direct-permission administration endpoints with fail-closed 404 responses and matching policy checks
+- constrain route model binding for tenant-owned admin models to the authenticated tenant so cross-tenant resource identifiers fail closed before controller logic
+- preserve access to global system qualifications and onboarding templates while still fail-closing tenant-foreign bindings, including employee-linked submissions and qualification records
 - harden OpenTimestamp proof handling by creating restrictive temporary proof files via shared cleanup helpers and by logging only sanitized digest hints instead of full digests
 - align the Person API contract with plaintext transient fields by accepting `note_plain` instead of exposing direct `*_enc` input semantics
 - block tenant-crossing user reuse during pre-contract employee provisioning so onboarding accounts are only linked within the same tenant, and avoid logging employee email addresses in this path

--- a/app/Http/Requests/ExtendRoleRequest.php
+++ b/app/Http/Requests/ExtendRoleRequest.php
@@ -11,6 +11,7 @@ use Carbon\Carbon;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Validator;
 use Spatie\Permission\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
 
 class ExtendRoleRequest extends FormRequest
 {
@@ -63,11 +64,21 @@ class ExtendRoleRequest extends FormRequest
                 return;
             }
 
+            $tenantId = match (true) {
+                $routeUser instanceof User => $routeUser->tenant_id,
+                default => app(PermissionRegistrar::class)->getPermissionsTeamId(),
+            };
+
             // Find current assignment using role_id
-            $assignment = TemporalRoleUser::where('role_id', $role->id)
+            $assignmentQuery = TemporalRoleUser::where('role_id', $role->id)
                 ->where('model_id', $userId)
-                ->where('model_type', User::class)
-                ->first();
+                ->where('model_type', User::class);
+
+            if ($tenantId !== null) {
+                $assignmentQuery->where('tenant_id', $tenantId);
+            }
+
+            $assignment = $assignmentQuery->first();
 
             // Validate new valid_until is after current valid_until
             if ($assignment && $this->input('valid_until')) {

--- a/app/Models/Activity.php
+++ b/app/Models/Activity.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * SPDX-FileCopyrightText: 2025 SecPal Contributors
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Models\Concerns\EnforcesTenantRouteBinding;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Facades\DB;
@@ -66,7 +68,7 @@ use Spatie\Activitylog\Models\Activity as SpatieActivity;
 class Activity extends SpatieActivity
 {
     /** @use HasFactory<\Database\Factories\ActivityFactory> */
-    use HasFactory;
+    use EnforcesTenantRouteBinding, HasFactory;
 
     /**
      * The table associated with the model.
@@ -124,6 +126,18 @@ class Activity extends SpatieActivity
         'causer_id' => 'string',
         'subject_id' => 'string',
     ];
+
+    /**
+     * @param  Builder<static>  $query
+     * @param  mixed  $value
+     * @param  string|null  $field
+     * @return Builder<static>
+     */
+    protected function resolveBaseRouteBindingQuery($query, $value, $field = null): Builder
+    {
+        /** @var Builder<static> */
+        return parent::resolveRouteBindingQuery($query, $value, $field);
+    }
 
     /**
      * Get the OTS proof attribute.

--- a/app/Models/Concerns/EnforcesTenantRouteBinding.php
+++ b/app/Models/Concerns/EnforcesTenantRouteBinding.php
@@ -50,8 +50,12 @@ trait EnforcesTenantRouteBinding
      */
     protected function resolveBaseRouteBindingQuery($query, $value, $field = null): Builder
     {
-        /** @var Builder<static> */
-        return $this->resolveUuidRouteBindingQuery($query, $value, $field);
+        /** @var Builder<static> $builder */
+        $builder = $query;
+
+        $field ??= $this->getRouteKeyName();
+
+        return $builder->where($field, $value);
     }
 
     /**

--- a/app/Models/CostCenter.php
+++ b/app/Models/CostCenter.php
@@ -1,12 +1,13 @@
 <?php
 
-// SPDX-FileCopyrightText: 2025 SecPal Contributors
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Models\Concerns\EnforcesTenantRouteBinding;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -48,7 +49,10 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 class CostCenter extends Model
 {
     /** @use HasFactory<\Database\Factories\CostCenterFactory> */
-    use HasFactory, HasUuids, SoftDeletes;
+    use EnforcesTenantRouteBinding, HasFactory, HasUuids, SoftDeletes {
+        EnforcesTenantRouteBinding::resolveRouteBindingQuery insteadof HasUuids;
+        HasUuids::resolveRouteBindingQuery as resolveUuidRouteBindingQuery;
+    }
 
     /**
      * The table associated with the model.

--- a/app/Models/Customer.php
+++ b/app/Models/Customer.php
@@ -1,10 +1,11 @@
 <?php
 
-// SPDX-FileCopyrightText: 2025 SecPal Contributors
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 namespace App\Models;
 
+use App\Models\Concerns\EnforcesTenantRouteBinding;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -54,7 +55,10 @@ use Spatie\Activitylog\Traits\LogsActivity;
 class Customer extends Model
 {
     /** @use HasFactory<\Database\Factories\CustomerFactory> */
-    use HasFactory, HasUuids, LogsActivity, SoftDeletes;
+    use EnforcesTenantRouteBinding, HasFactory, HasUuids, LogsActivity, SoftDeletes {
+        EnforcesTenantRouteBinding::resolveRouteBindingQuery insteadof HasUuids;
+        HasUuids::resolveRouteBindingQuery as resolveUuidRouteBindingQuery;
+    }
 
     /**
      * The table associated with the model.

--- a/app/Models/CustomerAssignment.php
+++ b/app/Models/CustomerAssignment.php
@@ -1,12 +1,13 @@
 <?php
 
-// SPDX-FileCopyrightText: 2025 SecPal Contributors
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Models\Concerns\EnforcesTenantRouteBinding;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
@@ -49,7 +50,10 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 class CustomerAssignment extends Model
 {
     /** @use HasFactory<\Database\Factories\CustomerAssignmentFactory> */
-    use HasFactory, HasUuids;
+    use EnforcesTenantRouteBinding, HasFactory, HasUuids {
+        EnforcesTenantRouteBinding::resolveRouteBindingQuery insteadof HasUuids;
+        HasUuids::resolveRouteBindingQuery as resolveUuidRouteBindingQuery;
+    }
 
     /**
      * The table associated with the model.

--- a/app/Models/Employee.php
+++ b/app/Models/Employee.php
@@ -1,10 +1,11 @@
 <?php
 
-// SPDX-FileCopyrightText: 2025 SecPal Contributors
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 namespace App\Models;
 
+use App\Models\Concerns\EnforcesTenantRouteBinding;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
@@ -128,7 +129,10 @@ use Spatie\Activitylog\Traits\LogsActivity;
 class Employee extends Model
 {
     /** @use HasFactory<\Database\Factories\EmployeeFactory> */
-    use HasFactory, HasUuids, LogsActivity, SoftDeletes;
+    use EnforcesTenantRouteBinding, HasFactory, HasUuids, LogsActivity, SoftDeletes {
+        EnforcesTenantRouteBinding::resolveRouteBindingQuery insteadof HasUuids;
+        HasUuids::resolveRouteBindingQuery as resolveUuidRouteBindingQuery;
+    }
 
     /** Status constants */
     public const STATUS_APPLICANT = 'applicant';

--- a/app/Models/EmployeeQualification.php
+++ b/app/Models/EmployeeQualification.php
@@ -5,6 +5,8 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\EnforcesTenantRouteBinding;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -28,7 +30,10 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 class EmployeeQualification extends Model
 {
     /** @use HasFactory<\Database\Factories\EmployeeQualificationFactory> */
-    use HasFactory, HasUuids, SoftDeletes;
+    use EnforcesTenantRouteBinding, HasFactory, HasUuids, SoftDeletes {
+        EnforcesTenantRouteBinding::resolveRouteBindingQuery insteadof HasUuids;
+        HasUuids::resolveRouteBindingQuery as resolveUuidRouteBindingQuery;
+    }
 
     public const STATUS_ACTIVE = 'valid';
 
@@ -80,5 +85,16 @@ class EmployeeQualification extends Model
     public function qualification(): BelongsTo
     {
         return $this->belongsTo(Qualification::class);
+    }
+
+    /**
+     * @param  Builder<static>  $query
+     * @return Builder<static>
+     */
+    protected function applyTenantRouteBindingConstraint(Builder $query, int $tenantId): Builder
+    {
+        return $query->whereHas('employee', function (Builder $employeeQuery) use ($tenantId): void {
+            $employeeQuery->where('tenant_id', $tenantId);
+        });
     }
 }

--- a/app/Models/OnboardingFormSubmission.php
+++ b/app/Models/OnboardingFormSubmission.php
@@ -5,6 +5,8 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\EnforcesTenantRouteBinding;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -27,7 +29,10 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 class OnboardingFormSubmission extends Model
 {
     /** @use HasFactory<\Database\Factories\OnboardingFormSubmissionFactory> */
-    use HasFactory, HasUuids, SoftDeletes;
+    use EnforcesTenantRouteBinding, HasFactory, HasUuids, SoftDeletes {
+        EnforcesTenantRouteBinding::resolveRouteBindingQuery insteadof HasUuids;
+        HasUuids::resolveRouteBindingQuery as resolveUuidRouteBindingQuery;
+    }
 
     protected $fillable = [
         'employee_id',
@@ -75,5 +80,16 @@ class OnboardingFormSubmission extends Model
     public function reviewer(): BelongsTo
     {
         return $this->belongsTo(User::class, 'reviewed_by');
+    }
+
+    /**
+     * @param  Builder<static>  $query
+     * @return Builder<static>
+     */
+    protected function applyTenantRouteBindingConstraint(Builder $query, int $tenantId): Builder
+    {
+        return $query->whereHas('employee', function (Builder $employeeQuery) use ($tenantId): void {
+            $employeeQuery->where('tenant_id', $tenantId);
+        });
     }
 }

--- a/app/Models/OnboardingFormTemplate.php
+++ b/app/Models/OnboardingFormTemplate.php
@@ -5,6 +5,7 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\EnforcesTenantRouteBinding;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -27,7 +28,10 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 class OnboardingFormTemplate extends Model
 {
     /** @use HasFactory<\Database\Factories\OnboardingFormTemplateFactory> */
-    use HasFactory, HasUuids, SoftDeletes;
+    use EnforcesTenantRouteBinding, HasFactory, HasUuids, SoftDeletes {
+        EnforcesTenantRouteBinding::resolveRouteBindingQuery insteadof HasUuids;
+        HasUuids::resolveRouteBindingQuery as resolveUuidRouteBindingQuery;
+    }
 
     protected $fillable = [
         'tenant_id',
@@ -83,5 +87,13 @@ class OnboardingFormTemplate extends Model
     public function getCanBeEditedAttribute(): bool
     {
         return ! $this->is_system_template;
+    }
+
+    /**
+     * System templates remain globally addressable alongside tenant-local ones.
+     */
+    protected function routeBindingAllowsGlobalRecords(): bool
+    {
+        return true;
     }
 }

--- a/app/Models/OrganizationalUnit.php
+++ b/app/Models/OrganizationalUnit.php
@@ -1,10 +1,11 @@
 <?php
 
-// SPDX-FileCopyrightText: 2025 SecPal Contributors
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 namespace App\Models;
 
+use App\Models\Concerns\EnforcesTenantRouteBinding;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
@@ -49,7 +50,10 @@ use Illuminate\Support\Facades\DB;
 class OrganizationalUnit extends Model
 {
     /** @use HasFactory<\Database\Factories\OrganizationalUnitFactory> */
-    use HasFactory, HasUuids, SoftDeletes;
+    use EnforcesTenantRouteBinding, HasFactory, HasUuids, SoftDeletes {
+        EnforcesTenantRouteBinding::resolveRouteBindingQuery insteadof HasUuids;
+        HasUuids::resolveRouteBindingQuery as resolveUuidRouteBindingQuery;
+    }
 
     /**
      * The table associated with the model.

--- a/app/Models/Qualification.php
+++ b/app/Models/Qualification.php
@@ -5,6 +5,7 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\EnforcesTenantRouteBinding;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -30,7 +31,10 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 class Qualification extends Model
 {
     /** @use HasFactory<\Database\Factories\QualificationFactory> */
-    use HasFactory, HasUuids, SoftDeletes;
+    use EnforcesTenantRouteBinding, HasFactory, HasUuids, SoftDeletes {
+        EnforcesTenantRouteBinding::resolveRouteBindingQuery insteadof HasUuids;
+        HasUuids::resolveRouteBindingQuery as resolveUuidRouteBindingQuery;
+    }
 
     protected $fillable = [
         'tenant_id',
@@ -77,5 +81,13 @@ class Qualification extends Model
     public function employeeQualifications(): HasMany
     {
         return $this->hasMany(EmployeeQualification::class);
+    }
+
+    /**
+     * System qualifications remain globally addressable alongside tenant-local ones.
+     */
+    protected function routeBindingAllowsGlobalRecords(): bool
+    {
+        return true;
     }
 }

--- a/app/Models/Site.php
+++ b/app/Models/Site.php
@@ -1,10 +1,11 @@
 <?php
 
-// SPDX-FileCopyrightText: 2025 SecPal Contributors
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 namespace App\Models;
 
+use App\Models\Concerns\EnforcesTenantRouteBinding;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
@@ -68,7 +69,10 @@ use Spatie\Activitylog\Traits\LogsActivity;
 class Site extends Model
 {
     /** @use HasFactory<\Database\Factories\SiteFactory> */
-    use HasFactory, HasUuids, LogsActivity, SoftDeletes;
+    use EnforcesTenantRouteBinding, HasFactory, HasUuids, LogsActivity, SoftDeletes {
+        EnforcesTenantRouteBinding::resolveRouteBindingQuery insteadof HasUuids;
+        HasUuids::resolveRouteBindingQuery as resolveUuidRouteBindingQuery;
+    }
 
     /**
      * The table associated with the model.

--- a/app/Models/SiteAssignment.php
+++ b/app/Models/SiteAssignment.php
@@ -1,12 +1,13 @@
 <?php
 
-// SPDX-FileCopyrightText: 2025 SecPal Contributors
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Models\Concerns\EnforcesTenantRouteBinding;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
@@ -49,7 +50,10 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 class SiteAssignment extends Model
 {
     /** @use HasFactory<\Database\Factories\SiteAssignmentFactory> */
-    use HasFactory, HasUuids;
+    use EnforcesTenantRouteBinding, HasFactory, HasUuids {
+        EnforcesTenantRouteBinding::resolveRouteBindingQuery insteadof HasUuids;
+        HasUuids::resolveRouteBindingQuery as resolveUuidRouteBindingQuery;
+    }
 
     /**
      * The table associated with the model.

--- a/tests/Feature/Controllers/Api/V1/ActivityLogControllerTest.php
+++ b/tests/Feature/Controllers/Api/V1/ActivityLogControllerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * SPDX-FileCopyrightText: 2025 SecPal Contributors
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
@@ -16,46 +16,40 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Artisan;
 use Spatie\Permission\PermissionRegistrar;
 
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\getJson;
+
 /**
- * Feature tests for ActivityLogController.
- *
- * Tests scoped access control with:
- * - Tenant isolation
- * - Permission checks (activity_log.read)
- * - Organizational scope filtering
- * - Leadership level filtering
- * - Verification endpoints
- *
- * @see \App\Http\Controllers\Api\V1\ActivityLogController
- * @see \App\Policies\ActivityPolicy
- * @see SecPal/api#394 PR-11: ActivityLogController with scoped filtering
- * @see SecPal/api#385 Epic: Activity Logging & Audit Trail Strategy
- *
- * @property TenantKey $tenant
- * @property User $user
- * @property mixed $token
+ * @return array{tenant: TenantKey, registrar: PermissionRegistrar, user: User}
  */
+function createActivityLogContext(): array
+{
+    $keys = TenantKey::generateEnvelopeKeys();
+    $tenant = TenantKey::create($keys);
+
+    /** @var PermissionRegistrar $registrar */
+    $registrar = app(PermissionRegistrar::class);
+    $registrar->setPermissionsTeamId($tenant->id);
+
+    Artisan::call('db:seed', ['--class' => 'RolesAndPermissionsSeeder']);
+
+    $user = User::factory()->create(['tenant_id' => $tenant->id]);
+
+    return [
+        'tenant' => $tenant,
+        'registrar' => $registrar,
+        'user' => $user,
+    ];
+}
+
 uses(RefreshDatabase::class);
 
 beforeEach(function (): void {
     TenantKey::setKekPath(getTestKekPath());
     TenantKey::generateKek();
-    $keys = TenantKey::generateEnvelopeKeys();
-    $this->tenant = TenantKey::create($keys);
-
-    // Set tenant context for permission system
-    $registrar = app(PermissionRegistrar::class);
-    $registrar->setPermissionsTeamId($this->tenant->id);
-
-    // Run seeder to ensure predefined roles exist
-    Artisan::call('db:seed', ['--class' => 'RolesAndPermissionsSeeder']);
-
-    $this->user = User::factory()->create(['tenant_id' => $this->tenant->id]);
-    $this->token = $this->user->createToken('test-device')->plainTextToken;
 });
 
 afterEach(function (): void {
-    // Reset tenant context
     app(PermissionRegistrar::class)->setPermissionsTeamId(null);
     cleanupTestKekFile();
     TenantKey::setKekPath(null);
@@ -63,19 +57,28 @@ afterEach(function (): void {
 
 describe('GET /v1/activity-logs', function () {
     test('returns 401 when not authenticated', function (): void {
-        $response = $this->getJson('/v1/activity-logs');
+        createActivityLogContext();
+
+        $response = getJson('/v1/activity-logs');
         $response->assertStatus(401);
     });
 
     test('returns 403 when user lacks activity_log.read permission', function (): void {
-        $response = $this->withToken($this->token)->getJson('/v1/activity-logs');
+        ['user' => $user] = createActivityLogContext();
+
+        actingAs($user, 'sanctum');
+
+        $response = getJson('/v1/activity-logs');
         $response->assertStatus(403);
     });
 
     test('returns empty list when user has permission but no accessible logs', function (): void {
-        givePermissionWithTenant($this->user, $this->tenant->id, 'activity_log.read');
+        ['tenant' => $tenant, 'user' => $user] = createActivityLogContext();
 
-        $response = $this->withToken($this->token)->getJson('/v1/activity-logs');
+        givePermissionWithTenant($user, $tenant->id, 'activity_log.read');
+        actingAs($user, 'sanctum');
+
+        $response = getJson('/v1/activity-logs');
 
         $response->assertOk();
         expect($response->json('data'))->toBeArray();
@@ -83,17 +86,19 @@ describe('GET /v1/activity-logs', function () {
     });
 
     test('returns global activities (no org unit) to any user with permission', function (): void {
-        givePermissionWithTenant($this->user, $this->tenant->id, 'activity_log.read');
+        ['tenant' => $tenant, 'user' => $user] = createActivityLogContext();
 
-        // Create global activity (no organizational_unit_id)
+        givePermissionWithTenant($user, $tenant->id, 'activity_log.read');
+        actingAs($user, 'sanctum');
+
         Activity::factory()->create([
-            'tenant_id' => $this->tenant->id,
+            'tenant_id' => $tenant->id,
             'organizational_unit_id' => null,
             'log_name' => 'authentication',
             'description' => 'User logged in',
         ]);
 
-        $response = $this->withToken($this->token)->getJson('/v1/activity-logs');
+        $response = getJson('/v1/activity-logs');
 
         $response->assertOk();
         expect($response->json('data'))->toHaveCount(1);
@@ -101,32 +106,32 @@ describe('GET /v1/activity-logs', function () {
     });
 
     test('returns activities from accessible organizational units', function (): void {
-        givePermissionWithTenant($this->user, $this->tenant->id, 'activity_log.read');
+        ['tenant' => $tenant, 'user' => $user] = createActivityLogContext();
 
-        // Create organizational unit
+        givePermissionWithTenant($user, $tenant->id, 'activity_log.read');
+        actingAs($user, 'sanctum');
+
         $orgUnit = OrganizationalUnit::factory()->create([
-            'tenant_id' => $this->tenant->id,
+            'tenant_id' => $tenant->id,
             'name' => 'Department A',
         ]);
 
-        // Give user scope to this org unit
         UserInternalOrganizationalScope::factory()->create([
-            'user_id' => $this->user->id,
+            'user_id' => $user->id,
             'organizational_unit_id' => $orgUnit->id,
             'access_level' => 'read',
             'min_viewable_rank' => null,
             'max_viewable_rank' => null,
         ]);
 
-        // Create activity in this org unit
         Activity::factory()->create([
-            'tenant_id' => $this->tenant->id,
+            'tenant_id' => $tenant->id,
             'organizational_unit_id' => $orgUnit->id,
             'log_name' => 'employee_changes',
             'description' => 'Employee updated',
         ]);
 
-        $response = $this->withToken($this->token)->getJson('/v1/activity-logs');
+        $response = getJson('/v1/activity-logs');
 
         $response->assertOk();
         expect($response->json('data'))->toHaveCount(1);
@@ -134,39 +139,40 @@ describe('GET /v1/activity-logs', function () {
     });
 
     test('excludes activities from inaccessible organizational units', function (): void {
-        givePermissionWithTenant($this->user, $this->tenant->id, 'activity_log.read');
+        ['tenant' => $tenant, 'user' => $user] = createActivityLogContext();
+
+        givePermissionWithTenant($user, $tenant->id, 'activity_log.read');
+        actingAs($user, 'sanctum');
 
         $accessibleUnit = OrganizationalUnit::factory()->create([
-            'tenant_id' => $this->tenant->id,
+            'tenant_id' => $tenant->id,
         ]);
 
         $inaccessibleUnit = OrganizationalUnit::factory()->create([
-            'tenant_id' => $this->tenant->id,
+            'tenant_id' => $tenant->id,
         ]);
 
-        // Give user scope only to accessibleUnit
         UserInternalOrganizationalScope::factory()->create([
-            'user_id' => $this->user->id,
+            'user_id' => $user->id,
             'organizational_unit_id' => $accessibleUnit->id,
             'access_level' => 'read',
             'min_viewable_rank' => null,
             'max_viewable_rank' => null,
         ]);
 
-        // Create activities in both units
         Activity::factory()->create([
-            'tenant_id' => $this->tenant->id,
+            'tenant_id' => $tenant->id,
             'organizational_unit_id' => $accessibleUnit->id,
             'description' => 'Accessible activity',
         ]);
 
         Activity::factory()->create([
-            'tenant_id' => $this->tenant->id,
+            'tenant_id' => $tenant->id,
             'organizational_unit_id' => $inaccessibleUnit->id,
             'description' => 'Inaccessible activity',
         ]);
 
-        $response = $this->withToken($this->token)->getJson('/v1/activity-logs');
+        $response = getJson('/v1/activity-logs');
 
         $response->assertOk();
         expect($response->json('data'))->toHaveCount(1);
@@ -174,79 +180,78 @@ describe('GET /v1/activity-logs', function () {
     });
 
     test('excludes global activities for users with organizational scopes', function (): void {
-        givePermissionWithTenant($this->user, $this->tenant->id, 'activity_log.read');
+        ['tenant' => $tenant, 'user' => $user] = createActivityLogContext();
+
+        givePermissionWithTenant($user, $tenant->id, 'activity_log.read');
+        actingAs($user, 'sanctum');
 
         $orgUnit = OrganizationalUnit::factory()->create([
-            'tenant_id' => $this->tenant->id,
+            'tenant_id' => $tenant->id,
         ]);
 
-        // Give user scope to orgUnit
         UserInternalOrganizationalScope::factory()->create([
-            'user_id' => $this->user->id,
+            'user_id' => $user->id,
             'organizational_unit_id' => $orgUnit->id,
             'access_level' => 'read',
             'min_viewable_rank' => null,
             'max_viewable_rank' => null,
         ]);
 
-        // Create a global activity (no organizational_unit_id)
         Activity::factory()->create([
-            'tenant_id' => $this->tenant->id,
+            'tenant_id' => $tenant->id,
             'organizational_unit_id' => null,
             'description' => 'Global activity',
         ]);
 
-        // Create a scoped activity
         Activity::factory()->create([
-            'tenant_id' => $this->tenant->id,
+            'tenant_id' => $tenant->id,
             'organizational_unit_id' => $orgUnit->id,
             'description' => 'Scoped activity',
         ]);
 
-        $response = $this->withToken($this->token)->getJson('/v1/activity-logs');
+        $response = getJson('/v1/activity-logs');
 
         $response->assertOk();
-        // Users WITH scopes should see ONLY scoped activities, NOT global ones
         expect($response->json('data'))->toHaveCount(1);
         expect($response->json('data')[0]['description'])->toBe('Scoped activity');
     });
 
     test('filters by leadership level - only shows subordinates activities', function (): void {
-        givePermissionWithTenant($this->user, $this->tenant->id, 'activity_log.read');
+        ['tenant' => $tenant, 'user' => $user] = createActivityLogContext();
+
+        givePermissionWithTenant($user, $tenant->id, 'activity_log.read');
+        actingAs($user, 'sanctum');
 
         $orgUnit = OrganizationalUnit::factory()->create([
-            'tenant_id' => $this->tenant->id,
+            'tenant_id' => $tenant->id,
         ]);
 
-        // User has scope to view management levels 2-5 (subordinates)
         UserInternalOrganizationalScope::factory()->create([
-            'user_id' => $this->user->id,
+            'user_id' => $user->id,
             'organizational_unit_id' => $orgUnit->id,
             'access_level' => 'read',
             'min_viewable_rank' => 2,
             'max_viewable_rank' => 5,
         ]);
 
-        // Create employee users at different management levels
-        $seniorManager = User::factory()->create(['tenant_id' => $this->tenant->id]);
+        $seniorManager = User::factory()->create(['tenant_id' => $tenant->id]);
         Employee::factory()->create([
-            'tenant_id' => $this->tenant->id,
+            'tenant_id' => $tenant->id,
             'user_id' => $seniorManager->id,
             'organizational_unit_id' => $orgUnit->id,
-            'management_level' => 1, // Not visible (above viewable range)
+            'management_level' => 1,
         ]);
 
-        $subordinate = User::factory()->create(['tenant_id' => $this->tenant->id]);
+        $subordinate = User::factory()->create(['tenant_id' => $tenant->id]);
         Employee::factory()->create([
-            'tenant_id' => $this->tenant->id,
+            'tenant_id' => $tenant->id,
             'user_id' => $subordinate->id,
             'organizational_unit_id' => $orgUnit->id,
-            'management_level' => 3, // Visible (within range 2-5)
+            'management_level' => 3,
         ]);
 
-        // Create activities caused by these users
         Activity::factory()->create([
-            'tenant_id' => $this->tenant->id,
+            'tenant_id' => $tenant->id,
             'organizational_unit_id' => $orgUnit->id,
             'causer_type' => User::class,
             'causer_id' => $seniorManager->id,
@@ -254,14 +259,14 @@ describe('GET /v1/activity-logs', function () {
         ]);
 
         Activity::factory()->create([
-            'tenant_id' => $this->tenant->id,
+            'tenant_id' => $tenant->id,
             'organizational_unit_id' => $orgUnit->id,
             'causer_type' => User::class,
             'causer_id' => $subordinate->id,
             'description' => 'Subordinate activity',
         ]);
 
-        $response = $this->withToken($this->token)->getJson('/v1/activity-logs');
+        $response = getJson('/v1/activity-logs');
 
         $response->assertOk();
         expect($response->json('data'))->toHaveCount(1);
@@ -269,30 +274,32 @@ describe('GET /v1/activity-logs', function () {
     });
 
     test('shows system-generated activities regardless of leadership level', function (): void {
-        givePermissionWithTenant($this->user, $this->tenant->id, 'activity_log.read');
+        ['tenant' => $tenant, 'user' => $user] = createActivityLogContext();
+
+        givePermissionWithTenant($user, $tenant->id, 'activity_log.read');
+        actingAs($user, 'sanctum');
 
         $orgUnit = OrganizationalUnit::factory()->create([
-            'tenant_id' => $this->tenant->id,
+            'tenant_id' => $tenant->id,
         ]);
 
         UserInternalOrganizationalScope::factory()->create([
-            'user_id' => $this->user->id,
+            'user_id' => $user->id,
             'organizational_unit_id' => $orgUnit->id,
             'access_level' => 'read',
             'min_viewable_rank' => 2,
             'max_viewable_rank' => 5,
         ]);
 
-        // System-generated activity (no causer)
         Activity::factory()->create([
-            'tenant_id' => $this->tenant->id,
+            'tenant_id' => $tenant->id,
             'organizational_unit_id' => $orgUnit->id,
             'causer_type' => null,
             'causer_id' => null,
             'description' => 'System activity',
         ]);
 
-        $response = $this->withToken($this->token)->getJson('/v1/activity-logs');
+        $response = getJson('/v1/activity-logs');
 
         $response->assertOk();
         expect($response->json('data'))->toHaveCount(1);
@@ -300,25 +307,26 @@ describe('GET /v1/activity-logs', function () {
     });
 
     test('filters by date range', function (): void {
-        givePermissionWithTenant($this->user, $this->tenant->id, 'activity_log.read');
+        ['tenant' => $tenant, 'user' => $user] = createActivityLogContext();
 
-        // Create activities at different dates
+        givePermissionWithTenant($user, $tenant->id, 'activity_log.read');
+        actingAs($user, 'sanctum');
+
         Activity::factory()->create([
-            'tenant_id' => $this->tenant->id,
+            'tenant_id' => $tenant->id,
             'organizational_unit_id' => null,
             'description' => 'Old activity',
             'created_at' => now()->subDays(10),
         ]);
 
         Activity::factory()->create([
-            'tenant_id' => $this->tenant->id,
+            'tenant_id' => $tenant->id,
             'organizational_unit_id' => null,
             'description' => 'Recent activity',
             'created_at' => now()->subDays(2),
         ]);
 
-        $response = $this->withToken($this->token)
-            ->getJson('/v1/activity-logs?from_date='.now()->subDays(3)->toDateString());
+        $response = getJson('/v1/activity-logs?from_date='.now()->subDays(3)->toDateString());
 
         $response->assertOk();
         expect($response->json('data'))->toHaveCount(1);
@@ -326,24 +334,26 @@ describe('GET /v1/activity-logs', function () {
     });
 
     test('filters by log_name', function (): void {
-        givePermissionWithTenant($this->user, $this->tenant->id, 'activity_log.read');
+        ['tenant' => $tenant, 'user' => $user] = createActivityLogContext();
+
+        givePermissionWithTenant($user, $tenant->id, 'activity_log.read');
+        actingAs($user, 'sanctum');
 
         Activity::factory()->create([
-            'tenant_id' => $this->tenant->id,
+            'tenant_id' => $tenant->id,
             'organizational_unit_id' => null,
             'log_name' => 'authentication',
             'description' => 'User logged in',
         ]);
 
         Activity::factory()->create([
-            'tenant_id' => $this->tenant->id,
+            'tenant_id' => $tenant->id,
             'organizational_unit_id' => null,
             'log_name' => 'hr_access',
             'description' => 'HR data accessed',
         ]);
 
-        $response = $this->withToken($this->token)
-            ->getJson('/v1/activity-logs?log_name=hr_access');
+        $response = getJson('/v1/activity-logs?log_name=hr_access');
 
         $response->assertOk();
         expect($response->json('data'))->toHaveCount(1);
@@ -351,22 +361,24 @@ describe('GET /v1/activity-logs', function () {
     });
 
     test('searches in description', function (): void {
-        givePermissionWithTenant($this->user, $this->tenant->id, 'activity_log.read');
+        ['tenant' => $tenant, 'user' => $user] = createActivityLogContext();
+
+        givePermissionWithTenant($user, $tenant->id, 'activity_log.read');
+        actingAs($user, 'sanctum');
 
         Activity::factory()->create([
-            'tenant_id' => $this->tenant->id,
+            'tenant_id' => $tenant->id,
             'organizational_unit_id' => null,
             'description' => 'Employee contract updated',
         ]);
 
         Activity::factory()->create([
-            'tenant_id' => $this->tenant->id,
+            'tenant_id' => $tenant->id,
             'organizational_unit_id' => null,
             'description' => 'User logged out',
         ]);
 
-        $response = $this->withToken($this->token)
-            ->getJson('/v1/activity-logs?search=contract');
+        $response = getJson('/v1/activity-logs?search=contract');
 
         $response->assertOk();
         expect($response->json('data'))->toHaveCount(1);
@@ -374,16 +386,17 @@ describe('GET /v1/activity-logs', function () {
     });
 
     test('respects pagination parameters', function (): void {
-        givePermissionWithTenant($this->user, $this->tenant->id, 'activity_log.read');
+        ['tenant' => $tenant, 'user' => $user] = createActivityLogContext();
 
-        // Create 15 activities
+        givePermissionWithTenant($user, $tenant->id, 'activity_log.read');
+        actingAs($user, 'sanctum');
+
         Activity::factory()->count(15)->create([
-            'tenant_id' => $this->tenant->id,
+            'tenant_id' => $tenant->id,
             'organizational_unit_id' => null,
         ]);
 
-        $response = $this->withToken($this->token)
-            ->getJson('/v1/activity-logs?per_page=5');
+        $response = getJson('/v1/activity-logs?per_page=5');
 
         $response->assertOk();
         expect($response->json('data'))->toHaveCount(5);
@@ -392,16 +405,17 @@ describe('GET /v1/activity-logs', function () {
     });
 
     test('enforces tenant isolation', function (): void {
-        givePermissionWithTenant($this->user, $this->tenant->id, 'activity_log.read');
+        ['tenant' => $tenant, 'user' => $user] = createActivityLogContext();
 
-        // Create activity in user's tenant
+        givePermissionWithTenant($user, $tenant->id, 'activity_log.read');
+        actingAs($user, 'sanctum');
+
         Activity::factory()->create([
-            'tenant_id' => $this->tenant->id,
+            'tenant_id' => $tenant->id,
             'organizational_unit_id' => null,
             'description' => 'Own tenant activity',
         ]);
 
-        // Create second tenant and activity
         $otherTenant = TenantKey::factory()->create();
         Activity::factory()->create([
             'tenant_id' => $otherTenant->id,
@@ -409,7 +423,7 @@ describe('GET /v1/activity-logs', function () {
             'description' => 'Other tenant activity',
         ]);
 
-        $response = $this->withToken($this->token)->getJson('/v1/activity-logs');
+        $response = getJson('/v1/activity-logs');
 
         $response->assertOk();
         expect($response->json('data'))->toHaveCount(1);
@@ -419,29 +433,37 @@ describe('GET /v1/activity-logs', function () {
 
 describe('GET /v1/activity-logs/{activity}', function () {
     test('returns 401 when not authenticated', function (): void {
+        ['tenant' => $tenant] = createActivityLogContext();
+
         $activity = Activity::factory()->create([
-            'tenant_id' => $this->tenant->id,
+            'tenant_id' => $tenant->id,
             'organizational_unit_id' => null,
         ]);
 
-        $response = $this->getJson("/v1/activity-logs/{$activity->id}");
+        $response = getJson("/v1/activity-logs/{$activity->id}");
         $response->assertStatus(401);
     });
 
     test('returns 403 when user lacks activity_log.read permission', function (): void {
+        ['tenant' => $tenant, 'user' => $user] = createActivityLogContext();
+
         $activity = Activity::factory()->create([
-            'tenant_id' => $this->tenant->id,
+            'tenant_id' => $tenant->id,
             'organizational_unit_id' => null,
         ]);
 
-        $response = $this->withToken($this->token)
-            ->getJson("/v1/activity-logs/{$activity->id}");
+        actingAs($user, 'sanctum');
+
+        $response = getJson("/v1/activity-logs/{$activity->id}");
 
         $response->assertStatus(403);
     });
 
-    test('returns 403 when user tries to access activity from different tenant', function (): void {
-        givePermissionWithTenant($this->user, $this->tenant->id, 'activity_log.read');
+    test('returns 404 when user tries to access activity from different tenant', function (): void {
+        ['tenant' => $tenant, 'user' => $user] = createActivityLogContext();
+
+        givePermissionWithTenant($user, $tenant->id, 'activity_log.read');
+        actingAs($user, 'sanctum');
 
         $otherTenant = TenantKey::factory()->create();
         $activity = Activity::factory()->create([
@@ -449,24 +471,25 @@ describe('GET /v1/activity-logs/{activity}', function () {
             'organizational_unit_id' => null,
         ]);
 
-        $response = $this->withToken($this->token)
-            ->getJson("/v1/activity-logs/{$activity->id}");
+        $response = getJson("/v1/activity-logs/{$activity->id}");
 
-        $response->assertStatus(403);
+        $response->assertNotFound();
     });
 
     test('returns global activity when user has permission', function (): void {
-        givePermissionWithTenant($this->user, $this->tenant->id, 'activity_log.read');
+        ['tenant' => $tenant, 'user' => $user] = createActivityLogContext();
+
+        givePermissionWithTenant($user, $tenant->id, 'activity_log.read');
+        actingAs($user, 'sanctum');
 
         $activity = Activity::factory()->create([
-            'tenant_id' => $this->tenant->id,
+            'tenant_id' => $tenant->id,
             'organizational_unit_id' => null,
             'log_name' => 'authentication',
             'description' => 'User logged in',
         ]);
 
-        $response = $this->withToken($this->token)
-            ->getJson("/v1/activity-logs/{$activity->id}");
+        $response = getJson("/v1/activity-logs/{$activity->id}");
 
         $response->assertOk()
             ->assertJsonStructure([
@@ -485,14 +508,17 @@ describe('GET /v1/activity-logs/{activity}', function () {
     });
 
     test('returns activity from accessible organizational unit', function (): void {
-        givePermissionWithTenant($this->user, $this->tenant->id, 'activity_log.read');
+        ['tenant' => $tenant, 'user' => $user] = createActivityLogContext();
+
+        givePermissionWithTenant($user, $tenant->id, 'activity_log.read');
+        actingAs($user, 'sanctum');
 
         $orgUnit = OrganizationalUnit::factory()->create([
-            'tenant_id' => $this->tenant->id,
+            'tenant_id' => $tenant->id,
         ]);
 
         UserInternalOrganizationalScope::factory()->create([
-            'user_id' => $this->user->id,
+            'user_id' => $user->id,
             'organizational_unit_id' => $orgUnit->id,
             'access_level' => 'read',
             'min_viewable_rank' => null,
@@ -500,48 +526,50 @@ describe('GET /v1/activity-logs/{activity}', function () {
         ]);
 
         $activity = Activity::factory()->create([
-            'tenant_id' => $this->tenant->id,
+            'tenant_id' => $tenant->id,
             'organizational_unit_id' => $orgUnit->id,
         ]);
 
-        $response = $this->withToken($this->token)
-            ->getJson("/v1/activity-logs/{$activity->id}");
+        $response = getJson("/v1/activity-logs/{$activity->id}");
 
         $response->assertOk();
         expect($response->json('data.id'))->toBe($activity->id);
     });
 
     test('returns 403 for activity in inaccessible organizational unit', function (): void {
-        givePermissionWithTenant($this->user, $this->tenant->id, 'activity_log.read');
+        ['tenant' => $tenant, 'user' => $user] = createActivityLogContext();
+
+        givePermissionWithTenant($user, $tenant->id, 'activity_log.read');
+        actingAs($user, 'sanctum');
 
         $inaccessibleUnit = OrganizationalUnit::factory()->create([
-            'tenant_id' => $this->tenant->id,
+            'tenant_id' => $tenant->id,
         ]);
 
         $activity = Activity::factory()->create([
-            'tenant_id' => $this->tenant->id,
+            'tenant_id' => $tenant->id,
             'organizational_unit_id' => $inaccessibleUnit->id,
         ]);
 
-        $response = $this->withToken($this->token)
-            ->getJson("/v1/activity-logs/{$activity->id}");
+        $response = getJson("/v1/activity-logs/{$activity->id}");
 
         $response->assertStatus(403);
     });
 
     test('includes verification data when requested', function (): void {
-        givePermissionWithTenant($this->user, $this->tenant->id, 'activity_log.read');
+        ['tenant' => $tenant, 'user' => $user] = createActivityLogContext();
+
+        givePermissionWithTenant($user, $tenant->id, 'activity_log.read');
+        actingAs($user, 'sanctum');
 
         $activity = Activity::factory()->create([
-            'tenant_id' => $this->tenant->id,
+            'tenant_id' => $tenant->id,
             'organizational_unit_id' => null,
         ]);
 
-        // Hash chain must be built (happens via job in real scenario)
         $activity->refresh();
 
-        $response = $this->withToken($this->token)
-            ->getJson("/v1/activity-logs/{$activity->id}?include_verification=1");
+        $response = getJson("/v1/activity-logs/{$activity->id}?include_verification=1");
 
         $response->assertOk()
             ->assertJsonStructure([
@@ -559,41 +587,47 @@ describe('GET /v1/activity-logs/{activity}', function () {
 
 describe('GET /v1/activity-logs/{activity}/verify', function () {
     test('returns 401 when not authenticated', function (): void {
+        ['tenant' => $tenant] = createActivityLogContext();
+
         $activity = Activity::factory()->create([
-            'tenant_id' => $this->tenant->id,
+            'tenant_id' => $tenant->id,
             'organizational_unit_id' => null,
         ]);
 
-        $response = $this->getJson("/v1/activity-logs/{$activity->id}/verify");
+        $response = getJson("/v1/activity-logs/{$activity->id}/verify");
         $response->assertStatus(401);
     });
 
     test('returns 403 when user lacks activity_log.read permission', function (): void {
+        ['tenant' => $tenant, 'user' => $user] = createActivityLogContext();
+
         $activity = Activity::factory()->create([
-            'tenant_id' => $this->tenant->id,
+            'tenant_id' => $tenant->id,
             'organizational_unit_id' => null,
         ]);
 
-        $response = $this->withToken($this->token)
-            ->getJson("/v1/activity-logs/{$activity->id}/verify");
+        actingAs($user, 'sanctum');
+
+        $response = getJson("/v1/activity-logs/{$activity->id}/verify");
 
         $response->assertStatus(403);
     });
 
     test('returns verification results for accessible activity', function (): void {
-        givePermissionWithTenant($this->user, $this->tenant->id, 'activity_log.read');
+        ['tenant' => $tenant, 'user' => $user] = createActivityLogContext();
+
+        givePermissionWithTenant($user, $tenant->id, 'activity_log.read');
+        actingAs($user, 'sanctum');
 
         $activity = Activity::factory()->create([
-            'tenant_id' => $this->tenant->id,
+            'tenant_id' => $tenant->id,
             'organizational_unit_id' => null,
             'log_name' => 'authentication',
         ]);
 
-        // Hash chain must be built
         $activity->refresh();
 
-        $response = $this->withToken($this->token)
-            ->getJson("/v1/activity-logs/{$activity->id}/verify");
+        $response = getJson("/v1/activity-logs/{$activity->id}/verify");
 
         $response->assertOk()
             ->assertJsonStructure([
@@ -617,8 +651,11 @@ describe('GET /v1/activity-logs/{activity}/verify', function () {
         expect($response->json('data.verification.chain_valid'))->toBeTrue();
     });
 
-    test('enforces tenant isolation for verification', function (): void {
-        givePermissionWithTenant($this->user, $this->tenant->id, 'activity_log.read');
+    test('returns 404 for verification when activity belongs to different tenant', function (): void {
+        ['tenant' => $tenant, 'user' => $user] = createActivityLogContext();
+
+        givePermissionWithTenant($user, $tenant->id, 'activity_log.read');
+        actingAs($user, 'sanctum');
 
         $otherTenant = TenantKey::factory()->create();
         $activity = Activity::factory()->create([
@@ -626,9 +663,8 @@ describe('GET /v1/activity-logs/{activity}/verify', function () {
             'organizational_unit_id' => null,
         ]);
 
-        $response = $this->withToken($this->token)
-            ->getJson("/v1/activity-logs/{$activity->id}/verify");
+        $response = getJson("/v1/activity-logs/{$activity->id}/verify");
 
-        $response->assertStatus(403);
+        $response->assertNotFound();
     });
 });

--- a/tests/Feature/Models/TenantScopedRouteBindingTest.php
+++ b/tests/Feature/Models/TenantScopedRouteBindingTest.php
@@ -3,6 +3,13 @@
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+use App\Models\Activity;
+use App\Models\Customer;
+use App\Models\Employee;
+use App\Models\EmployeeQualification;
+use App\Models\OnboardingFormSubmission;
+use App\Models\OnboardingFormTemplate;
+use App\Models\Qualification;
 use App\Models\TenantKey;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -61,4 +68,134 @@ test('user route binding resolves only within the authenticated tenant', functio
 
     expect($resolvedSameTenantUser?->id)->toBe($sameTenantUser->id)
         ->and($resolvedOtherTenantUser)->toBeNull();
+});
+
+test('customer route binding resolves only within the authenticated tenant', function (): void {
+    ['tenant' => $tenant, 'otherTenant' => $otherTenant] = createTenantRouteBindingContext();
+
+    $sameTenantCustomer = Customer::factory()->forTenant($tenant->id)->create();
+    $otherTenantCustomer = Customer::factory()->forTenant($otherTenant->id)->create();
+
+    /** @var Customer|null $resolvedSameTenantCustomer */
+    $resolvedSameTenantCustomer = (new Customer)->resolveRouteBindingQuery(Customer::query(), $sameTenantCustomer->id)->first();
+    /** @var Customer|null $resolvedOtherTenantCustomer */
+    $resolvedOtherTenantCustomer = (new Customer)->resolveRouteBindingQuery(Customer::query(), $otherTenantCustomer->id)->first();
+
+    expect($resolvedSameTenantCustomer?->id)->toBe($sameTenantCustomer->id)
+        ->and($resolvedOtherTenantCustomer)->toBeNull();
+});
+
+test('qualification route binding includes global records and rejects other tenant records', function (): void {
+    ['tenant' => $tenant, 'otherTenant' => $otherTenant] = createTenantRouteBindingContext();
+
+    $sameTenantQualification = Qualification::factory()->create([
+        'tenant_id' => $tenant->id,
+        'is_system_qualification' => false,
+    ]);
+    $globalQualification = Qualification::factory()->create([
+        'tenant_id' => null,
+        'is_system_qualification' => true,
+    ]);
+    $otherTenantQualification = Qualification::factory()->create([
+        'tenant_id' => $otherTenant->id,
+        'is_system_qualification' => false,
+    ]);
+
+    /** @var Qualification|null $resolvedSameTenantQualification */
+    $resolvedSameTenantQualification = (new Qualification)->resolveRouteBindingQuery(Qualification::query(), $sameTenantQualification->id)->first();
+    /** @var Qualification|null $resolvedGlobalQualification */
+    $resolvedGlobalQualification = (new Qualification)->resolveRouteBindingQuery(Qualification::query(), $globalQualification->id)->first();
+    /** @var Qualification|null $resolvedOtherTenantQualification */
+    $resolvedOtherTenantQualification = (new Qualification)->resolveRouteBindingQuery(Qualification::query(), $otherTenantQualification->id)->first();
+
+    expect($resolvedSameTenantQualification?->id)->toBe($sameTenantQualification->id)
+        ->and($resolvedGlobalQualification?->id)->toBe($globalQualification->id)
+        ->and($resolvedOtherTenantQualification)->toBeNull();
+});
+
+test('employee qualification route binding resolves only through same-tenant employees', function (): void {
+    ['tenant' => $tenant, 'otherTenant' => $otherTenant] = createTenantRouteBindingContext();
+
+    $sameTenantEmployee = Employee::factory()->create([
+        'tenant_id' => $tenant->id,
+    ]);
+    $otherTenantEmployee = Employee::factory()->create([
+        'tenant_id' => $otherTenant->id,
+    ]);
+    $sameTenantQualification = Qualification::factory()->create([
+        'tenant_id' => $tenant->id,
+    ]);
+    $otherTenantQualification = Qualification::factory()->create([
+        'tenant_id' => $otherTenant->id,
+    ]);
+
+    $sameTenantEmployeeQualification = EmployeeQualification::factory()->create([
+        'employee_id' => $sameTenantEmployee->id,
+        'qualification_id' => $sameTenantQualification->id,
+    ]);
+    $otherTenantEmployeeQualification = EmployeeQualification::factory()->create([
+        'employee_id' => $otherTenantEmployee->id,
+        'qualification_id' => $otherTenantQualification->id,
+    ]);
+
+    /** @var EmployeeQualification|null $resolvedSameTenantEmployeeQualification */
+    $resolvedSameTenantEmployeeQualification = (new EmployeeQualification)->resolveRouteBindingQuery(EmployeeQualification::query(), $sameTenantEmployeeQualification->id)->first();
+    /** @var EmployeeQualification|null $resolvedOtherTenantEmployeeQualification */
+    $resolvedOtherTenantEmployeeQualification = (new EmployeeQualification)->resolveRouteBindingQuery(EmployeeQualification::query(), $otherTenantEmployeeQualification->id)->first();
+
+    expect($resolvedSameTenantEmployeeQualification?->id)->toBe($sameTenantEmployeeQualification->id)
+        ->and($resolvedOtherTenantEmployeeQualification)->toBeNull();
+});
+
+test('onboarding submission route binding resolves only through same-tenant employees', function (): void {
+    ['tenant' => $tenant, 'otherTenant' => $otherTenant] = createTenantRouteBindingContext();
+
+    $sameTenantEmployee = Employee::factory()->create([
+        'tenant_id' => $tenant->id,
+    ]);
+    $otherTenantEmployee = Employee::factory()->create([
+        'tenant_id' => $otherTenant->id,
+    ]);
+    $sameTenantTemplate = OnboardingFormTemplate::factory()->create([
+        'tenant_id' => $tenant->id,
+    ]);
+    $otherTenantTemplate = OnboardingFormTemplate::factory()->create([
+        'tenant_id' => $otherTenant->id,
+    ]);
+
+    $sameTenantSubmission = OnboardingFormSubmission::factory()->create([
+        'employee_id' => $sameTenantEmployee->id,
+        'form_template_id' => $sameTenantTemplate->id,
+    ]);
+    $otherTenantSubmission = OnboardingFormSubmission::factory()->create([
+        'employee_id' => $otherTenantEmployee->id,
+        'form_template_id' => $otherTenantTemplate->id,
+    ]);
+
+    /** @var OnboardingFormSubmission|null $resolvedSameTenantSubmission */
+    $resolvedSameTenantSubmission = (new OnboardingFormSubmission)->resolveRouteBindingQuery(OnboardingFormSubmission::query(), $sameTenantSubmission->id)->first();
+    /** @var OnboardingFormSubmission|null $resolvedOtherTenantSubmission */
+    $resolvedOtherTenantSubmission = (new OnboardingFormSubmission)->resolveRouteBindingQuery(OnboardingFormSubmission::query(), $otherTenantSubmission->id)->first();
+
+    expect($resolvedSameTenantSubmission?->id)->toBe($sameTenantSubmission->id)
+        ->and($resolvedOtherTenantSubmission)->toBeNull();
+});
+
+test('activity route binding resolves only within the authenticated tenant', function (): void {
+    ['tenant' => $tenant, 'otherTenant' => $otherTenant] = createTenantRouteBindingContext();
+
+    $sameTenantActivity = Activity::factory()->create([
+        'tenant_id' => $tenant->id,
+    ]);
+    $otherTenantActivity = Activity::factory()->create([
+        'tenant_id' => $otherTenant->id,
+    ]);
+
+    /** @var Activity|null $resolvedSameTenantActivity */
+    $resolvedSameTenantActivity = (new Activity)->resolveRouteBindingQuery(Activity::query(), $sameTenantActivity->id)->first();
+    /** @var Activity|null $resolvedOtherTenantActivity */
+    $resolvedOtherTenantActivity = (new Activity)->resolveRouteBindingQuery(Activity::query(), $otherTenantActivity->id)->first();
+
+    expect($resolvedSameTenantActivity?->id)->toBe($sameTenantActivity->id)
+        ->and($resolvedOtherTenantActivity)->toBeNull();
 });

--- a/tests/Feature/Models/TenantScopedRouteBindingTest.php
+++ b/tests/Feature/Models/TenantScopedRouteBindingTest.php
@@ -181,6 +181,34 @@ test('onboarding submission route binding resolves only through same-tenant empl
         ->and($resolvedOtherTenantSubmission)->toBeNull();
 });
 
+test('onboarding template route binding includes global records and rejects other tenant records', function (): void {
+    ['tenant' => $tenant, 'otherTenant' => $otherTenant] = createTenantRouteBindingContext();
+
+    $sameTenantTemplate = OnboardingFormTemplate::factory()->create([
+        'tenant_id' => $tenant->id,
+        'is_system_template' => false,
+    ]);
+    $globalTemplate = OnboardingFormTemplate::factory()->create([
+        'tenant_id' => null,
+        'is_system_template' => true,
+    ]);
+    $otherTenantTemplate = OnboardingFormTemplate::factory()->create([
+        'tenant_id' => $otherTenant->id,
+        'is_system_template' => false,
+    ]);
+
+    /** @var OnboardingFormTemplate|null $resolvedSameTenantTemplate */
+    $resolvedSameTenantTemplate = (new OnboardingFormTemplate)->resolveRouteBindingQuery(OnboardingFormTemplate::query(), $sameTenantTemplate->id)->first();
+    /** @var OnboardingFormTemplate|null $resolvedGlobalTemplate */
+    $resolvedGlobalTemplate = (new OnboardingFormTemplate)->resolveRouteBindingQuery(OnboardingFormTemplate::query(), $globalTemplate->id)->first();
+    /** @var OnboardingFormTemplate|null $resolvedOtherTenantTemplate */
+    $resolvedOtherTenantTemplate = (new OnboardingFormTemplate)->resolveRouteBindingQuery(OnboardingFormTemplate::query(), $otherTenantTemplate->id)->first();
+
+    expect($resolvedSameTenantTemplate?->id)->toBe($sameTenantTemplate->id)
+        ->and($resolvedGlobalTemplate?->id)->toBe($globalTemplate->id)
+        ->and($resolvedOtherTenantTemplate)->toBeNull();
+});
+
 test('activity route binding resolves only within the authenticated tenant', function (): void {
     ['tenant' => $tenant, 'otherTenant' => $otherTenant] = createTenantRouteBindingContext();
 


### PR DESCRIPTION
## Summary
- extend tenant-scoped route model binding across tenant-owned admin resources so foreign identifiers fail closed before controller logic
- preserve globally addressable qualifications and onboarding templates while constraining tenant-linked submissions and qualification records
- align the activity and regression coverage with the new fail-closed route binding behavior

## Context
- stacked on #574 to keep one topic per PR and reuse the shared binding concern introduced there
- addresses #572

## Validation
- `ddev exec vendor/bin/pint --dirty`
- `ddev exec php artisan test tests/Feature/Models/TenantScopedRouteBindingTest.php tests/Feature/Controllers/QualificationControllerTest.php tests/Feature/Controllers/EmployeeQualificationControllerTest.php tests/Feature/Controllers/OnboardingControllerTest.php tests/Feature/Controllers/Api/V1/ActivityLogControllerTest.php tests/Feature/Controllers/EmployeeDocumentControllerTest.php tests/Feature/Policies/EmployeeDocumentPolicyTest.php tests/Feature/Services/EmployeeDocumentStorageServiceTest.php --compact`
- `ddev exec php -d memory_limit=512M ./vendor/bin/phpstan analyse`
- editor diagnostics clean for the touched files