### PR TITLE
chore(style): re-enable fully qualified strict types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `pint.json` and repository-wide PHP/test files - re-enabled `fully_qualified_strict_types` after a dedicated Pint baseline to keep the stricter style rule active without mixing it into the dependency bump PR
 - `app/Http/Controllers/Api/V1/EmployeeDocumentController.php`, `app/Policies/EmployeeDocumentPolicy.php`, and `app/Http/Resources/EmployeeDocumentResource.php` - aligned employee document authorization with a consistent policy model, encrypted stored document binaries at rest, and removed raw storage paths from API responses
 - `database/factories/EmployeeDocumentFactory.php` and employee document feature/policy tests - updated fixtures and tests to reflect encrypted storage and the normalized authorization behavior
 - `app/Services/EmployeeDocumentStorageService.php` and employee document controller/policy tests - tightened missing-file handling to return 404 only for true storage misses, validated upload metadata before persisting encrypted blobs, and replaced duplicate manager coverage with a real scoped-manager scenario

--- a/app/Http/Controllers/Api/V1/ActivityLogController.php
+++ b/app/Http/Controllers/Api/V1/ActivityLogController.php
@@ -27,7 +27,7 @@ use Illuminate\Http\Request;
  * - Verification endpoint (hash chain + Merkle + OpenTimestamp)
  *
  * @see \App\Policies\ActivityPolicy
- * @see \App\Models\Activity
+ * @see Activity
  * @see SecPal/api#394 PR-11: ActivityLogController with scoped filtering
  * @see SecPal/api#385 Epic: Activity Logging & Audit Trail Strategy
  * @see SecPal/.github#docs/adr/20251221-activity-logging-audit-trail-strategy.md ADR-010

--- a/app/Http/Controllers/Api/V1/CustomerAssignmentController.php
+++ b/app/Http/Controllers/Api/V1/CustomerAssignmentController.php
@@ -24,7 +24,7 @@ use Symfony\Component\HttpFoundation\Response;
  * Allows organizations to use their own terminology (e.g., "Key Account Manager",
  * "Sales Representative", "Billing Contact").
  *
- * @see \App\Models\CustomerAssignment
+ * @see CustomerAssignment
  * @see SecPal/api#315 Assignment API endpoints
  * @see SecPal/.github#210 Customer & Site Management Epic
  */

--- a/app/Http/Controllers/Api/V1/OrganizationalUnitController.php
+++ b/app/Http/Controllers/Api/V1/OrganizationalUnitController.php
@@ -81,7 +81,7 @@ class OrganizationalUnitController extends Controller
                         ],
                     ]);
                 }
-                $childIds = \App\Models\OrganizationalUnitClosure::where('ancestor_id', $parentId)
+                $childIds = OrganizationalUnitClosure::where('ancestor_id', $parentId)
                     ->where('depth', 1)
                     ->whereIn('descendant_id', $accessibleIds)
                     ->pluck('descendant_id');
@@ -121,7 +121,7 @@ class OrganizationalUnitController extends Controller
 
         foreach ($accessibleUnits as $unit) {
             // Get immediate parent via closure table
-            $parentClosure = \App\Models\OrganizationalUnitClosure::where('descendant_id', $unit->id)
+            $parentClosure = OrganizationalUnitClosure::where('descendant_id', $unit->id)
                 ->where('depth', 1)
                 ->first();
 

--- a/app/Http/Controllers/Api/V1/SiteAssignmentController.php
+++ b/app/Http/Controllers/Api/V1/SiteAssignmentController.php
@@ -24,7 +24,7 @@ use Symfony\Component\HttpFoundation\Response;
  * Allows organizations to use their own terminology (e.g., "Account Manager",
  * "Site Manager", "Operations Lead", "Quality Manager").
  *
- * @see \App\Models\SiteAssignment
+ * @see SiteAssignment
  * @see SecPal/api#315 Assignment API endpoints
  * @see SecPal/.github#210 Customer & Site Management Epic
  */

--- a/app/Http/Controllers/RoleController.php
+++ b/app/Http/Controllers/RoleController.php
@@ -47,7 +47,7 @@ class RoleController extends Controller
             ? Carbon::parse($request->string('valid_until')->toString())
             : null;
 
-        /** @var \App\Models\User $authUser */
+        /** @var User $authUser */
         $authUser = $request->user();
         /** @var int|null $tenantId */
         $tenantId = app(\Spatie\Permission\PermissionRegistrar::class)->getPermissionsTeamId();
@@ -175,7 +175,7 @@ class RoleController extends Controller
         $targetUser = $user;
         $role = Role::where('name', $roleName)->firstOrFail();
 
-        /** @var \App\Models\User $authUser */
+        /** @var User $authUser */
         $authUser = $request->user();
         /** @var int|null $tenantId */
         $tenantId = app(\Spatie\Permission\PermissionRegistrar::class)->getPermissionsTeamId();
@@ -222,7 +222,7 @@ class RoleController extends Controller
         $targetUser = $user;
         $role = Role::where('name', $roleName)->firstOrFail();
 
-        /** @var \App\Models\User $authUser */
+        /** @var User $authUser */
         $authUser = $request->user();
         /** @var int|null $tenantId */
         $tenantId = app(\Spatie\Permission\PermissionRegistrar::class)->getPermissionsTeamId();

--- a/app/Http/Middleware/CheckOrganizationalScope.php
+++ b/app/Http/Middleware/CheckOrganizationalScope.php
@@ -39,7 +39,7 @@ class CheckOrganizationalScope
     /**
      * Handle an incoming request.
      *
-     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     * @param  Closure(Request): (Response)  $next
      * @param  string  $requiredLevel  The minimum access level required (default: 'read')
      */
     public function handle(Request $request, Closure $next, string $requiredLevel = 'read'): Response

--- a/app/Http/Middleware/EnsureNotPreContract.php
+++ b/app/Http/Middleware/EnsureNotPreContract.php
@@ -27,7 +27,7 @@ class EnsureNotPreContract
     /**
      * Handle an incoming request.
      *
-     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     * @param  Closure(Request): (Response)  $next
      */
     public function handle(Request $request, Closure $next): Response
     {

--- a/app/Http/Middleware/EnsurePreContract.php
+++ b/app/Http/Middleware/EnsurePreContract.php
@@ -27,7 +27,7 @@ class EnsurePreContract
     /**
      * Handle an incoming request.
      *
-     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     * @param  Closure(Request): (Response)  $next
      */
     public function handle(Request $request, Closure $next): Response
     {

--- a/app/Http/Middleware/ForceJsonResponse.php
+++ b/app/Http/Middleware/ForceJsonResponse.php
@@ -26,7 +26,7 @@ class ForceJsonResponse
     /**
      * Handle an incoming request.
      *
-     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     * @param  Closure(Request): (Response)  $next
      */
     public function handle(Request $request, Closure $next): Response
     {

--- a/app/Http/Middleware/InjectTenantId.php
+++ b/app/Http/Middleware/InjectTenantId.php
@@ -34,7 +34,7 @@ class InjectTenantId
      * Returns 401 if user is not authenticated.
      * Always overrides client-provided tenant_id to prevent cross-tenant attacks.
      *
-     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     * @param  Closure(Request): (Response)  $next
      */
     public function handle(Request $request, Closure $next): Response
     {

--- a/app/Http/Middleware/RestoreSessionFromRememberToken.php
+++ b/app/Http/Middleware/RestoreSessionFromRememberToken.php
@@ -29,7 +29,7 @@ class RestoreSessionFromRememberToken
     /**
      * Handle an incoming request.
      *
-     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     * @param  Closure(Request): (Response)  $next
      */
     public function handle(Request $request, Closure $next): Response
     {

--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -20,7 +20,7 @@ class SecurityHeaders
     /**
      * Handle an incoming request.
      *
-     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     * @param  Closure(Request): (Response)  $next
      */
     public function handle(Request $request, Closure $next): Response
     {

--- a/app/Http/Middleware/SetLocaleFromHeader.php
+++ b/app/Http/Middleware/SetLocaleFromHeader.php
@@ -21,7 +21,7 @@ class SetLocaleFromHeader
      *
      * Supported locales: en (English), de (German)
      *
-     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     * @param  Closure(Request): (Response)  $next
      */
     public function handle(Request $request, Closure $next): Response
     {

--- a/app/Http/Middleware/SetTenant.php
+++ b/app/Http/Middleware/SetTenant.php
@@ -23,7 +23,7 @@ class SetTenant
     /**
      * Handle an incoming request.
      *
-     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     * @param  Closure(Request): (Response)  $next
      */
     public function handle(Request $request, Closure $next): Response
     {

--- a/app/Jobs/SubmitMerkleRootToOpenTimestamp.php
+++ b/app/Jobs/SubmitMerkleRootToOpenTimestamp.php
@@ -99,8 +99,8 @@ class SubmitMerkleRootToOpenTimestamp implements ShouldQueue
      * This job creates PENDING proofs. The UpgradeOpenTimestampProofs job
      * (scheduled hourly) converts pending → confirmed when Bitcoin confirms.
      *
-     * @see \App\Jobs\UpgradeOpenTimestampProofs for proof upgrade
-     * @see \App\Services\OpenTimestampService::submit() for calendar submission
+     * @see UpgradeOpenTimestampProofs for proof upgrade
+     * @see OpenTimestampService::submit() for calendar submission
      * @see ADR-010 Section 6: OpenTimestamp Integration
      *
      * @throws \RuntimeException if submission fails (triggers retry with backoff)

--- a/app/Jobs/UpgradeOpenTimestampProofs.php
+++ b/app/Jobs/UpgradeOpenTimestampProofs.php
@@ -96,8 +96,8 @@ class UpgradeOpenTimestampProofs implements ShouldQueue
      *   - Skip recent (<1h) to reduce calendar load
      *   - Continue on individual errors (don't fail entire batch)
      *
-     * @see \App\Jobs\SubmitMerkleRootToOpenTimestamp for proof creation
-     * @see \App\Services\OpenTimestampService::upgrade() for upgrade logic
+     * @see SubmitMerkleRootToOpenTimestamp for proof creation
+     * @see OpenTimestampService::upgrade() for upgrade logic
      * @see ADR-010 Section 6: OpenTimestamp Integration
      */
     public function handle(OpenTimestampService $otsService): void

--- a/app/Models/Activity.php
+++ b/app/Models/Activity.php
@@ -248,7 +248,7 @@ class Activity extends SpatieActivity
                 if (class_exists($subjectType)) {
                     // Use withTrashed() to find soft-deleted models (e.g., during 'deleted' event)
                     if (method_exists($subjectType, 'withTrashed')) {
-                        /** @var \Illuminate\Database\Eloquent\Builder<\Illuminate\Database\Eloquent\Model> $query */
+                        /** @var Builder<\Illuminate\Database\Eloquent\Model> $query */
                         $query = $subjectType::withTrashed();
                         $subjectModel = $query->find($activity->subject_id);
                     } else {
@@ -764,7 +764,7 @@ class Activity extends SpatieActivity
             return $otsService->verify($this->ots_proof, $this->merkle_root);
         } catch (\Exception $e) {
             // Log error but return false (don't expose exception)
-            \Illuminate\Support\Facades\Log::warning('OpenTimestamp verification failed', [
+            Log::warning('OpenTimestamp verification failed', [
                 'activity_id' => $this->id,
                 'tenant_id' => $this->tenant_id,
                 'error' => $e->getMessage(),

--- a/app/Models/Customer.php
+++ b/app/Models/Customer.php
@@ -46,7 +46,7 @@ use Spatie\Activitylog\Traits\LogsActivity;
  * @property \Illuminate\Support\Carbon|null $deleted_at
  * @property-read TenantKey $tenant The tenant this customer belongs to
  * @property-read \Illuminate\Database\Eloquent\Collection<int, Site> $sites Sites belonging to this customer
- * @property-read \Illuminate\Database\Eloquent\Collection<int, \Illuminate\Database\Eloquent\Model> $assignments User assignments to this customer
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, Model> $assignments User assignments to this customer
  * @property-read \Illuminate\Database\Eloquent\Collection<int, User> $assignedUsers Users assigned to this customer
  *
  * @see SecPal/.github#210 Customer & Site Management Epic

--- a/app/Models/RoleAssignmentLog.php
+++ b/app/Models/RoleAssignmentLog.php
@@ -25,9 +25,9 @@ use Spatie\Permission\Models\Role;
  * @property string|null $assigned_by
  * @property string|null $reason
  * @property \Illuminate\Support\Carbon $created_at
- * @property-read \App\Models\User $user
- * @property-read \Spatie\Permission\Models\Role $role
- * @property-read \App\Models\User|null $assignedBy
+ * @property-read User $user
+ * @property-read Role $role
+ * @property-read User|null $assignedBy
  */
 class RoleAssignmentLog extends Model
 {

--- a/app/Models/Site.php
+++ b/app/Models/Site.php
@@ -59,9 +59,9 @@ use Spatie\Activitylog\Traits\LogsActivity;
  * @property-read TenantKey $tenant The tenant this site belongs to
  * @property-read Customer $customer The customer that owns this site
  * @property-read OrganizationalUnit $organizationalUnit The internal unit responsible
- * @property-read \Illuminate\Database\Eloquent\Collection<int, \Illuminate\Database\Eloquent\Model> $assignments User assignments to this site
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, Model> $assignments User assignments to this site
  * @property-read \Illuminate\Database\Eloquent\Collection<int, User> $assignedUsers Users assigned to this site
- * @property-read \Illuminate\Database\Eloquent\Collection<int, \Illuminate\Database\Eloquent\Model> $costCenters Cost centers for this site
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, Model> $costCenters Cost centers for this site
  *
  * @see SecPal/.github#210 Customer & Site Management Epic
  * @see SecPal/api#310 Customer and Site Eloquent models

--- a/app/Models/TemporalRoleUser.php
+++ b/app/Models/TemporalRoleUser.php
@@ -24,8 +24,8 @@ use Illuminate\Database\Eloquent\Relations\MorphPivot;
  * @property string $model_type
  * @property int $model_id
  * @property int $tenant_id
- * @property \Carbon\Carbon|null $valid_from
- * @property \Carbon\Carbon|null $valid_until
+ * @property Carbon|null $valid_from
+ * @property Carbon|null $valid_until
  * @property bool $auto_revoke
  * @property int|null $assigned_by
  * @property string|null $reason

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -18,18 +18,18 @@ return Application::configure(basePath: dirname(__DIR__))
     )
     ->withMiddleware(function (Middleware $middleware): void {
         $middleware->alias([
-            'tenant' => \App\Http\Middleware\SetTenant::class,
-            'tenant.inject' => \App\Http\Middleware\InjectTenantId::class,
-            'check.organizational.scope' => \App\Http\Middleware\CheckOrganizationalScope::class,
-            'check.customer.scope' => \App\Http\Middleware\CheckCustomerScope::class,
-            'permission' => \Spatie\Permission\Middleware\PermissionMiddleware::class,
-            'role' => \Spatie\Permission\Middleware\RoleMiddleware::class,
-            'ensure.pre_contract' => \App\Http\Middleware\EnsurePreContract::class,
-            'ensure.not_pre_contract' => \App\Http\Middleware\EnsureNotPreContract::class,
+            'tenant' => App\Http\Middleware\SetTenant::class,
+            'tenant.inject' => App\Http\Middleware\InjectTenantId::class,
+            'check.organizational.scope' => App\Http\Middleware\CheckOrganizationalScope::class,
+            'check.customer.scope' => App\Http\Middleware\CheckCustomerScope::class,
+            'permission' => Spatie\Permission\Middleware\PermissionMiddleware::class,
+            'role' => Spatie\Permission\Middleware\RoleMiddleware::class,
+            'ensure.pre_contract' => App\Http\Middleware\EnsurePreContract::class,
+            'ensure.not_pre_contract' => App\Http\Middleware\EnsureNotPreContract::class,
         ]);
 
         // Apply security headers globally to all requests (including API routes and Sanctum routes like /sanctum/csrf-cookie)
-        $middleware->append(\App\Http\Middleware\SecurityHeaders::class);
+        $middleware->append(App\Http\Middleware\SecurityHeaders::class);
 
         // Apply Sanctum's stateful middleware to API routes for SPA authentication
         // This enables session-based auth for requests from stateful domains (localhost:5173, etc.)
@@ -37,15 +37,15 @@ return Application::configure(basePath: dirname(__DIR__))
         // to restore sessions from remember tokens when session expires but remember cookie is valid
         // ForceJsonResponse ensures all API routes return JSON, never HTML (prevents HTML error pages on validation errors)
         $middleware->api(prepend: [
-            \App\Http\Middleware\ForceJsonResponse::class,
-            \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
-            \App\Http\Middleware\RestoreSessionFromRememberToken::class,
+            App\Http\Middleware\ForceJsonResponse::class,
+            Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
+            App\Http\Middleware\RestoreSessionFromRememberToken::class,
         ]);
 
         // Apply middleware to all API routes
         $middleware->api(append: [
-            \App\Http\Middleware\InjectTenantId::class,
-            \App\Http\Middleware\SetLocaleFromHeader::class,
+            App\Http\Middleware\InjectTenantId::class,
+            App\Http\Middleware\SetLocaleFromHeader::class,
         ]);
 
         // Configure CSRF protection

--- a/config/activitylog.php
+++ b/config/activitylog.php
@@ -44,7 +44,7 @@ return [
      * @see App\Models\Activity
      * @see ADR-010 Section 2: Custom Activity Model with Extensions
      */
-    'activity_model' => \App\Models\Activity::class,
+    'activity_model' => App\Models\Activity::class,
 
     /*
      * This is the name of the table that will be created by the migration and

--- a/config/permission.php
+++ b/config/permission.php
@@ -142,7 +142,7 @@ return [
     /*
      * The class to use to resolve the permissions team id
      */
-    'team_resolver' => \Spatie\Permission\DefaultTeamResolver::class,
+    'team_resolver' => Spatie\Permission\DefaultTeamResolver::class,
 
     /*
      * Passport Client Credentials Grant
@@ -189,7 +189,7 @@ return [
          * When permissions or roles are updated the cache is flushed automatically.
          */
 
-        'expiration_time' => \DateInterval::createFromDateString('24 hours'),
+        'expiration_time' => DateInterval::createFromDateString('24 hours'),
 
         /*
          * The cache key used to store all permissions.

--- a/database/factories/ActivityArchiveFactory.php
+++ b/database/factories/ActivityArchiveFactory.php
@@ -23,7 +23,7 @@ class ActivityArchiveFactory extends Factory
     /**
      * The name of the factory's corresponding model.
      *
-     * @var class-string<\App\Models\ActivityArchive>
+     * @var class-string<ActivityArchive>
      */
     protected $model = ActivityArchive::class;
 

--- a/database/factories/ActivityFactory.php
+++ b/database/factories/ActivityFactory.php
@@ -18,7 +18,7 @@ class ActivityFactory extends Factory
     /**
      * The name of the factory's corresponding model.
      *
-     * @var class-string<\App\Models\Activity>
+     * @var class-string<Activity>
      */
     protected $model = Activity::class;
 

--- a/database/factories/PersonFactory.php
+++ b/database/factories/PersonFactory.php
@@ -19,7 +19,7 @@ final class PersonFactory extends Factory
     /**
      * The name of the factory's corresponding model.
      *
-     * @var class-string<\App\Models\Person>
+     * @var class-string<Person>
      */
     protected $model = Person::class;
 

--- a/pint.json
+++ b/pint.json
@@ -1,6 +1,6 @@
 {
   "preset": "laravel",
   "rules": {
-    "fully_qualified_strict_types": false
+    "fully_qualified_strict_types": true
   }
 }

--- a/routes/console.php
+++ b/routes/console.php
@@ -29,14 +29,14 @@ Schedule::command('employees:send-contract-ending-notifications')->dailyAt('08:0
 // Default: every minute (local), hourly (production)
 $merkleFrequency = config('opentimestamp.merkle_schedule_frequency', 'hour');
 $merkleSchedule = $merkleFrequency === 'minute'
-    ? Schedule::job(\App\Jobs\BuildMerkleTreeBatch::class)->everyMinute()
-    : Schedule::job(\App\Jobs\BuildMerkleTreeBatch::class)->hourly();
+    ? Schedule::job(App\Jobs\BuildMerkleTreeBatch::class)->everyMinute()
+    : Schedule::job(App\Jobs\BuildMerkleTreeBatch::class)->hourly();
 $merkleSchedule->name('merkle-tree-batch');
 
 // Schedule: Upgrade pending OpenTimestamp proofs hourly
 // See ADR-010 Phase 3: OpenTimestamp Integration
 // Checks for Bitcoin block confirmations and upgrades pending proofs
-Schedule::job(\App\Jobs\UpgradeOpenTimestampProofs::class)->hourly()->name('ots-proof-upgrade');
+Schedule::job(App\Jobs\UpgradeOpenTimestampProofs::class)->hourly()->name('ots-proof-upgrade');
 
 // Schedule: Apply retention policies daily at 02:00
 // See ADR-010 Phase 4: Retention Policies

--- a/tests/Feature/Auth/CsrfProtectionTest.php
+++ b/tests/Feature/Auth/CsrfProtectionTest.php
@@ -42,7 +42,7 @@ describe('CSRF Protection for State-Changing Requests', function () {
 
         expect($middleware)->toHaveKey('validate_csrf_token')
             ->and($middleware['validate_csrf_token'])->toBe(
-                \Illuminate\Foundation\Http\Middleware\ValidateCsrfToken::class
+                Illuminate\Foundation\Http\Middleware\ValidateCsrfToken::class
             );
     });
 

--- a/tests/Feature/Auth/PasswordResetTest.php
+++ b/tests/Feature/Auth/PasswordResetTest.php
@@ -21,7 +21,7 @@ uses(RefreshDatabase::class);
 /**
  * Helper to create a password reset token for testing.
  */
-function createPasswordResetToken(User $user, ?\DateTimeInterface $createdAt = null): string
+function createPasswordResetToken(User $user, ?DateTimeInterface $createdAt = null): string
 {
     $token = Str::random(64);
 

--- a/tests/Feature/Auth/SanctumSpaConfigTest.php
+++ b/tests/Feature/Auth/SanctumSpaConfigTest.php
@@ -20,7 +20,7 @@ describe('Sanctum SPA Authentication Configuration', function () {
 
         expect($middleware)->toHaveKey('validate_csrf_token')
             ->and($middleware['validate_csrf_token'])->toBe(
-                \Illuminate\Foundation\Http\Middleware\ValidateCsrfToken::class
+                Illuminate\Foundation\Http\Middleware\ValidateCsrfToken::class
             );
     });
 

--- a/tests/Feature/AuthTest.php
+++ b/tests/Feature/AuthTest.php
@@ -427,7 +427,7 @@ describe('Login Rate Limiting', function () {
         // Clear rate limiter cache between tests
         // RateLimiter::clear('login') doesn't work because it expects full key like 'login:ip|email'
         // Using Cache::flush() ensures clean state for each test
-        \Illuminate\Support\Facades\Cache::flush();
+        Illuminate\Support\Facades\Cache::flush();
     });
 
     test('token endpoint is rate limited after 5 failed attempts', function () {
@@ -636,8 +636,8 @@ describe('Organizational Scopes Authorization', function () {
     });
 
     test('hasOrganizationalScopes is true when user has scopes', function () {
-        $tenant = \App\Models\TenantKey::factory()->create();
-        $orgUnit = \App\Models\OrganizationalUnit::factory()->create([
+        $tenant = App\Models\TenantKey::factory()->create();
+        $orgUnit = App\Models\OrganizationalUnit::factory()->create([
             'tenant_id' => $tenant->id,
         ]);
 

--- a/tests/Feature/Console/Commands/CheckOpenTimestampStatusTest.php
+++ b/tests/Feature/Console/Commands/CheckOpenTimestampStatusTest.php
@@ -18,14 +18,14 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
  * Tests that the command correctly detects Python, OpenTimestamp installation,
  * performs functional tests, and optionally checks for updates.
  *
- * @see App\Console\Commands\CheckOpenTimestampStatus
+ * @see CheckOpenTimestampStatus
  * @see Issue #391 PR-6: Integrate OpenTimestamp PHP library
  */
 uses(RefreshDatabase::class);
 
 test('command detects python and ots versions', function () {
     // Mock ProcessExecutor for Python version
-    /** @var ProcessExecutor&\Mockery\MockInterface $executor */
+    /** @var ProcessExecutor&Mockery\MockInterface $executor */
     $executor = $this->mock(ProcessExecutor::class);
     $executor
         ->shouldReceive('execute')
@@ -47,12 +47,12 @@ test('command detects python and ots versions', function () {
         ]);
 
     // Mock functional test
-    /** @var OpenTimestampService&\Mockery\MockInterface $otsService */
+    /** @var OpenTimestampService&Mockery\MockInterface $otsService */
     $otsService = $this->mock(OpenTimestampService::class);
     $otsService
         ->shouldReceive('submit')
         ->once()
-        ->with(\Mockery::pattern('/^[0-9a-f]{64}$/'))
+        ->with(Mockery::pattern('/^[0-9a-f]{64}$/'))
         ->andReturn('mock-proof-data');
 
     $this->artisan(CheckOpenTimestampStatus::class)
@@ -61,7 +61,7 @@ test('command detects python and ots versions', function () {
 });
 
 test('command fails when functional test fails', function () {
-    /** @var ProcessExecutor&\Mockery\MockInterface $executor */
+    /** @var ProcessExecutor&Mockery\MockInterface $executor */
     $executor = $this->mock(ProcessExecutor::class);
 
     // Mock version checks
@@ -76,19 +76,19 @@ test('command fails when functional test fails', function () {
         ->andReturn(['exitCode' => 0, 'stdout' => '0.4.5', 'stderr' => '']);
 
     // Mock functional test failure
-    /** @var OpenTimestampService&\Mockery\MockInterface $otsService */
+    /** @var OpenTimestampService&Mockery\MockInterface $otsService */
     $otsService = $this->mock(OpenTimestampService::class);
     $otsService
         ->shouldReceive('submit')
         ->once()
-        ->andThrow(new \RuntimeException('Calendar server unavailable'));
+        ->andThrow(new RuntimeException('Calendar server unavailable'));
 
     $this->artisan(CheckOpenTimestampStatus::class)
         ->assertExitCode(1);
 });
 
 test('command checks for updates when flag provided', function () {
-    /** @var ProcessExecutor&\Mockery\MockInterface $executor */
+    /** @var ProcessExecutor&Mockery\MockInterface $executor */
     $executor = $this->mock(ProcessExecutor::class);
 
     // Mock version checks
@@ -103,7 +103,7 @@ test('command checks for updates when flag provided', function () {
         ->andReturn(['exitCode' => 0, 'stdout' => '0.4.5', 'stderr' => '']);
 
     // Mock functional test
-    /** @var OpenTimestampService&\Mockery\MockInterface $otsService */
+    /** @var OpenTimestampService&Mockery\MockInterface $otsService */
     $otsService = $this->mock(OpenTimestampService::class);
     $otsService
         ->shouldReceive('submit')
@@ -128,7 +128,7 @@ test('command checks for updates when flag provided', function () {
 });
 
 test('command handles pip errors gracefully', function () {
-    /** @var ProcessExecutor&\Mockery\MockInterface $executor */
+    /** @var ProcessExecutor&Mockery\MockInterface $executor */
     $executor = $this->mock(ProcessExecutor::class);
 
     // Mock version checks
@@ -143,7 +143,7 @@ test('command handles pip errors gracefully', function () {
         ->andReturn(['exitCode' => 0, 'stdout' => '0.4.5', 'stderr' => '']);
 
     // Mock functional test
-    /** @var OpenTimestampService&\Mockery\MockInterface $otsService */
+    /** @var OpenTimestampService&Mockery\MockInterface $otsService */
     $otsService = $this->mock(OpenTimestampService::class);
     $otsService
         ->shouldReceive('submit')

--- a/tests/Feature/Console/Commands/MonitorOpenTimestampTest.php
+++ b/tests/Feature/Console/Commands/MonitorOpenTimestampTest.php
@@ -22,7 +22,7 @@ use Illuminate\Support\Facades\Log;
  * Tests the scheduled monitoring command that checks OpenTimestamp
  * health and warns about high pending proof counts.
  *
- * @see App\Console\Commands\MonitorOpenTimestamp
+ * @see MonitorOpenTimestamp
  * @see Issue #491: Convert OpenTimestamp PHPUnit tests to Pest
  */
 uses(RefreshDatabase::class);

--- a/tests/Feature/Console/Commands/SendContractEndingNotificationsTest.php
+++ b/tests/Feature/Console/Commands/SendContractEndingNotificationsTest.php
@@ -17,8 +17,8 @@ use Illuminate\Support\Facades\Mail;
 uses(RefreshDatabase::class);
 
 /**
- * @property \App\Models\TenantKey $tenant
- * @property \App\Models\OrganizationalUnit $orgUnit
+ * @property TenantKey $tenant
+ * @property OrganizationalUnit $orgUnit
  */
 beforeEach(function () {
     Mail::fake();

--- a/tests/Feature/Console/Commands/UpdateEmployeeStatusTest.php
+++ b/tests/Feature/Console/Commands/UpdateEmployeeStatusTest.php
@@ -15,8 +15,8 @@ use Illuminate\Support\Facades\Artisan;
 uses(RefreshDatabase::class);
 
 /**
- * @property \App\Models\TenantKey $tenant
- * @property \App\Models\OrganizationalUnit $orgUnit
+ * @property TenantKey $tenant
+ * @property OrganizationalUnit $orgUnit
  */
 beforeEach(function () {
     TenantKey::setKekPath(getTestKekPath());

--- a/tests/Feature/Console/Commands/UpdateOpenTimestampTest.php
+++ b/tests/Feature/Console/Commands/UpdateOpenTimestampTest.php
@@ -141,9 +141,9 @@ test('command performs upgrade with confirmation', function () {
         ]);
 
     // Mock OpenTimestampService for ots:check
-    $otsService = \Mockery::mock(\App\Services\OpenTimestampService::class);
+    $otsService = Mockery::mock(App\Services\OpenTimestampService::class);
     $otsService->shouldReceive('submit')->andReturn('test-proof');
-    $this->app->instance(\App\Services\OpenTimestampService::class, $otsService);
+    $this->app->instance(App\Services\OpenTimestampService::class, $otsService);
 
     $this->artisan(UpdateOpenTimestamp::class)
         ->expectsQuestion('Do you want to update OpenTimestamp now?', true)

--- a/tests/Feature/Console/Commands/UpdateQualificationStatusTest.php
+++ b/tests/Feature/Console/Commands/UpdateQualificationStatusTest.php
@@ -19,9 +19,9 @@ use Illuminate\Support\Facades\Mail;
 uses(RefreshDatabase::class);
 
 /**
- * @property \App\Models\TenantKey $tenant
- * @property \App\Models\OrganizationalUnit $orgUnit
- * @property \App\Models\Qualification $qualification
+ * @property TenantKey $tenant
+ * @property OrganizationalUnit $orgUnit
+ * @property Qualification $qualification
  */
 beforeEach(function () {
     Mail::fake();

--- a/tests/Feature/Controllers/Api/V1/CostCenterControllerTest.php
+++ b/tests/Feature/Controllers/Api/V1/CostCenterControllerTest.php
@@ -19,12 +19,12 @@ use Spatie\Permission\PermissionRegistrar;
 uses(RefreshDatabase::class);
 
 /**
- * @property \App\Models\TenantKey $tenant
- * @property \App\Models\User $user
+ * @property TenantKey $tenant
+ * @property User $user
  * @property string $token
- * @property \App\Models\Customer $customer
- * @property \App\Models\OrganizationalUnit $organizationalUnit
- * @property \App\Models\Site $site
+ * @property Customer $customer
+ * @property OrganizationalUnit $organizationalUnit
+ * @property Site $site
  */
 beforeEach(function (): void {
     TenantKey::setKekPath(getTestKekPath());

--- a/tests/Feature/Controllers/Api/V1/CustomerAssignmentControllerTest.php
+++ b/tests/Feature/Controllers/Api/V1/CustomerAssignmentControllerTest.php
@@ -17,10 +17,10 @@ use Spatie\Permission\PermissionRegistrar;
 uses(RefreshDatabase::class);
 
 /**
- * @property \App\Models\TenantKey $tenant
- * @property \App\Models\User $user
+ * @property TenantKey $tenant
+ * @property User $user
  * @property string $token
- * @property \App\Models\Customer $customer
+ * @property Customer $customer
  */
 beforeEach(function (): void {
     TenantKey::setKekPath(getTestKekPath());

--- a/tests/Feature/Controllers/Api/V1/OrganizationalUnitControllerTest.php
+++ b/tests/Feature/Controllers/Api/V1/OrganizationalUnitControllerTest.php
@@ -20,10 +20,10 @@ use function Pest\Laravel\postJson;
 uses(RefreshDatabase::class);
 
 /**
- * @property \App\Models\TenantKey $tenant
- * @property \Spatie\Permission\PermissionRegistrar $registrar
- * @property \App\Models\User $user
- * @property \App\Models\OrganizationalUnit $rootUnit
+ * @property TenantKey $tenant
+ * @property PermissionRegistrar $registrar
+ * @property User $user
+ * @property OrganizationalUnit $rootUnit
  */
 beforeEach(function () {
     // Use process-specific KEK file for parallel test isolation

--- a/tests/Feature/Controllers/Api/V1/SecretControllerTest.php
+++ b/tests/Feature/Controllers/Api/V1/SecretControllerTest.php
@@ -19,8 +19,8 @@ use function Pest\Laravel\postJson;
 uses(RefreshDatabase::class);
 
 /**
- * @property \App\Models\TenantKey $tenant
- * @property \App\Models\User $user
+ * @property TenantKey $tenant
+ * @property User $user
  */
 beforeEach(function () {
     // Use process-specific KEK file for parallel test isolation
@@ -423,7 +423,7 @@ describe('SecretController - Share-Based Access', function () {
         ]);
 
         // Grant read access to current user
-        \App\Models\SecretShare::create([
+        App\Models\SecretShare::create([
             'secret_id' => $secret->id,
             'user_id' => $this->user->id,
             'permission' => 'read',
@@ -449,7 +449,7 @@ describe('SecretController - Share-Based Access', function () {
             'title_plain' => 'Read Only',
         ]);
 
-        \App\Models\SecretShare::create([
+        App\Models\SecretShare::create([
             'secret_id' => $secret->id,
             'user_id' => $this->user->id,
             'permission' => 'read',
@@ -475,7 +475,7 @@ describe('SecretController - Share-Based Access', function () {
             'title_plain' => 'Editable',
         ]);
 
-        \App\Models\SecretShare::create([
+        App\Models\SecretShare::create([
             'secret_id' => $secret->id,
             'user_id' => $this->user->id,
             'permission' => 'write',
@@ -502,7 +502,7 @@ describe('SecretController - Share-Based Access', function () {
             'title_plain' => 'Protected',
         ]);
 
-        \App\Models\SecretShare::create([
+        App\Models\SecretShare::create([
             'secret_id' => $secret->id,
             'user_id' => $this->user->id,
             'permission' => 'write',
@@ -526,7 +526,7 @@ describe('SecretController - Share-Based Access', function () {
             'title_plain' => 'Deletable',
         ]);
 
-        \App\Models\SecretShare::create([
+        App\Models\SecretShare::create([
             'secret_id' => $secret->id,
             'user_id' => $this->user->id,
             'permission' => 'admin',
@@ -550,7 +550,7 @@ describe('SecretController - Share-Based Access', function () {
             'title_plain' => 'Expired Access',
         ]);
 
-        \App\Models\SecretShare::create([
+        App\Models\SecretShare::create([
             'secret_id' => $secret->id,
             'user_id' => $this->user->id,
             'permission' => 'read',
@@ -583,7 +583,7 @@ describe('SecretController - Filter Parameter', function () {
             'owner_id' => $owner->id,
             'title_plain' => 'Shared Secret',
         ]);
-        \App\Models\SecretShare::create([
+        App\Models\SecretShare::create([
             'secret_id' => $sharedSecret->id,
             'user_id' => $this->user->id,
             'permission' => 'read',
@@ -615,7 +615,7 @@ describe('SecretController - Filter Parameter', function () {
             'owner_id' => $owner->id,
             'title_plain' => 'Shared Secret',
         ]);
-        \App\Models\SecretShare::create([
+        App\Models\SecretShare::create([
             'secret_id' => $sharedSecret->id,
             'user_id' => $this->user->id,
             'permission' => 'read',
@@ -647,7 +647,7 @@ describe('SecretController - Filter Parameter', function () {
             'owner_id' => $owner->id,
             'title_plain' => 'Shared Secret',
         ]);
-        \App\Models\SecretShare::create([
+        App\Models\SecretShare::create([
             'secret_id' => $sharedSecret->id,
             'user_id' => $this->user->id,
             'permission' => 'read',

--- a/tests/Feature/Controllers/Api/V1/SecretShareControllerTest.php
+++ b/tests/Feature/Controllers/Api/V1/SecretShareControllerTest.php
@@ -19,10 +19,10 @@ use function Pest\Laravel\postJson;
 uses(RefreshDatabase::class);
 
 /**
- * @property \App\Models\TenantKey $tenant
- * @property \App\Models\User $owner
- * @property \App\Models\Secret $secret
- * @property \App\Models\User $otherUser
+ * @property TenantKey $tenant
+ * @property User $owner
+ * @property Secret $secret
+ * @property User $otherUser
  */
 beforeEach(function () {
     // Use process-specific KEK file for parallel test isolation
@@ -34,7 +34,7 @@ beforeEach(function () {
     $this->tenant = TenantKey::create($keys);
 
     // Seed roles and permissions
-    $this->seed(\Database\Seeders\RolesAndPermissionsSeeder::class);
+    $this->seed(Database\Seeders\RolesAndPermissionsSeeder::class);
 
     // Create owner user
     $this->owner = User::factory()->create();

--- a/tests/Feature/Controllers/Api/V1/SiteAssignmentControllerTest.php
+++ b/tests/Feature/Controllers/Api/V1/SiteAssignmentControllerTest.php
@@ -18,10 +18,10 @@ use Spatie\Permission\PermissionRegistrar;
 uses(RefreshDatabase::class);
 
 /**
- * @property \App\Models\TenantKey $tenant
- * @property \App\Models\User $user
+ * @property TenantKey $tenant
+ * @property User $user
  * @property string $token
- * @property \App\Models\Site $site
+ * @property Site $site
  */
 beforeEach(function (): void {
     TenantKey::setKekPath(getTestKekPath());

--- a/tests/Feature/Controllers/Api/V1/SiteControllerTest.php
+++ b/tests/Feature/Controllers/Api/V1/SiteControllerTest.php
@@ -19,11 +19,11 @@ use Spatie\Permission\PermissionRegistrar;
 uses(RefreshDatabase::class);
 
 /**
- * @property \App\Models\TenantKey $tenant
- * @property \App\Models\User $user
+ * @property TenantKey $tenant
+ * @property User $user
  * @property string $token
- * @property \App\Models\OrganizationalUnit $orgUnit
- * @property \App\Models\Customer $customer
+ * @property OrganizationalUnit $orgUnit
+ * @property Customer $customer
  */
 beforeEach(function (): void {
     TenantKey::setKekPath(getTestKekPath());

--- a/tests/Feature/Controllers/Api/V1/UserAssignmentControllerTest.php
+++ b/tests/Feature/Controllers/Api/V1/UserAssignmentControllerTest.php
@@ -19,8 +19,8 @@ use Spatie\Permission\PermissionRegistrar;
 uses(RefreshDatabase::class);
 
 /**
- * @property \App\Models\TenantKey $tenant
- * @property \App\Models\User $user
+ * @property TenantKey $tenant
+ * @property User $user
  * @property string $token
  */
 beforeEach(function (): void {

--- a/tests/Feature/Controllers/EmployeeControllerTest.php
+++ b/tests/Feature/Controllers/EmployeeControllerTest.php
@@ -18,10 +18,10 @@ use Spatie\Permission\PermissionRegistrar;
 uses(RefreshDatabase::class);
 
 /**
- * @property \App\Models\TenantKey $tenant
- * @property \App\Models\User $user
+ * @property TenantKey $tenant
+ * @property User $user
  * @property string $token
- * @property \App\Models\OrganizationalUnit $organizationalUnit
+ * @property OrganizationalUnit $organizationalUnit
  */
 beforeEach(function (): void {
     TenantKey::setKekPath(getTestKekPath());

--- a/tests/Feature/Controllers/EmployeeDocumentControllerTest.php
+++ b/tests/Feature/Controllers/EmployeeDocumentControllerTest.php
@@ -22,10 +22,10 @@ use Spatie\Permission\PermissionRegistrar;
 uses(RefreshDatabase::class);
 
 /**
- * @property \App\Models\TenantKey $tenant
- * @property \App\Models\User $user
+ * @property TenantKey $tenant
+ * @property User $user
  * @property string $token
- * @property \App\Models\Employee $employee
+ * @property Employee $employee
  */
 beforeEach(function (): void {
     TenantKey::setKekPath(getTestKekPath());

--- a/tests/Feature/Controllers/EmployeeQualificationControllerTest.php
+++ b/tests/Feature/Controllers/EmployeeQualificationControllerTest.php
@@ -83,7 +83,7 @@ describe('GET /v1/employees/{employee}/qualifications', function () {
         givePermissionWithTenant($this->user, $this->tenant->id, 'employee_qualification.read');
 
         $this->employee->qualifications()->attach($this->qualification->id, [
-            'id' => \Illuminate\Support\Str::uuid()->toString(),
+            'id' => Illuminate\Support\Str::uuid()->toString(),
             'obtained_date' => now()->toDateString(),
             'status' => 'valid',
         ]);
@@ -138,13 +138,13 @@ describe('GET /v1/employees/{employee}/qualifications', function () {
         ]);
 
         $employeeA->qualifications()->attach($this->qualification->id, [
-            'id' => \Illuminate\Support\Str::uuid()->toString(),
+            'id' => Illuminate\Support\Str::uuid()->toString(),
             'obtained_date' => now()->toDateString(),
             'status' => 'valid',
         ]);
 
         $employeeB->qualifications()->attach($this->qualification->id, [
-            'id' => \Illuminate\Support\Str::uuid()->toString(),
+            'id' => Illuminate\Support\Str::uuid()->toString(),
             'obtained_date' => now()->toDateString(),
             'status' => 'valid',
         ]);
@@ -223,7 +223,7 @@ describe('POST /v1/employees/{employee}/qualifications', function () {
         givePermissionWithTenant($this->user, $this->tenant->id, 'employee_qualification.write');
 
         $this->employee->qualifications()->attach($this->qualification->id, [
-            'id' => \Illuminate\Support\Str::uuid()->toString(),
+            'id' => Illuminate\Support\Str::uuid()->toString(),
             'obtained_date' => now()->toDateString(),
             'status' => 'valid',
         ]);

--- a/tests/Feature/Controllers/QualificationControllerTest.php
+++ b/tests/Feature/Controllers/QualificationControllerTest.php
@@ -15,8 +15,8 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 uses(RefreshDatabase::class);
 
 /**
- * @property \App\Models\TenantKey $tenant
- * @property \App\Models\User $user
+ * @property TenantKey $tenant
+ * @property User $user
  * @property string $token
  */
 beforeEach(function (): void {

--- a/tests/Feature/Controllers/SecretAttachmentControllerTest.php
+++ b/tests/Feature/Controllers/SecretAttachmentControllerTest.php
@@ -15,9 +15,9 @@ use Illuminate\Support\Facades\Storage;
 uses(RefreshDatabase::class);
 
 /**
- * @property \App\Models\TenantKey $tenant
- * @property \App\Models\User $user
- * @property \App\Models\Secret $secret
+ * @property TenantKey $tenant
+ * @property User $user
+ * @property Secret $secret
  */
 beforeEach(function (): void {
     Storage::fake('local');
@@ -124,7 +124,7 @@ describe('GET /v1/secrets/{secret}/attachments - List', function () {
     test('lists attachments for secret', function (): void {
         // Create 2 attachments
         $att1 = new SecretAttachment;
-        $att1->id = \Illuminate\Support\Str::uuid();
+        $att1->id = Illuminate\Support\Str::uuid();
         $att1->secret_id = $this->secret->id;
         $att1->tenant_id = $this->tenant->id;
         $att1->filename_plain = 'file1.pdf';
@@ -136,7 +136,7 @@ describe('GET /v1/secrets/{secret}/attachments - List', function () {
         $att1->save();
 
         $att2 = new SecretAttachment;
-        $att2->id = \Illuminate\Support\Str::uuid();
+        $att2->id = Illuminate\Support\Str::uuid();
         $att2->secret_id = $this->secret->id;
         $att2->tenant_id = $this->tenant->id;
         $att2->filename_plain = 'file2.jpg';
@@ -196,7 +196,7 @@ describe('GET /v1/attachments/{attachment}/download - Download', function () {
 
     test('requires authorization (non-owner)', function (): void {
         $attachment = new SecretAttachment;
-        $attachment->id = \Illuminate\Support\Str::uuid();
+        $attachment->id = Illuminate\Support\Str::uuid();
         $attachment->secret_id = $this->secret->id;
         $attachment->tenant_id = $this->tenant->id;
         $attachment->filename_plain = 'test.pdf';
@@ -243,7 +243,7 @@ describe('DELETE /v1/attachments/{attachment} - Delete', function () {
         Storage::put('test/path.enc', 'encrypted content');
 
         $attachment = new SecretAttachment;
-        $attachment->id = \Illuminate\Support\Str::uuid();
+        $attachment->id = Illuminate\Support\Str::uuid();
         $attachment->secret_id = $this->secret->id;
         $attachment->tenant_id = $this->tenant->id;
         $attachment->filename_plain = 'document.pdf';
@@ -262,7 +262,7 @@ describe('DELETE /v1/attachments/{attachment} - Delete', function () {
 
     test('requires authorization (non-owner)', function (): void {
         $attachment = new SecretAttachment;
-        $attachment->id = \Illuminate\Support\Str::uuid();
+        $attachment->id = Illuminate\Support\Str::uuid();
         $attachment->secret_id = $this->secret->id;
         $attachment->tenant_id = $this->tenant->id;
         $attachment->filename_plain = 'test.pdf';

--- a/tests/Feature/Integration/SecretSharingIntegrationTest.php
+++ b/tests/Feature/Integration/SecretSharingIntegrationTest.php
@@ -299,7 +299,7 @@ describe('Secrets + Attachments + Shares Integration', function () {
 describe('Role-Based Shares Integration', function () {
     beforeEach(function () {
         // Set up permission registrar for tenant context
-        $registrar = app(\Spatie\Permission\PermissionRegistrar::class);
+        $registrar = app(Spatie\Permission\PermissionRegistrar::class);
         $registrar->setPermissionsTeamId($this->tenant->id);
 
         $this->owner = User::factory()->create();

--- a/tests/Feature/Jobs/BuildMerkleTreeBatchTest.php
+++ b/tests/Feature/Jobs/BuildMerkleTreeBatchTest.php
@@ -17,8 +17,8 @@ use Illuminate\Support\Facades\Queue;
 uses(RefreshDatabase::class);
 
 /**
- * @property \App\Models\TenantKey $tenant
- * @property \App\Models\User $user
+ * @property TenantKey $tenant
+ * @property User $user
  */
 beforeEach(function () {
     $this->tenant = TenantKey::factory()->create();
@@ -253,7 +253,7 @@ test('all logs schedule opentimestamp submission', function () {
     $job->handle();
 
     // Verify OTS job dispatched
-    Queue::assertPushed(\App\Jobs\SubmitMerkleRootToOpenTimestamp::class, function ($job) use ($log) {
+    Queue::assertPushed(App\Jobs\SubmitMerkleRootToOpenTimestamp::class, function ($job) use ($log) {
         $log->refresh();
 
         return $job->tenantId === $log->tenant_id
@@ -291,5 +291,5 @@ test('multiple log types all get opentimestamp', function () {
     $job->handle();
 
     // Verify OTS job dispatched for ALL logs (not filtered by level anymore)
-    Queue::assertPushed(\App\Jobs\SubmitMerkleRootToOpenTimestamp::class);
+    Queue::assertPushed(App\Jobs\SubmitMerkleRootToOpenTimestamp::class);
 });

--- a/tests/Feature/Jobs/ProcessActivityHashChainTest.php
+++ b/tests/Feature/Jobs/ProcessActivityHashChainTest.php
@@ -17,8 +17,8 @@ use Illuminate\Support\Facades\Queue;
 uses(RefreshDatabase::class);
 
 /**
- * @property \App\Models\TenantKey $tenant
- * @property \App\Models\User $user
+ * @property TenantKey $tenant
+ * @property User $user
  */
 beforeEach(function () {
     $this->tenant = TenantKey::factory()->create();

--- a/tests/Feature/Jobs/SubmitMerkleRootToOpenTimestampTest.php
+++ b/tests/Feature/Jobs/SubmitMerkleRootToOpenTimestampTest.php
@@ -21,7 +21,7 @@ use Illuminate\Support\Facades\Queue;
  * Tests submission of Merkle roots to OpenTimestamp calendar servers
  * and storage of pending proofs.
  *
- * @see App\Jobs\SubmitMerkleRootToOpenTimestamp
+ * @see SubmitMerkleRootToOpenTimestamp
  * @see Issue #391 PR-6: Integrate OpenTimestamp PHP library
  */
 uses(RefreshDatabase::class);
@@ -47,7 +47,7 @@ test('job submits merkle root and stores proof', function () {
     ]));
 
     // Mock OpenTimestamp service
-    /** @var OpenTimestampService&\Mockery\MockInterface $mockService */
+    /** @var OpenTimestampService&Mockery\MockInterface $mockService */
     $mockService = $this->mock(OpenTimestampService::class);
     $mockProof = hex2bin('0004f0'.bin2hex('pending-proof'));
 
@@ -103,7 +103,7 @@ test('job only updates logs in specified batch', function () {
     ]));
 
     // Mock service
-    /** @var OpenTimestampService&\Mockery\MockInterface $mockService */
+    /** @var OpenTimestampService&Mockery\MockInterface $mockService */
     $mockService = $this->mock(OpenTimestampService::class);
     $mockService->shouldReceive('submit')
         ->with($merkleRoot1)
@@ -132,14 +132,14 @@ test('job handles submission failure gracefully', function () {
     ]);
 
     // Mock service - submission fails
-    /** @var OpenTimestampService&\Mockery\MockInterface $mockService */
+    /** @var OpenTimestampService&Mockery\MockInterface $mockService */
     $mockService = $this->mock(OpenTimestampService::class);
     $mockService->shouldReceive('submit')
-        ->andThrow(new \RuntimeException('Calendar servers unavailable'));
+        ->andThrow(new RuntimeException('Calendar servers unavailable'));
 
     // Act & Assert: Job should throw exception (will be retried by queue)
     expect(fn () => (new SubmitMerkleRootToOpenTimestamp($this->tenant->id, $batchId, $merkleRoot))->handle($mockService))
-        ->toThrow(\RuntimeException::class);
+        ->toThrow(RuntimeException::class);
 
     // Logs should NOT be updated
     $log = Activity::first();
@@ -163,7 +163,7 @@ test('job skips if no logs found', function () {
     $batchId = 9999;
     $merkleRoot = hash('sha256', 'root');
 
-    /** @var OpenTimestampService&\Mockery\MockInterface $mockService */
+    /** @var OpenTimestampService&Mockery\MockInterface $mockService */
     $mockService = $this->mock(OpenTimestampService::class);
     $mockService->shouldNotReceive('submit');
 
@@ -191,7 +191,7 @@ test('job converts binary proof for storage', function () {
     // Mock service - returns binary proof
     $binaryProof = "\x00\x04\xf0".random_bytes(50);
 
-    /** @var OpenTimestampService&\Mockery\MockInterface $mockService */
+    /** @var OpenTimestampService&Mockery\MockInterface $mockService */
     $mockService = $this->mock(OpenTimestampService::class);
     $mockService->shouldReceive('submit')
         ->andReturn($binaryProof);

--- a/tests/Feature/Jobs/UpgradeOpenTimestampProofsTest.php
+++ b/tests/Feature/Jobs/UpgradeOpenTimestampProofsTest.php
@@ -20,7 +20,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
  * Tests upgrading of pending OTS proofs to confirmed proofs
  * when Bitcoin blocks confirm.
  *
- * @see App\Jobs\UpgradeOpenTimestampProofs
+ * @see UpgradeOpenTimestampProofs
  * @see Issue #391 PR-6: Integrate OpenTimestamp PHP library
  */
 uses(RefreshDatabase::class);
@@ -45,7 +45,7 @@ test('job upgrades pending proofs', function () {
     ]));
 
     // Mock service - proof is now confirmed
-    /** @var OpenTimestampService&\Mockery\MockInterface $mockService */
+    /** @var OpenTimestampService&Mockery\MockInterface $mockService */
     $mockService = $this->mock(OpenTimestampService::class);
     $mockService->shouldReceive('upgrade')
         ->times(3)
@@ -77,7 +77,7 @@ test('job skips logs without pending proofs', function () {
         'ots_confirmed_at' => null,
     ]));
 
-    /** @var OpenTimestampService&\Mockery\MockInterface $mockService */
+    /** @var OpenTimestampService&Mockery\MockInterface $mockService */
     $mockService = $this->mock(OpenTimestampService::class);
     $mockService->shouldNotReceive('upgrade');
 
@@ -104,7 +104,7 @@ test('job skips already confirmed proofs', function () {
         'ots_confirmed_at' => now()->subDays(1),
     ]);
 
-    /** @var OpenTimestampService&\Mockery\MockInterface $mockService */
+    /** @var OpenTimestampService&Mockery\MockInterface $mockService */
     $mockService = $this->mock(OpenTimestampService::class);
     $mockService->shouldNotReceive('upgrade');
 
@@ -132,7 +132,7 @@ test('job handles proof not yet ready for upgrade', function () {
     ]);
 
     // Mock service - upgrade not yet available (Bitcoin not confirmed)
-    /** @var OpenTimestampService&\Mockery\MockInterface $mockService */
+    /** @var OpenTimestampService&Mockery\MockInterface $mockService */
     $mockService = $this->mock(OpenTimestampService::class);
     $mockService->shouldReceive('upgrade')
         ->once()
@@ -172,7 +172,7 @@ test('job processes multiple tenants', function () {
         'ots_confirmed_at' => null,
     ]);
 
-    /** @var OpenTimestampService&\Mockery\MockInterface $mockService */
+    /** @var OpenTimestampService&Mockery\MockInterface $mockService */
     $mockService = $this->mock(OpenTimestampService::class);
     $mockService->shouldReceive('upgrade')
         ->twice()
@@ -198,10 +198,10 @@ test('job handles upgrade errors gracefully', function () {
     ]);
 
     // Mock service - upgrade throws exception
-    /** @var OpenTimestampService&\Mockery\MockInterface $mockService */
+    /** @var OpenTimestampService&Mockery\MockInterface $mockService */
     $mockService = $this->mock(OpenTimestampService::class);
     $mockService->shouldReceive('upgrade')
-        ->andThrow(new \RuntimeException('Calendar server timeout'));
+        ->andThrow(new RuntimeException('Calendar server timeout'));
 
     // Act: Job should handle gracefully (don't fail entire job)
     $job = new UpgradeOpenTimestampProofs;
@@ -225,7 +225,7 @@ test('job batch processes logs efficiently', function () {
         'ots_confirmed_at' => null,
     ]));
 
-    /** @var OpenTimestampService&\Mockery\MockInterface $mockService */
+    /** @var OpenTimestampService&Mockery\MockInterface $mockService */
     $mockService = $this->mock(OpenTimestampService::class);
     $mockService->shouldReceive('upgrade')
         ->times(100)
@@ -255,7 +255,7 @@ test('job respects batch limit of 100 proofs', function () {
         ]);
     }
 
-    /** @var OpenTimestampService&\Mockery\MockInterface $mockService */
+    /** @var OpenTimestampService&Mockery\MockInterface $mockService */
     $mockService = $this->mock(OpenTimestampService::class);
     $mockService->shouldReceive('upgrade')
         ->times(100) // Only 100 should be processed
@@ -294,7 +294,7 @@ test('job skips recently submitted proofs', function () {
         'ots_confirmed_at' => null,
     ]);
 
-    /** @var OpenTimestampService&\Mockery\MockInterface $mockService */
+    /** @var OpenTimestampService&Mockery\MockInterface $mockService */
     $mockService = $this->mock(OpenTimestampService::class);
     $mockService->shouldReceive('upgrade')
         ->once() // Only old proof processed

--- a/tests/Feature/KeyRotationTest.php
+++ b/tests/Feature/KeyRotationTest.php
@@ -13,9 +13,9 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 uses(RefreshDatabase::class);
 
 /**
- * @property \App\Models\TenantKey $tenant
+ * @property TenantKey $tenant
  * @property string $originalDekWrapped
- * @property \App\Models\Person $person
+ * @property Person $person
  */
 beforeEach(function (): void {
     // Increment counter to ensure unique KEK file for this test

--- a/tests/Feature/Middleware/CheckOrganizationalScopeTest.php
+++ b/tests/Feature/Middleware/CheckOrganizationalScopeTest.php
@@ -68,7 +68,7 @@ function createMockRequest(User $user, ?string $unitId = null): Request
 
     if ($unitId !== null) {
         $request->setRouteResolver(function () use ($unitId) {
-            $route = new \Illuminate\Routing\Route('GET', '/test/{organizational_unit}', []);
+            $route = new Illuminate\Routing\Route('GET', '/test/{organizational_unit}', []);
             $route->parameters = ['organizational_unit' => $unitId];
 
             return $route;
@@ -219,7 +219,7 @@ describe('CheckOrganizationalScope Middleware', function () {
             $request = Request::create('/test', 'GET');
             $request->setUserResolver(fn () => null);
             $request->setRouteResolver(function () {
-                $route = new \Illuminate\Routing\Route('GET', '/test/{organizational_unit}', []);
+                $route = new Illuminate\Routing\Route('GET', '/test/{organizational_unit}', []);
                 $route->parameters = ['organizational_unit' => $this->region->id];
 
                 return $route;

--- a/tests/Feature/Middleware/InjectTenantIdMiddlewareTest.php
+++ b/tests/Feature/Middleware/InjectTenantIdMiddlewareTest.php
@@ -124,7 +124,7 @@ describe('InjectTenantId Middleware', function () {
 
         $middleware->handle($request, function ($req) {
             // Verify that Spatie Permission team ID was set
-            $permissionRegistrar = app(\Spatie\Permission\PermissionRegistrar::class);
+            $permissionRegistrar = app(Spatie\Permission\PermissionRegistrar::class);
             expect($permissionRegistrar->getPermissionsTeamId())->toBe($this->user->tenant_id);
 
             return response()->json(['ok' => true]);

--- a/tests/Feature/Middleware/RestoreSessionFromRememberTokenTest.php
+++ b/tests/Feature/Middleware/RestoreSessionFromRememberTokenTest.php
@@ -64,7 +64,7 @@ describe('RestoreSessionFromRememberToken Middleware', function () {
         $request->setLaravelSession(app('session.store'));
 
         // Set remember cookie on request (simulating browser sending remember cookie)
-        /** @var \Illuminate\Auth\SessionGuard $guard */
+        /** @var Illuminate\Auth\SessionGuard $guard */
         $guard = Auth::guard('web');
         $cookieName = $guard->getRecallerName();
         $request->cookies->set($cookieName, 'some-remember-token-value');
@@ -85,12 +85,12 @@ describe('RestoreSessionFromRememberToken Middleware', function () {
 describe('Session Restoration Integration', function () {
     test('middleware is registered in api middleware stack', function () {
         // Verify the middleware is registered by checking the kernel
-        $kernel = app(\Illuminate\Contracts\Http\Kernel::class);
+        $kernel = app(Illuminate\Contracts\Http\Kernel::class);
         $middlewareGroups = $kernel->getMiddlewareGroups();
 
         // The RestoreSessionFromRememberToken should be in the api group
         expect($middlewareGroups['api'])->toContain(
-            \App\Http\Middleware\RestoreSessionFromRememberToken::class
+            RestoreSessionFromRememberToken::class
         );
     });
 

--- a/tests/Feature/Models/OrganizationalUnitClosureTest.php
+++ b/tests/Feature/Models/OrganizationalUnitClosureTest.php
@@ -51,7 +51,7 @@ describe('OrganizationalUnitClosure Model', function () {
             ]);
 
             // Try to create duplicate - should fail
-            $this->expectException(\Illuminate\Database\QueryException::class);
+            $this->expectException(Illuminate\Database\QueryException::class);
 
             OrganizationalUnitClosure::create([
                 'ancestor_id' => $unit->id,

--- a/tests/Feature/Models/OrganizationalUnitTest.php
+++ b/tests/Feature/Models/OrganizationalUnitTest.php
@@ -540,7 +540,7 @@ describe('OrganizationalUnit Model', function () {
             ]);
 
             expect(fn () => $unit->setParent($unit))
-                ->toThrow(\InvalidArgumentException::class, 'Cannot set unit as its own parent.');
+                ->toThrow(InvalidArgumentException::class, 'Cannot set unit as its own parent.');
         });
 
         it('prevents setting a descendant as parent (cycle prevention)', function (): void {
@@ -567,11 +567,11 @@ describe('OrganizationalUnit Model', function () {
 
             // Trying to set C as parent of A would create a cycle: A -> B -> C -> A
             expect(fn () => $a->setParent($c))
-                ->toThrow(\InvalidArgumentException::class, 'Cannot set a descendant as parent (would create a cycle).');
+                ->toThrow(InvalidArgumentException::class, 'Cannot set a descendant as parent (would create a cycle).');
 
             // Similarly, trying to set B as parent of A
             expect(fn () => $a->setParent($b))
-                ->toThrow(\InvalidArgumentException::class, 'Cannot set a descendant as parent (would create a cycle).');
+                ->toThrow(InvalidArgumentException::class, 'Cannot set a descendant as parent (would create a cycle).');
         });
     });
 });

--- a/tests/Feature/Models/SecretShareTest.php
+++ b/tests/Feature/Models/SecretShareTest.php
@@ -27,7 +27,7 @@ beforeEach(function (): void {
     $this->tenant = TenantKey::create($keys);
 
     // Seed roles and permissions
-    $this->seed(\Database\Seeders\RolesAndPermissionsSeeder::class);
+    $this->seed(Database\Seeders\RolesAndPermissionsSeeder::class);
 
     $this->owner = User::factory()->create();
     $this->sharedUser = User::factory()->create();

--- a/tests/Feature/Models/TemporalRoleUserTest.php
+++ b/tests/Feature/Models/TemporalRoleUserTest.php
@@ -149,7 +149,7 @@ describe('TemporalRoleUser Pivot Model', function () {
             ]);
 
             // Query using active() scope directly on TemporalRoleUser
-            $activeAssignments = \App\Models\TemporalRoleUser::query()
+            $activeAssignments = App\Models\TemporalRoleUser::query()
                 ->where('model_id', $this->user->id)
                 ->where('model_type', User::class)
                 ->where('tenant_id', $this->tenant->id)
@@ -187,7 +187,7 @@ describe('TemporalRoleUser Pivot Model', function () {
             ]);
 
             // Query using expired() scope
-            $expiredAssignments = \App\Models\TemporalRoleUser::query()
+            $expiredAssignments = App\Models\TemporalRoleUser::query()
                 ->where('model_id', $this->user->id)
                 ->where('model_type', User::class)
                 ->where('tenant_id', $this->tenant->id)
@@ -207,7 +207,7 @@ describe('TemporalRoleUser Pivot Model', function () {
                 'valid_until' => now()->addHour(),
             ]);
 
-            $pivot = \App\Models\TemporalRoleUser::query()
+            $pivot = App\Models\TemporalRoleUser::query()
                 ->where('model_id', $this->user->id)
                 ->where('model_type', User::class)
                 ->where('role_id', $this->managerRole->id)
@@ -223,7 +223,7 @@ describe('TemporalRoleUser Pivot Model', function () {
                 'valid_until' => now()->addDays(2),
             ]);
 
-            $pivot = \App\Models\TemporalRoleUser::query()
+            $pivot = App\Models\TemporalRoleUser::query()
                 ->where('model_id', $this->user->id)
                 ->where('model_type', User::class)
                 ->where('role_id', $this->managerRole->id)
@@ -239,7 +239,7 @@ describe('TemporalRoleUser Pivot Model', function () {
                 'valid_until' => now()->subDay(),
             ]);
 
-            $pivot = \App\Models\TemporalRoleUser::query()
+            $pivot = App\Models\TemporalRoleUser::query()
                 ->where('model_id', $this->user->id)
                 ->where('model_type', User::class)
                 ->where('role_id', $this->managerRole->id)
@@ -255,7 +255,7 @@ describe('TemporalRoleUser Pivot Model', function () {
                 'valid_until' => now()->addHour(),
             ]);
 
-            $pivot = \App\Models\TemporalRoleUser::query()
+            $pivot = App\Models\TemporalRoleUser::query()
                 ->where('model_id', $this->user->id)
                 ->where('model_type', User::class)
                 ->where('role_id', $this->managerRole->id)
@@ -287,7 +287,7 @@ describe('TemporalRoleUser Pivot Model', function () {
             ]);
 
             // Use expired() scope to get auto-revoke candidates
-            $autoRevokeAssignments = \App\Models\TemporalRoleUser::query()
+            $autoRevokeAssignments = App\Models\TemporalRoleUser::query()
                 ->where('model_id', $this->user->id)
                 ->where('model_type', User::class)
                 ->where('tenant_id', $this->tenant->id)

--- a/tests/Feature/Observers/EmployeeObserverTest.php
+++ b/tests/Feature/Observers/EmployeeObserverTest.php
@@ -427,7 +427,7 @@ test('employee observer creates user immediately when status=pre_contract during
 
     // This test reproduces the exact scenario from Issue #345
     // Verifies observer works with direct model creation (not just via factory) for comprehensive coverage
-    $uniqueId = \Illuminate\Support\Str::random(8);
+    $uniqueId = Illuminate\Support\Str::random(8);
     $employee = Employee::create([
         'tenant_id' => $this->tenant->id,
         'organizational_unit_id' => $this->orgUnit->id,

--- a/tests/Feature/OnboardingCompletionTest.php
+++ b/tests/Feature/OnboardingCompletionTest.php
@@ -385,7 +385,7 @@ test('logs name changes with enhanced activity log', function () {
     $response->assertOk();
 
     // Verify activity log was created
-    $activity = \Spatie\Activitylog\Models\Activity::where('subject_id', $employee->id)
+    $activity = Spatie\Activitylog\Models\Activity::where('subject_id', $employee->id)
         ->where('log_name', 'employee-onboarding')
         ->where('description', 'Employee name changed during onboarding completion')
         ->first();
@@ -428,7 +428,7 @@ test('does not log activity if names unchanged', function () {
     $response->assertOk();
 
     // Verify NO activity log for name change was created
-    $activity = \Spatie\Activitylog\Models\Activity::where('subject_id', $employee->id)
+    $activity = Spatie\Activitylog\Models\Activity::where('subject_id', $employee->id)
         ->where('log_name', 'employee-onboarding')
         ->where('description', 'Employee name changed during onboarding completion')
         ->first();
@@ -505,7 +505,7 @@ test('allows minor name correction (typo, >80% similar)', function () {
     expect($employee->last_name)->toBe('Müller');
 
     // Verify activity log contains severity info
-    $activity = \Spatie\Activitylog\Models\Activity::where('subject_id', $employee->id)
+    $activity = Spatie\Activitylog\Models\Activity::where('subject_id', $employee->id)
         ->where('log_name', 'employee-onboarding')
         ->where('description', 'Employee name changed during onboarding completion')
         ->first();
@@ -516,7 +516,7 @@ test('allows minor name correction (typo, >80% similar)', function () {
 });
 
 test('allows medium name change with warning (50-80% similar)', function () {
-    \Illuminate\Support\Facades\Mail::fake();
+    Illuminate\Support\Facades\Mail::fake();
 
     /** @var User $user */
     $user = User::factory()->create(['email' => 'test@example.com']);
@@ -549,7 +549,7 @@ test('allows medium name change with warning (50-80% similar)', function () {
     expect($employee->last_name)->toBe('Müller-Schmidt');
 
     // Verify HR notification was sent
-    \Illuminate\Support\Facades\Mail::assertQueued(\App\Mail\OnboardingNameChangedMail::class, function ($mail) use ($employee) {
+    Illuminate\Support\Facades\Mail::assertQueued(App\Mail\OnboardingNameChangedMail::class, function ($mail) use ($employee) {
         return $mail->employee->id === $employee->id
             && $mail->oldFirstName === 'Hans'
             && $mail->oldLastName === 'Müller'
@@ -594,7 +594,7 @@ test('blocks major name change (<50% similar)', function () {
 });
 
 test('allows unchanged name without HR notification', function () {
-    \Illuminate\Support\Facades\Mail::fake();
+    Illuminate\Support\Facades\Mail::fake();
 
     /** @var User $user */
     $user = User::factory()->create(['email' => 'test@example.com']);
@@ -622,8 +622,8 @@ test('allows unchanged name without HR notification', function () {
     $response->assertOk();
 
     // Verify NO HR notification was sent
-    \Illuminate\Support\Facades\Mail::assertNothingQueued();
-    \Illuminate\Support\Facades\Mail::assertNotSent(\App\Mail\OnboardingNameChangedMail::class);
+    Illuminate\Support\Facades\Mail::assertNothingQueued();
+    Illuminate\Support\Facades\Mail::assertNotSent(App\Mail\OnboardingNameChangedMail::class);
 });
 
 // Bug fix tests: User name sync and auto-login
@@ -704,13 +704,13 @@ test('creates activity log for automatic login after onboarding', function () {
     $response->assertOk();
 
     // Assert: Activity log was created for automatic login (BUG FIX)
-    expect(\Spatie\Activitylog\Models\Activity::where('log_name', 'authentication')
+    expect(Spatie\Activitylog\Models\Activity::where('log_name', 'authentication')
         ->where('causer_id', $user->id)
         ->where('description', 'User logged in after onboarding completion')
         ->exists())->toBeTrue();
 
     // Verify properties contain method='onboarding_completion'
-    $activityLog = \Spatie\Activitylog\Models\Activity::where('log_name', 'authentication')
+    $activityLog = Spatie\Activitylog\Models\Activity::where('log_name', 'authentication')
         ->where('causer_id', $user->id)
         ->where('description', 'User logged in after onboarding completion')
         ->first();
@@ -779,7 +779,7 @@ test('sends HR notification when only first name changes with medium severity', 
     $tokenData = EmployeeOnboardingToken::generate($employee);
     $plainToken = $tokenData['plain'];
 
-    \Illuminate\Support\Facades\Mail::fake();
+    Illuminate\Support\Facades\Mail::fake();
 
     $response = $this->withSession([])->postJson('/v1/onboarding/complete', [
         'token' => $plainToken,
@@ -792,7 +792,7 @@ test('sends HR notification when only first name changes with medium severity', 
     $response->assertOk();
 
     // Assert: HR notification was sent for medium severity first name change
-    \Illuminate\Support\Facades\Mail::assertQueued(\App\Mail\OnboardingNameChangedMail::class, function ($mail) use ($employee) {
+    Illuminate\Support\Facades\Mail::assertQueued(App\Mail\OnboardingNameChangedMail::class, function ($mail) use ($employee) {
         return $mail->hasTo(config('mail.hr_email', config('mail.from.address')))
             && $mail->employee->id === $employee->id
             && $mail->oldFirstName === 'Max'
@@ -815,7 +815,7 @@ test('sends HR notification when only last name changes with medium severity', f
     $tokenData = EmployeeOnboardingToken::generate($employee);
     $plainToken = $tokenData['plain'];
 
-    \Illuminate\Support\Facades\Mail::fake();
+    Illuminate\Support\Facades\Mail::fake();
 
     $response = $this->withSession([])->postJson('/v1/onboarding/complete', [
         'token' => $plainToken,
@@ -828,7 +828,7 @@ test('sends HR notification when only last name changes with medium severity', f
     $response->assertOk();
 
     // Assert: HR notification was sent for medium severity last name change
-    \Illuminate\Support\Facades\Mail::assertQueued(\App\Mail\OnboardingNameChangedMail::class, function ($mail) use ($employee) {
+    Illuminate\Support\Facades\Mail::assertQueued(App\Mail\OnboardingNameChangedMail::class, function ($mail) use ($employee) {
         return $mail->hasTo(config('mail.hr_email', config('mail.from.address')))
             && $mail->employee->id === $employee->id
             && $mail->oldFirstName === 'Hans'
@@ -851,7 +851,7 @@ test('sends HR notification when mixed severity changes occur', function () {
     $tokenData = EmployeeOnboardingToken::generate($employee);
     $plainToken = $tokenData['plain'];
 
-    \Illuminate\Support\Facades\Mail::fake();
+    Illuminate\Support\Facades\Mail::fake();
 
     $response = $this->withSession([])->postJson('/v1/onboarding/complete', [
         'token' => $plainToken,
@@ -865,7 +865,7 @@ test('sends HR notification when mixed severity changes occur', function () {
 
     // Assert: HR notification was sent because of medium severity last name change
     // (even though first name is only minor)
-    \Illuminate\Support\Facades\Mail::assertQueued(\App\Mail\OnboardingNameChangedMail::class, function ($mail) use ($employee) {
+    Illuminate\Support\Facades\Mail::assertQueued(App\Mail\OnboardingNameChangedMail::class, function ($mail) use ($employee) {
         return $mail->hasTo(config('mail.hr_email', config('mail.from.address')))
             && $mail->employee->id === $employee->id
             && $mail->oldFirstName === 'Hanz'

--- a/tests/Feature/OpenTimestampServiceTest.php
+++ b/tests/Feature/OpenTimestampServiceTest.php
@@ -15,7 +15,7 @@ use App\Services\OpenTimestampService;
  *
  * Tests submission and upgrade of timestamps via REST API.
  *
- * @see App\Services\OpenTimestampService
+ * @see OpenTimestampService
  */
 /**
  * @property ProcessExecutor $mockExecutor
@@ -89,7 +89,7 @@ test('submit fails if insufficient calendars respond', function () {
 
     // Act & Assert: Should throw exception
     expect(fn () => $this->service->submit($merkleRoot))
-        ->toThrow(\RuntimeException::class, 'only 1 of 3 calendars responded');
+        ->toThrow(RuntimeException::class, 'only 1 of 3 calendars responded');
 });
 
 test('upgrade returns null if not yet confirmed', function () {

--- a/tests/Feature/PersonTest.php
+++ b/tests/Feature/PersonTest.php
@@ -222,7 +222,7 @@ describe('PersonRepository - Blind Index Search', function () {
         $person->phone_plain = '123';
         $person->save();
 
-        $repo = new \App\Repositories\PersonRepository;
+        $repo = new App\Repositories\PersonRepository;
         $found = $repo->findByEmail($this->tenant->id, 'test@example.com');
 
         expect($found)->not->toBeNull();
@@ -236,7 +236,7 @@ describe('PersonRepository - Blind Index Search', function () {
         $person->phone_plain = '123';
         $person->save();
 
-        $repo = new \App\Repositories\PersonRepository;
+        $repo = new App\Repositories\PersonRepository;
         $found = $repo->findByEmail($this->tenant->id, 'test@example.com');
 
         expect($found)->not->toBeNull();
@@ -244,7 +244,7 @@ describe('PersonRepository - Blind Index Search', function () {
     });
 
     test('findByEmail returns null when not found', function (): void {
-        $repo = new \App\Repositories\PersonRepository;
+        $repo = new App\Repositories\PersonRepository;
         $found = $repo->findByEmail($this->tenant->id, 'nonexistent@example.com');
 
         expect($found)->toBeNull();
@@ -257,7 +257,7 @@ describe('PersonRepository - Blind Index Search', function () {
         $person->phone_plain = '+49 123 456789';
         $person->save();
 
-        $repo = new \App\Repositories\PersonRepository;
+        $repo = new App\Repositories\PersonRepository;
         $found = $repo->findByPhone($this->tenant->id, '49123456789');
 
         expect($found)->not->toBeNull();
@@ -271,7 +271,7 @@ describe('PersonRepository - Blind Index Search', function () {
         $person->phone_plain = '49123456789';
         $person->save();
 
-        $repo = new \App\Repositories\PersonRepository;
+        $repo = new App\Repositories\PersonRepository;
         $found = $repo->findByPhone($this->tenant->id, '+49 (123) 456-789');
 
         expect($found)->not->toBeNull();
@@ -281,7 +281,7 @@ describe('PersonRepository - Blind Index Search', function () {
 
 describe('PersonRepository - Create or Update', function () {
     test('createOrUpdate creates new Person when email not found', function (): void {
-        $repo = new \App\Repositories\PersonRepository;
+        $repo = new App\Repositories\PersonRepository;
 
         $person = $repo->createOrUpdate($this->tenant->id, [
             'email_plain' => 'new@example.com',
@@ -304,7 +304,7 @@ describe('PersonRepository - Create or Update', function () {
         $existing->note_plain = 'Old note';
         $existing->save();
 
-        $repo = new \App\Repositories\PersonRepository;
+        $repo = new App\Repositories\PersonRepository;
 
         $updated = $repo->createOrUpdate($this->tenant->id, [
             'email_plain' => 'existing@example.com',
@@ -318,11 +318,11 @@ describe('PersonRepository - Create or Update', function () {
     });
 
     test('createOrUpdate throws exception when email_plain missing', function (): void {
-        $repo = new \App\Repositories\PersonRepository;
+        $repo = new App\Repositories\PersonRepository;
 
         expect(fn () => $repo->createOrUpdate($this->tenant->id, [
             'phone_plain' => '123',
-        ]))->toThrow(\InvalidArgumentException::class, 'email_plain is required');
+        ]))->toThrow(InvalidArgumentException::class, 'email_plain is required');
     });
 });
 
@@ -366,7 +366,7 @@ describe('Person Model - Tenant Isolation', function () {
         $person2->phone_plain = '456';
         $person2->save();
 
-        $repo = new \App\Repositories\PersonRepository;
+        $repo = new App\Repositories\PersonRepository;
 
         // Search in tenant1 -> returns person1
         $found1 = $repo->findByEmail($this->tenant->id, 'test@example.com');

--- a/tests/Feature/Policies/SecretAttachmentPolicyTest.php
+++ b/tests/Feature/Policies/SecretAttachmentPolicyTest.php
@@ -39,7 +39,7 @@ beforeEach(function (): void {
     $this->secret->save();
 
     $this->attachment = new SecretAttachment;
-    $this->attachment->id = \Illuminate\Support\Str::uuid();
+    $this->attachment->id = Illuminate\Support\Str::uuid();
     $this->attachment->secret_id = $this->secret->id;
     $this->attachment->tenant_id = $this->tenant->id;
     $this->attachment->filename_plain = 'test.pdf';

--- a/tests/Feature/SecretTest.php
+++ b/tests/Feature/SecretTest.php
@@ -14,8 +14,8 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 uses(RefreshDatabase::class);
 
 /**
- * @property \App\Models\TenantKey $tenant
- * @property \App\Models\User $user
+ * @property TenantKey $tenant
+ * @property User $user
  */
 beforeEach(function (): void {
     // Use process-specific KEK file for parallel test isolation
@@ -166,7 +166,7 @@ describe('Secret Model - Hidden Fields', function () {
         $secret->save();
 
         // Verify FTS column was populated (check via raw query)
-        $result = \DB::selectOne('SELECT notes_tsv FROM secrets WHERE id = ?', [$secret->id]);
+        $result = DB::selectOne('SELECT notes_tsv FROM secrets WHERE id = ?', [$secret->id]);
         expect($result->notes_tsv)->not->toBeNull();
     });
 
@@ -181,7 +181,7 @@ describe('Secret Model - Hidden Fields', function () {
         $secret->notes_plain = 'Updated notes with more details';
         $secret->save();
 
-        $result = \DB::selectOne('SELECT notes_tsv FROM secrets WHERE id = ?', [$secret->id]);
+        $result = DB::selectOne('SELECT notes_tsv FROM secrets WHERE id = ?', [$secret->id]);
         expect($result->notes_tsv)->not->toBeNull();
     });
 });
@@ -194,7 +194,7 @@ describe('Secret Model - Relationships', function () {
         $secret->title_plain = 'Test Secret';
         $secret->save();
 
-        expect($secret->attachments())->toBeInstanceOf(\Illuminate\Database\Eloquent\Relations\HasMany::class);
+        expect($secret->attachments())->toBeInstanceOf(Illuminate\Database\Eloquent\Relations\HasMany::class);
         expect($secret->attachments)->toBeEmpty();
     });
 

--- a/tests/Feature/SecurityHardeningTest.php
+++ b/tests/Feature/SecurityHardeningTest.php
@@ -180,7 +180,7 @@ describe('No Plaintext in Logs', function () {
             $person = new Person;
             $person->email_plain = $sensitiveEmail;
             $person->save(); // Should throw exception
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             // Exception message should not contain the sensitive email
             expect($e->getMessage())->not->toContain($sensitiveEmail);
             expect($e->getMessage())->not->toContain('confidential');

--- a/tests/Feature/Services/EmployeeDocumentStorageServiceTest.php
+++ b/tests/Feature/Services/EmployeeDocumentStorageServiceTest.php
@@ -62,13 +62,13 @@ test('service stores employee document with encryption', function (): void {
 });
 
 test('service does not persist blob when mime type cannot be determined', function (): void {
-    $file = \Mockery::mock(UploadedFile::class);
+    $file = Mockery::mock(UploadedFile::class);
     $file->shouldReceive('getRealPath')->once()->andReturn(__FILE__);
     $file->shouldReceive('getMimeType')->once()->andReturn(null);
     $file->shouldNotReceive('getSize');
 
     expect(fn () => $this->service->store($file, $this->employee))
-        ->toThrow(\RuntimeException::class, 'Failed to determine employee document MIME type');
+        ->toThrow(RuntimeException::class, 'Failed to determine employee document MIME type');
 
     expect(Storage::disk('local')->allFiles())->toBe([]);
 });

--- a/tests/Feature/SetTenantMiddlewareTest.php
+++ b/tests/Feature/SetTenantMiddlewareTest.php
@@ -103,7 +103,7 @@ describe('SetTenant Middleware', function (): void {
         $this->getJson("/tenants/{$tenant->id}/test");
 
         // Verify that PermissionRegistrar has the correct team ID set
-        $registrar = app(\Spatie\Permission\PermissionRegistrar::class);
+        $registrar = app(Spatie\Permission\PermissionRegistrar::class);
         expect($registrar->getPermissionsTeamId())->toBe($tenant->id);
     });
 
@@ -116,7 +116,7 @@ describe('SetTenant Middleware', function (): void {
 
         // First request sets tenant1
         $this->getJson("/tenants/{$tenant1->id}/test");
-        $registrar = app(\Spatie\Permission\PermissionRegistrar::class);
+        $registrar = app(Spatie\Permission\PermissionRegistrar::class);
         expect($registrar->getPermissionsTeamId())->toBe($tenant1->id);
 
         // Second request should change to tenant2

--- a/tests/Performance/ActivityHashChainConcurrencyTest.php
+++ b/tests/Performance/ActivityHashChainConcurrencyTest.php
@@ -37,8 +37,8 @@ uses(RefreshDatabase::class);
  */
 
 /**
- * @property \App\Models\TenantKey $tenant
- * @property \App\Models\User $user
+ * @property TenantKey $tenant
+ * @property User $user
  */
 beforeEach(function () {
     $this->tenant = TenantKey::factory()->create();

--- a/tests/Performance/MerkleProofPerformanceTest.php
+++ b/tests/Performance/MerkleProofPerformanceTest.php
@@ -26,13 +26,13 @@ uses(RefreshDatabase::class);
  * - Small trees (4 leaves): < 5ms per verification (threshold enforced in CI)
  * - Medium trees (100 leaves): < 2ms per verification (threshold enforced below)
  *
- * @see App\Models\Activity::verifyMerkleProof()
+ * @see Activity::verifyMerkleProof()
  * @see Issue #390 PR-5: Add Merkle proof storage & verification methods
  */
 
 /**
- * @property \App\Models\TenantKey $tenant
- * @property \App\Models\User $user
+ * @property TenantKey $tenant
+ * @property User $user
  */
 beforeEach(function () {
     $this->tenant = TenantKey::factory()->create();

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -77,9 +77,9 @@ function cleanupTestKekFile(): void
  * Assign permissions to a user with proper tenant context.
  * Sets Spatie Permission team ID, assigns permission, then resets team ID.
  */
-function givePermissionWithTenant(\App\Models\User $user, int $tenantId, string $permission): void
+function givePermissionWithTenant(App\Models\User $user, int $tenantId, string $permission): void
 {
-    $registrar = app(\Spatie\Permission\PermissionRegistrar::class);
+    $registrar = app(Spatie\Permission\PermissionRegistrar::class);
     $registrar->setPermissionsTeamId($tenantId);
     $user->givePermissionTo($permission);
     $registrar->setPermissionsTeamId(null);
@@ -93,16 +93,16 @@ function givePermissionWithTenant(\App\Models\User $user, int $tenantId, string 
  * Creates a scope with manage access (min=0, max=255) by default.
  */
 function giveOrganizationalScope(
-    \App\Models\User $user,
-    \App\Models\OrganizationalUnit $organizationalUnit,
+    App\Models\User $user,
+    App\Models\OrganizationalUnit $organizationalUnit,
     ?int $minViewableRank = 0,
     ?int $maxViewableRank = 255,
     ?int $minAssignableRank = 0,
     ?int $maxAssignableRank = 255,
     bool $allowSelfAccess = true,
     string $accessLevel = 'manage'
-): \App\Models\UserInternalOrganizationalScope {
-    return \App\Models\UserInternalOrganizationalScope::create([
+): App\Models\UserInternalOrganizationalScope {
+    return App\Models\UserInternalOrganizationalScope::create([
         'user_id' => $user->id,
         'organizational_unit_id' => $organizationalUnit->id,
         'access_level' => $accessLevel,
@@ -120,14 +120,14 @@ function giveOrganizationalScope(
  * Directly inserts into model_has_roles with tenant_id support.
  */
 function assignTemporalRole(
-    \App\Models\User $user,
-    \Spatie\Permission\Models\Role $role,
+    App\Models\User $user,
+    Spatie\Permission\Models\Role $role,
     int $tenantId,
     array $attributes = []
 ): void {
     $now = now();
 
-    \Illuminate\Support\Facades\DB::table('model_has_roles')->insert(array_merge([
+    Illuminate\Support\Facades\DB::table('model_has_roles')->insert(array_merge([
         'model_type' => get_class($user),
         'model_id' => $user->id,
         'role_id' => $role->id,
@@ -145,9 +145,9 @@ function assignTemporalRole(
  * Create Secret with proper encryption pattern.
  * Sets tenant_id BEFORE title_plain to ensure correct encryption context.
  */
-function createTestSecret(array $attributes): \App\Models\Secret
+function createTestSecret(array $attributes): App\Models\Secret
 {
-    $secret = new \App\Models\Secret;
+    $secret = new App\Models\Secret;
     $secret->tenant_id = $attributes['tenant_id'];
     $secret->owner_id = $attributes['owner_id'];
     $secret->title_plain = $attributes['title_plain'] ?? 'Test Secret';
@@ -167,9 +167,9 @@ function createTestSecret(array $attributes): \App\Models\Secret
  * Create SecretAttachment with proper encryption pattern.
  * Sets tenant_id BEFORE filename_plain to ensure correct encryption context.
  */
-function createTestAttachment(array $attributes): \App\Models\SecretAttachment
+function createTestAttachment(array $attributes): App\Models\SecretAttachment
 {
-    $attachment = new \App\Models\SecretAttachment;
+    $attachment = new App\Models\SecretAttachment;
     $attachment->secret_id = $attributes['secret_id'];
     $attachment->tenant_id = $attributes['tenant_id'];
     $attachment->filename_plain = $attributes['filename_plain'];

--- a/tests/Unit/ActivityLog/ActivityLogTest.php
+++ b/tests/Unit/ActivityLog/ActivityLogTest.php
@@ -455,7 +455,7 @@ test('merkle proof verifies with valid proof via batch job', function () {
     ]));
 
     // Build Merkle tree via job
-    $job = new \App\Jobs\BuildMerkleTreeBatch;
+    $job = new App\Jobs\BuildMerkleTreeBatch;
     $job->handle();
 
     // Verify proofs work
@@ -499,7 +499,7 @@ test('opentimestamp verification works with valid proof', function () {
     ]);
 
     // Mock ProcessExecutor to simulate successful Python script verification
-    $mockExecutor = Mockery::mock(\App\Contracts\ProcessExecutor::class);
+    $mockExecutor = Mockery::mock(App\Contracts\ProcessExecutor::class);
     $mockExecutor->shouldReceive('commandExists')
         ->with('python3')
         ->once()
@@ -522,7 +522,7 @@ test('opentimestamp verification works with valid proof', function () {
             'stderr' => 'SUCCESS: Proof is valid and confirmed on Bitcoin blockchain',
         ]);
 
-    app()->instance(\App\Contracts\ProcessExecutor::class, $mockExecutor);
+    app()->instance(App\Contracts\ProcessExecutor::class, $mockExecutor);
 
     expect($log->verifyOpenTimestamp())->toBeTrue();
 });
@@ -532,7 +532,7 @@ test('opentimestamp verification works with valid proof', function () {
 // ============================================================================
 
 test('accepts valid organizational_unit_id from same tenant', function () {
-    $orgUnit = \App\Models\OrganizationalUnit::factory()->create([
+    $orgUnit = App\Models\OrganizationalUnit::factory()->create([
         'tenant_id' => $this->tenant->id,
     ]);
 
@@ -550,7 +550,7 @@ test('accepts valid organizational_unit_id from same tenant', function () {
 
 test('throws exception when organizational_unit_id belongs to different tenant', function () {
     $otherTenant = TenantKey::factory()->create();
-    $otherOrgUnit = \App\Models\OrganizationalUnit::factory()->create([
+    $otherOrgUnit = App\Models\OrganizationalUnit::factory()->create([
         'tenant_id' => $otherTenant->id,
     ]);
 
@@ -564,7 +564,7 @@ test('throws exception when organizational_unit_id belongs to different tenant',
             'description' => 'Test log with cross-tenant OU',
         ]);
         $this->fail('Expected InvalidArgumentException was not thrown');
-    } catch (\InvalidArgumentException $e) {
+    } catch (InvalidArgumentException $e) {
         expect($e->getMessage())->toMatch(
             "/Organizational unit '.*' belongs to tenant '.*' but activity log belongs to tenant '.*'/"
         );
@@ -578,7 +578,7 @@ test('throws exception when organizational_unit_id belongs to different tenant',
 test('throws exception when organizational_unit_id does not exist', function () {
     $this->actingAs($this->user);
 
-    $nonExistentOuId = \Illuminate\Support\Str::uuid()->toString();
+    $nonExistentOuId = Illuminate\Support\Str::uuid()->toString();
 
     expect(fn () => Activity::create([
         'tenant_id' => $this->tenant->id,
@@ -586,7 +586,7 @@ test('throws exception when organizational_unit_id does not exist', function () 
         'log_name' => 'default',
         'description' => 'Test log with invalid OU',
     ]))->toThrow(
-        \InvalidArgumentException::class,
+        InvalidArgumentException::class,
         "Organizational unit '{$nonExistentOuId}' does not exist"
     );
 })->group('security', 'issue-402');

--- a/tests/Unit/ActivityLog/ActivityRetentionYearsTest.php
+++ b/tests/Unit/ActivityLog/ActivityRetentionYearsTest.php
@@ -60,7 +60,7 @@ test('all retention years are valid integers', function (): void {
 
 test('retention years property has legal references', function (): void {
     // This test verifies the docblock contains legal references
-    $reflection = new \ReflectionClass(Activity::class);
+    $reflection = new ReflectionClass(Activity::class);
     $property = $reflection->getProperty('retentionYears');
     $docComment = $property->getDocComment();
 
@@ -73,15 +73,15 @@ test('get retention years methods exist and are static', function (): void {
     expect(method_exists(Activity::class, 'getRetentionYearsForLogType'))->toBeTrue();
     expect(method_exists(Activity::class, 'getAllRetentionYears'))->toBeTrue();
 
-    $reflection = new \ReflectionMethod(Activity::class, 'getRetentionYearsForLogType');
+    $reflection = new ReflectionMethod(Activity::class, 'getRetentionYearsForLogType');
     expect($reflection->isStatic())->toBeTrue();
 
-    $reflection2 = new \ReflectionMethod(Activity::class, 'getAllRetentionYears');
+    $reflection2 = new ReflectionMethod(Activity::class, 'getAllRetentionYears');
     expect($reflection2->isStatic())->toBeTrue();
 });
 
 test('get retention years for log type accepts string parameter', function (): void {
-    $reflection = new \ReflectionMethod(Activity::class, 'getRetentionYearsForLogType');
+    $reflection = new ReflectionMethod(Activity::class, 'getRetentionYearsForLogType');
     $parameters = $reflection->getParameters();
 
     expect($parameters)->toHaveCount(1);

--- a/tests/Unit/ActivityLog/MerkleProofTest.php
+++ b/tests/Unit/ActivityLog/MerkleProofTest.php
@@ -30,7 +30,7 @@ uses(RefreshDatabase::class);
  *
  * TDD approach: Tests written before implementation
  *
- * @see App\Models\Activity::verifyMerkleProof()
+ * @see Activity::verifyMerkleProof()
  * @see Issue #390 PR-5: Add Merkle proof storage & verification methods
  */
 beforeEach(function () {

--- a/tests/Unit/Factories/EmployeeFactoryBewachvTest.php
+++ b/tests/Unit/Factories/EmployeeFactoryBewachvTest.php
@@ -97,7 +97,7 @@ test('terminated factory state sets employment end date', function () {
 
     expect($employee->status)->toBe('terminated')
         ->and($employee->last_working_day)->not->toBeNull()
-        ->and($employee->last_working_day)->toBeInstanceOf(\Carbon\Carbon::class);
+        ->and($employee->last_working_day)->toBeInstanceOf(Carbon\Carbon::class);
 });
 
 test('factory creates unique BWR-IDs', function () {

--- a/tests/Unit/Models/ActivityArchiveTest.php
+++ b/tests/Unit/Models/ActivityArchiveTest.php
@@ -250,5 +250,5 @@ test('activity archive created_at is cast to carbon instance', function () {
     $tenant = TenantKey::factory()->create();
     $archive = ActivityArchive::factory()->create(['tenant_id' => $tenant->id]);
 
-    expect($archive->created_at)->toBeInstanceOf(\Carbon\Carbon::class);
+    expect($archive->created_at)->toBeInstanceOf(Carbon\Carbon::class);
 });

--- a/tests/Unit/Models/CustomerTest.php
+++ b/tests/Unit/Models/CustomerTest.php
@@ -127,14 +127,14 @@ test('customer has tenant relationship', function (): void {
 test('customer has sites relationship', function (): void {
     $customer = Customer::factory()->create();
 
-    expect($customer->sites)->toBeInstanceOf(\Illuminate\Database\Eloquent\Collection::class);
+    expect($customer->sites)->toBeInstanceOf(Illuminate\Database\Eloquent\Collection::class);
 });
 
 test('customer has assignments relationship', function (): void {
     $customer = Customer::factory()->create();
 
-    expect($customer->assignments())->toBeInstanceOf(\Illuminate\Database\Eloquent\Relations\HasMany::class)
-        ->and($customer->assignments)->toBeInstanceOf(\Illuminate\Database\Eloquent\Collection::class);
+    expect($customer->assignments())->toBeInstanceOf(Illuminate\Database\Eloquent\Relations\HasMany::class)
+        ->and($customer->assignments)->toBeInstanceOf(Illuminate\Database\Eloquent\Collection::class);
 });
 
 test('customer billing address is cast to array', function (): void {

--- a/tests/Unit/Models/EmployeeDocumentTest.php
+++ b/tests/Unit/Models/EmployeeDocumentTest.php
@@ -12,7 +12,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 uses(RefreshDatabase::class);
 
 /**
- * @property \App\Models\TenantKey $tenant
+ * @property TenantKey $tenant
  */
 beforeEach(function () {
     TenantKey::setKekPath(getTestKekPath());

--- a/tests/Unit/Models/EmployeeOnboardingTokenTest.php
+++ b/tests/Unit/Models/EmployeeOnboardingTokenTest.php
@@ -22,7 +22,7 @@ uses(RefreshDatabase::class);
  * - Expiry enforcement (7 days default)
  * - Constant-time token comparison
  *
- * @see App\Models\EmployeeOnboardingToken
+ * @see EmployeeOnboardingToken
  */
 test('generates token with 7 day expiry', function () {
     $employee = Employee::factory()->preContract()->create();

--- a/tests/Unit/Models/EmployeeQualificationTest.php
+++ b/tests/Unit/Models/EmployeeQualificationTest.php
@@ -12,7 +12,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 uses(RefreshDatabase::class);
 
 /**
- * @property \App\Models\TenantKey $tenant
+ * @property TenantKey $tenant
  */
 beforeEach(function () {
     TenantKey::setKekPath(getTestKekPath());
@@ -31,7 +31,7 @@ test('employee qualification can be created', function () {
     $qualification = Qualification::factory()->create(['tenant_id' => $this->tenant->id]);
 
     $employeeQual = EmployeeQualification::create([
-        'id' => (string) \Illuminate\Support\Str::uuid(),
+        'id' => (string) Illuminate\Support\Str::uuid(),
         'employee_id' => $employee->id,
         'qualification_id' => $qualification->id,
         'obtained_date' => now(),
@@ -48,7 +48,7 @@ test('employee qualification has employee relationship', function () {
     $qualification = Qualification::factory()->create(['tenant_id' => $this->tenant->id]);
 
     $employeeQual = EmployeeQualification::create([
-        'id' => (string) \Illuminate\Support\Str::uuid(),
+        'id' => (string) Illuminate\Support\Str::uuid(),
         'employee_id' => $employee->id,
         'qualification_id' => $qualification->id,
         'obtained_date' => now(),
@@ -64,7 +64,7 @@ test('employee qualification has qualification relationship', function () {
     $qualification = Qualification::factory()->create(['tenant_id' => $this->tenant->id]);
 
     $employeeQual = EmployeeQualification::create([
-        'id' => (string) \Illuminate\Support\Str::uuid(),
+        'id' => (string) Illuminate\Support\Str::uuid(),
         'employee_id' => $employee->id,
         'qualification_id' => $qualification->id,
         'obtained_date' => now(),
@@ -80,7 +80,7 @@ test('employee qualification casts dates correctly', function () {
     $qualification = Qualification::factory()->create(['tenant_id' => $this->tenant->id]);
 
     $employeeQual = EmployeeQualification::create([
-        'id' => (string) \Illuminate\Support\Str::uuid(),
+        'id' => (string) Illuminate\Support\Str::uuid(),
         'employee_id' => $employee->id,
         'qualification_id' => $qualification->id,
         'obtained_date' => '2023-01-15',
@@ -88,6 +88,6 @@ test('employee qualification casts dates correctly', function () {
         'status' => 'valid',
     ]);
 
-    expect($employeeQual->obtained_date)->toBeInstanceOf(\Illuminate\Support\Carbon::class)
-        ->and($employeeQual->expiry_date)->toBeInstanceOf(\Illuminate\Support\Carbon::class);
+    expect($employeeQual->obtained_date)->toBeInstanceOf(Illuminate\Support\Carbon::class)
+        ->and($employeeQual->expiry_date)->toBeInstanceOf(Illuminate\Support\Carbon::class);
 });

--- a/tests/Unit/Models/EmployeeTest.php
+++ b/tests/Unit/Models/EmployeeTest.php
@@ -14,7 +14,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 uses(RefreshDatabase::class)->group('unit', 'models', 'employee');
 
 /**
- * @property \App\Models\TenantKey $tenant
+ * @property TenantKey $tenant
  */
 beforeEach(function () {
     // Disable EmployeeObserver for unit tests - we test the model in isolation
@@ -86,7 +86,7 @@ test('employee model generates blind indexes for searchable encrypted fields', f
     ]);
 
     // Manually generate blind indexes by calling the observer's method
-    $observer = new \App\Observers\EmployeeObserver;
+    $observer = new App\Observers\EmployeeObserver;
     $observer->creating($employee);
 
     // Save the employee
@@ -200,7 +200,7 @@ test('employee relationships load correctly', function () {
 
     $qualification = Qualification::factory()->create(['tenant_id' => $this->tenant->id]);
     $employee->qualifications()->attach($qualification->id, [
-        'id' => (string) \Illuminate\Support\Str::uuid(),
+        'id' => (string) Illuminate\Support\Str::uuid(),
         'obtained_date' => now(),
     ]);
 

--- a/tests/Unit/Models/OnboardingFormSubmissionTest.php
+++ b/tests/Unit/Models/OnboardingFormSubmissionTest.php
@@ -13,7 +13,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 uses(RefreshDatabase::class);
 
 /**
- * @property \App\Models\TenantKey $tenant
+ * @property TenantKey $tenant
  */
 beforeEach(function () {
     TenantKey::setKekPath(getTestKekPath());
@@ -75,14 +75,14 @@ test('onboarding form submission casts dates correctly', function () {
         'submitted_at' => now(),
     ]);
 
-    expect($submission->submitted_at)->toBeInstanceOf(\Illuminate\Support\Carbon::class)
+    expect($submission->submitted_at)->toBeInstanceOf(Illuminate\Support\Carbon::class)
         ->and($submission->reviewed_at)->toBeNull();
 
     $submission->reviewed_at = now();
     $submission->save();
     $submission->refresh();
 
-    expect($submission->reviewed_at)->toBeInstanceOf(\Illuminate\Support\Carbon::class);
+    expect($submission->reviewed_at)->toBeInstanceOf(Illuminate\Support\Carbon::class);
 });
 
 test('onboarding form submission casts form data as array', function () {
@@ -106,15 +106,15 @@ test('onboarding form submission factory states work correctly', function () {
     $rejected = OnboardingFormSubmission::factory()->rejected()->create();
 
     expect($submitted->status)->toBe('submitted')
-        ->and($submitted->submitted_at)->toBeInstanceOf(\Illuminate\Support\Carbon::class)
+        ->and($submitted->submitted_at)->toBeInstanceOf(Illuminate\Support\Carbon::class)
         ->and($submitted->reviewed_by)->toBeNull()
         ->and($submitted->reviewed_at)->toBeNull();
 
     expect($approved->status)->toBe('approved')
         ->and($approved->reviewed_by)->not->toBeNull()
-        ->and($approved->reviewed_at)->toBeInstanceOf(\Illuminate\Support\Carbon::class);
+        ->and($approved->reviewed_at)->toBeInstanceOf(Illuminate\Support\Carbon::class);
 
     expect($rejected->status)->toBe('rejected')
         ->and($rejected->reviewed_by)->not->toBeNull()
-        ->and($rejected->reviewed_at)->toBeInstanceOf(\Illuminate\Support\Carbon::class);
+        ->and($rejected->reviewed_at)->toBeInstanceOf(Illuminate\Support\Carbon::class);
 });

--- a/tests/Unit/Models/OnboardingFormTemplateTest.php
+++ b/tests/Unit/Models/OnboardingFormTemplateTest.php
@@ -11,7 +11,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 uses(RefreshDatabase::class);
 
 /**
- * @property \App\Models\TenantKey $tenant
+ * @property TenantKey $tenant
  */
 beforeEach(function () {
     TenantKey::setKekPath(getTestKekPath());

--- a/tests/Unit/Models/QualificationTest.php
+++ b/tests/Unit/Models/QualificationTest.php
@@ -11,7 +11,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 uses(RefreshDatabase::class);
 
 /**
- * @property \App\Models\TenantKey $tenant
+ * @property TenantKey $tenant
  */
 beforeEach(function () {
     TenantKey::setKekPath(getTestKekPath());
@@ -45,7 +45,7 @@ test('qualification has employees relationship', function () {
     $employee = Employee::factory()->create(['tenant_id' => $this->tenant->id]);
 
     $qualification->employees()->attach($employee->id, [
-        'id' => (string) \Illuminate\Support\Str::uuid(),
+        'id' => (string) Illuminate\Support\Str::uuid(),
         'obtained_date' => now(),
     ]);
 

--- a/tests/Unit/Models/SiteTest.php
+++ b/tests/Unit/Models/SiteTest.php
@@ -17,7 +17,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 uses(RefreshDatabase::class)->group('unit', 'models', 'site');
 
 /**
- * @property \App\Models\TenantKey $tenant
+ * @property TenantKey $tenant
  */
 beforeEach(function () {
     TenantKey::setKekPath(getTestKekPath());
@@ -199,15 +199,15 @@ test('site has organizational unit relationship', function () {
 test('site has assignments relationship', function () {
     $site = Site::factory()->create();
 
-    expect($site->assignments())->toBeInstanceOf(\Illuminate\Database\Eloquent\Relations\HasMany::class);
-    expect($site->assignments)->toBeInstanceOf(\Illuminate\Database\Eloquent\Collection::class);
+    expect($site->assignments())->toBeInstanceOf(Illuminate\Database\Eloquent\Relations\HasMany::class);
+    expect($site->assignments)->toBeInstanceOf(Illuminate\Database\Eloquent\Collection::class);
 });
 
 test('site has cost centers relationship', function () {
     $site = Site::factory()->create();
 
-    expect($site->costCenters())->toBeInstanceOf(\Illuminate\Database\Eloquent\Relations\HasMany::class);
-    expect($site->costCenters)->toBeInstanceOf(\Illuminate\Database\Eloquent\Collection::class);
+    expect($site->costCenters())->toBeInstanceOf(Illuminate\Database\Eloquent\Relations\HasMany::class);
+    expect($site->costCenters)->toBeInstanceOf(Illuminate\Database\Eloquent\Collection::class);
 });
 
 test('full address accessor formats address correctly', function () {

--- a/tests/Unit/Models/UserAccessTest.php
+++ b/tests/Unit/Models/UserAccessTest.php
@@ -27,8 +27,8 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 uses(RefreshDatabase::class)->group('unit', 'models', 'user', 'access');
 
 /**
- * @property \App\Models\TenantKey $tenant
- * @property \App\Models\User $user
+ * @property TenantKey $tenant
+ * @property User $user
  */
 beforeEach(function () {
     TenantKey::setKekPath(getTestKekPath());

--- a/tests/Unit/Policies/OnboardingFormTemplatePolicyTest.php
+++ b/tests/Unit/Policies/OnboardingFormTemplatePolicyTest.php
@@ -141,7 +141,7 @@ describe('OnboardingFormTemplateResource - API Response', function () {
             'name' => 'Personal Information Form',
         ]);
 
-        $resource = new \App\Http\Resources\OnboardingFormTemplateResource($systemTemplate);
+        $resource = new App\Http\Resources\OnboardingFormTemplateResource($systemTemplate);
         $response = $resource->toArray(request());
 
         expect($response)->toHaveKey('can_be_deleted');
@@ -157,7 +157,7 @@ describe('OnboardingFormTemplateResource - API Response', function () {
             'name' => 'Custom Template',
         ]);
 
-        $resource = new \App\Http\Resources\OnboardingFormTemplateResource($customTemplate);
+        $resource = new App\Http\Resources\OnboardingFormTemplateResource($customTemplate);
         $response = $resource->toArray(request());
 
         expect($response)->toHaveKey('can_be_deleted');

--- a/tests/Unit/Services/ActivityLogServiceLoginFailureTest.php
+++ b/tests/Unit/Services/ActivityLogServiceLoginFailureTest.php
@@ -89,7 +89,7 @@ test('logs user without employee', function () {
     ]);
 
     // Give user an organizational scope (without employee record)
-    \App\Models\UserInternalOrganizationalScope::create([
+    App\Models\UserInternalOrganizationalScope::create([
         'user_id' => $user->id,
         'organizational_unit_id' => $this->orgUnit->id,
     ]);

--- a/tests/Unit/Services/OpenTimestampCliVerificationTest.php
+++ b/tests/Unit/Services/OpenTimestampCliVerificationTest.php
@@ -16,14 +16,14 @@ use App\Services\OpenTimestampService;
  * Tests the secure implementation using external `ots verify` CLI tool.
  * Mocks ProcessExecutor to avoid dependency on actual ots-cli installation.
  *
- * @see App\Services\OpenTimestampService::verify()
+ * @see OpenTimestampService::verify()
  * @see Issue #412 - Secure OpenTimestamp verification implementation
  */
 uses()->group('unit', 'services', 'opentimestamp', 'verification');
 
 /**
- * @property \App\Contracts\ProcessExecutor&\Mockery\MockInterface $mockExecutor
- * @property \App\Services\OpenTimestampService $service
+ * @property ProcessExecutor&Mockery\MockInterface $mockExecutor
+ * @property OpenTimestampService $service
  */
 beforeEach(function () {
     // Mock ProcessExecutor to avoid CLI dependency in tests

--- a/tests/Unit/Services/OpenTimestampProofMergingTest.php
+++ b/tests/Unit/Services/OpenTimestampProofMergingTest.php
@@ -21,12 +21,12 @@ use Illuminate\Support\Facades\Http;
  * Current behavior: Returns the first valid calendar proof, ensuring we always
  * store a structurally valid OTS proof that can be verified by external tools.
  *
- * @see App\Services\OpenTimestampService::mergeProofs()
+ * @see OpenTimestampService::mergeProofs()
  * @see Issue #411: Implement proper OpenTimestamp proof merging
  */
 beforeEach(function () {
     // Mock ProcessExecutor to avoid CLI dependency
-    /** @var ProcessExecutor&\Mockery\MockInterface $mockExecutor */
+    /** @var ProcessExecutor&Mockery\MockInterface $mockExecutor */
     $mockExecutor = $this->mock(ProcessExecutor::class);
     $mockExecutor->shouldReceive('commandExists')
         ->with('python3')

--- a/tests/Unit/Services/OpenTimestampServiceTest.php
+++ b/tests/Unit/Services/OpenTimestampServiceTest.php
@@ -17,14 +17,14 @@ use Illuminate\Support\Facades\Log;
  * Tests CLI-based verification with mocked ProcessExecutor.
  * For detailed CLI verification tests, see OpenTimestampCliVerificationTest.
  *
- * @see App\Services\OpenTimestampService::verify()
+ * @see OpenTimestampService::verify()
  * @see Issue #412 for secure implementation requirements
  */
 uses()->group('unit');
 
 /**
- * @property \App\Contracts\ProcessExecutor&\Mockery\MockInterface $mockExecutor
- * @property \App\Services\OpenTimestampService $service
+ * @property ProcessExecutor&Mockery\MockInterface $mockExecutor
+ * @property OpenTimestampService $service
  */
 beforeEach(function () {
     // Mock ProcessExecutor to avoid CLI dependency


### PR DESCRIPTION
Summary: apply the dedicated repository-wide Pint baseline and re-enable fully_qualified_strict_types after PR #582. Validation: ./vendor/bin/pint --test and ddev exec php artisan test tests/Feature/AuthTest.php tests/Feature/Controllers/Api/V1/ActivityLogControllerTest.php. Related: closes #583.