### PR TITLE
test(api): close tenant-binding regression gaps for issue 594

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - scope nested route bindings for cost centers and employee documents so child resources fail closed when resolved through the wrong parent path
 - validate assignment target users and employee qualification references against the active tenant so foreign-tenant IDs fail with 422 while global system qualifications remain attachable
 - preserve access to global system qualifications and onboarding templates while still fail-closing tenant-foreign bindings, including employee-linked submissions and qualification records
+- extend fail-closed tenant route-binding regression coverage for employee and organizational-unit models and prove cross-tenant employee detail requests return 404 before controller logic runs
 - harden OpenTimestamp proof handling by creating restrictive temporary proof files via shared cleanup helpers and by logging only sanitized digest hints instead of full digests
 - align the Person API contract with plaintext transient fields by accepting `note_plain` instead of exposing direct `*_enc` input semantics
 - block tenant-crossing user reuse during pre-contract employee provisioning so onboarding accounts are only linked within the same tenant, and avoid logging employee email addresses in this path

--- a/tests/Feature/Controllers/EmployeeControllerTest.php
+++ b/tests/Feature/Controllers/EmployeeControllerTest.php
@@ -445,6 +445,24 @@ describe('GET /v1/employees/{employee}', function () {
             ]);
     });
 
+    test('returns 404 when user tries to access employee from different tenant', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'employee.read');
+
+        $otherTenant = TenantKey::create(TenantKey::generateEnvelopeKeys());
+        $foreignUnit = OrganizationalUnit::factory()->create([
+            'tenant_id' => $otherTenant->id,
+        ]);
+        $employee = Employee::factory()->create([
+            'tenant_id' => $otherTenant->id,
+            'organizational_unit_id' => $foreignUnit->id,
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->getJson("/v1/employees/{$employee->id}");
+
+        $response->assertNotFound();
+    });
+
     test('returns 404 for invalid employee id format', function (): void {
         givePermissionWithTenant($this->user, $this->tenant->id, 'employee.read');
 

--- a/tests/Feature/Models/TenantScopedRouteBindingTest.php
+++ b/tests/Feature/Models/TenantScopedRouteBindingTest.php
@@ -9,6 +9,7 @@ use App\Models\Employee;
 use App\Models\EmployeeQualification;
 use App\Models\OnboardingFormSubmission;
 use App\Models\OnboardingFormTemplate;
+use App\Models\OrganizationalUnit;
 use App\Models\Qualification;
 use App\Models\TenantKey;
 use App\Models\User;
@@ -84,6 +85,44 @@ test('customer route binding resolves only within the authenticated tenant', fun
 
     expect($resolvedSameTenantCustomer?->id)->toBe($sameTenantCustomer->id)
         ->and($resolvedOtherTenantCustomer)->toBeNull();
+});
+
+test('employee route binding resolves only within the authenticated tenant', function (): void {
+    ['tenant' => $tenant, 'otherTenant' => $otherTenant] = createTenantRouteBindingContext();
+
+    $sameTenantEmployee = Employee::factory()->create([
+        'tenant_id' => $tenant->id,
+    ]);
+    $otherTenantEmployee = Employee::factory()->create([
+        'tenant_id' => $otherTenant->id,
+    ]);
+
+    /** @var Employee|null $resolvedSameTenantEmployee */
+    $resolvedSameTenantEmployee = (new Employee)->resolveRouteBindingQuery(Employee::query(), $sameTenantEmployee->id)->first();
+    /** @var Employee|null $resolvedOtherTenantEmployee */
+    $resolvedOtherTenantEmployee = (new Employee)->resolveRouteBindingQuery(Employee::query(), $otherTenantEmployee->id)->first();
+
+    expect($resolvedSameTenantEmployee?->id)->toBe($sameTenantEmployee->id)
+        ->and($resolvedOtherTenantEmployee)->toBeNull();
+});
+
+test('organizational unit route binding resolves only within the authenticated tenant', function (): void {
+    ['tenant' => $tenant, 'otherTenant' => $otherTenant] = createTenantRouteBindingContext();
+
+    $sameTenantUnit = OrganizationalUnit::factory()->create([
+        'tenant_id' => $tenant->id,
+    ]);
+    $otherTenantUnit = OrganizationalUnit::factory()->create([
+        'tenant_id' => $otherTenant->id,
+    ]);
+
+    /** @var OrganizationalUnit|null $resolvedSameTenantUnit */
+    $resolvedSameTenantUnit = (new OrganizationalUnit)->resolveRouteBindingQuery(OrganizationalUnit::query(), $sameTenantUnit->id)->first();
+    /** @var OrganizationalUnit|null $resolvedOtherTenantUnit */
+    $resolvedOtherTenantUnit = (new OrganizationalUnit)->resolveRouteBindingQuery(OrganizationalUnit::query(), $otherTenantUnit->id)->first();
+
+    expect($resolvedSameTenantUnit?->id)->toBe($sameTenantUnit->id)
+        ->and($resolvedOtherTenantUnit)->toBeNull();
 });
 
 test('tenant route binding rejects invalid UUID values before querying UUID primary keys', function (): void {


### PR DESCRIPTION
## Summary
- extend tenant route-binding regression coverage for Employee and OrganizationalUnit
- prove cross-tenant employee detail requests fail with 404 before controller logic runs
- document the hardening in CHANGELOG.md

## Validation
- php artisan test tests/Feature/Models/TenantScopedRouteBindingTest.php tests/Feature/Controllers/EmployeeControllerTest.php
- vendor/bin/pint --dirty
- reuse lint

Closes #594