### PR TITLE
fix(api): document tenant binding exceptions (#572)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- document the only explicit global-record exceptions to fail-closed tenant route binding so system qualifications and onboarding form templates are called out alongside the binding concern itself
 - harden API CORS origin matching for `/v1/*`, `/health*`, and Sanctum endpoints by replacing the single-origin static fallback with exact origin pattern matching, so only explicitly allowed origins receive `Access-Control-Allow-Origin` and `Access-Control-Allow-Credentials`
 - return a stable JSON `404` payload for API `ModelNotFoundException` responses so missing resources no longer expose Laravel model class names or framework-internal not-found text
 - preserve Laravel's UUID-aware implicit route model binding for tenant-scoped resources so invalid detail IDs return a controlled `404 Not Found` instead of bubbling PostgreSQL UUID syntax errors into `500` responses on employee, customer, site, and organizational-unit endpoints

--- a/app/Models/Concerns/EnforcesTenantRouteBinding.php
+++ b/app/Models/Concerns/EnforcesTenantRouteBinding.php
@@ -19,7 +19,10 @@ use Illuminate\Support\Str;
  *
  * When an authenticated user is present, bindings are constrained to that
  * user's tenant. As a fallback for tenant-prefixed routes, the explicit
- * {tenant} route parameter is used.
+ * {tenant} route parameter is used. Models that intentionally expose global
+ * records must opt in explicitly via routeBindingAllowsGlobalRecords(); in the
+ * current API surface this is limited to system qualifications and onboarding
+ * form templates.
  */
 trait EnforcesTenantRouteBinding
 {

--- a/app/Models/OnboardingFormTemplate.php
+++ b/app/Models/OnboardingFormTemplate.php
@@ -90,7 +90,8 @@ class OnboardingFormTemplate extends Model
     }
 
     /**
-     * System templates remain globally addressable alongside tenant-local ones.
+     * Allow route binding to resolve global system templates as an explicit
+     * exception to the default fail-closed tenant rule.
      */
     protected function routeBindingAllowsGlobalRecords(): bool
     {

--- a/app/Models/Qualification.php
+++ b/app/Models/Qualification.php
@@ -84,7 +84,8 @@ class Qualification extends Model
     }
 
     /**
-     * System qualifications remain globally addressable alongside tenant-local ones.
+     * Allow route binding to resolve global system qualifications as an explicit
+     * exception to the default fail-closed tenant rule.
      */
     protected function routeBindingAllowsGlobalRecords(): bool
     {


### PR DESCRIPTION
## Summary
- document the explicit global-record exceptions to fail-closed tenant route binding
- clarify in the shared binding concern that only system qualifications and onboarding form templates opt out
- record the clarification in the changelog

## Testing
- php artisan test tests/Feature/Models/TenantScopedRouteBindingTest.php
- vendor/bin/pint --dirty

Fixes #572