### PR TITLE
fix: harden auth when MFA storage is unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- prevented `POST /v1/auth/login` and `POST /v1/auth/token` from crashing with `500` on environments where the new `two_factor_authentications` migration has not run yet by treating missing MFA storage as unavailable during primary login, while MFA-specific endpoints now fail with a controlled `503` instead of an uncaught SQL error
 - switched API CI Prettier check to a local reusable workflow (`reusable-prettier.yml`) because GitHub Actions cannot resolve the shared `.github` composite action via `SecPal/.github/.github/actions/` due to the `.github/.github/` path ambiguity when the repository itself is named `.github`; the local workflow preserves the `Formatting Check / Check Code Formatting` check name required by branch protection
 - returned `chain_link_valid` from `GET /v1/activity-logs/{activity}/verify` so the Activity Log detail dialog no longer leaves the hash-link verification dot stuck in pending when the chain has already been processed successfully; corrected genesis validation in `Activity::verifyChainLink()` to check all earlier tenant activities (not just same `log_name`) so the signal stays accurate when the tenant hash chain spans multiple log names
 

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -72,7 +72,7 @@ class AuthController extends Controller
             $request->integer('tenant_id') ?: null,
         );
 
-        if ($user->hasTwoFactorEnabled()) {
+        if ($this->mfaService->hasEnabledTwoFactor($user)) {
             return $this->issueLoginChallenge($user, LoginMfaChallengeService::LOGIN_CONTEXT_SESSION);
         }
 
@@ -120,7 +120,7 @@ class AuthController extends Controller
 
         $deviceName = $validated['device_name'] ?? 'api-client';
 
-        if ($user->hasTwoFactorEnabled()) {
+        if ($this->mfaService->hasEnabledTwoFactor($user)) {
             return $this->issueLoginChallenge($user, LoginMfaChallengeService::LOGIN_CONTEXT_TOKEN, $deviceName);
         }
 
@@ -153,7 +153,13 @@ class AuthController extends Controller
             return $this->resourceNotFoundResponse();
         }
 
-        if (! $user->hasTwoFactorEnabled()) {
+        if (! $this->mfaService->isStorageAvailable()) {
+            $this->loginMfaChallengeService->forget($challengeId);
+
+            return $this->mfaUnavailableResponse();
+        }
+
+        if (! $this->mfaService->hasEnabledTwoFactor($user)) {
             $this->loginMfaChallengeService->forget($challengeId);
 
             return response()->json([
@@ -283,6 +289,10 @@ class AuthController extends Controller
      */
     public function mfaStatus(Request $request): JsonResponse
     {
+        if (! $this->mfaService->isStorageAvailable()) {
+            return $this->mfaUnavailableResponse();
+        }
+
         /** @var User $user */
         $user = $request->user();
 
@@ -296,10 +306,14 @@ class AuthController extends Controller
      */
     public function startTotpEnrollment(Request $request): JsonResponse
     {
+        if (! $this->mfaService->isStorageAvailable()) {
+            return $this->mfaUnavailableResponse();
+        }
+
         /** @var User $user */
         $user = $request->user();
 
-        if ($user->hasTwoFactorEnabled()) {
+        if ($this->mfaService->hasEnabledTwoFactor($user)) {
             return response()->json([
                 'message' => __('Two-factor authentication is already enabled for this account.'),
             ], 409);
@@ -317,10 +331,14 @@ class AuthController extends Controller
      */
     public function confirmTotpEnrollment(TotpCodeRequest $request): JsonResponse
     {
+        if (! $this->mfaService->isStorageAvailable()) {
+            return $this->mfaUnavailableResponse();
+        }
+
         /** @var User $user */
         $user = $request->user();
 
-        if (! $user->hasPendingTwoFactorEnrollment()) {
+        if (! $this->mfaService->hasPendingEnrollment($user)) {
             return response()->json([
                 'message' => __('No pending two-factor enrollment exists for this account.'),
             ], 409);
@@ -371,10 +389,14 @@ class AuthController extends Controller
      */
     public function regenerateRecoveryCodes(MfaVerificationCodeRequest $request): JsonResponse
     {
+        if (! $this->mfaService->isStorageAvailable()) {
+            return $this->mfaUnavailableResponse();
+        }
+
         /** @var User $user */
         $user = $request->user();
 
-        if (! $user->hasTwoFactorEnabled()) {
+        if (! $this->mfaService->hasEnabledTwoFactor($user)) {
             return response()->json([
                 'message' => __('Two-factor authentication is not enabled for this account.'),
             ], 409);
@@ -420,10 +442,14 @@ class AuthController extends Controller
      */
     public function disableMfa(MfaVerificationCodeRequest $request): JsonResponse
     {
+        if (! $this->mfaService->isStorageAvailable()) {
+            return $this->mfaUnavailableResponse();
+        }
+
         /** @var User $user */
         $user = $request->user();
 
-        if (! $user->hasTwoFactorEnabled()) {
+        if (! $this->mfaService->hasEnabledTwoFactor($user)) {
             return response()->json([
                 'message' => __('Two-factor authentication is not enabled for this account.'),
             ], 409);
@@ -463,6 +489,10 @@ class AuthController extends Controller
      */
     public function adminResetMfa(AdminResetUserMfaRequest $request, User $user): JsonResponse
     {
+        if (! $this->mfaService->isStorageAvailable()) {
+            return $this->mfaUnavailableResponse();
+        }
+
         Gate::authorize('resetMfa', $user);
 
         /** @var User $admin */
@@ -471,7 +501,7 @@ class AuthController extends Controller
         $user->loadMissing('twoFactorAuth');
 
         $previousStatus = $this->mfaService->buildStatusData($user);
-        $hadPendingEnrollment = $user->hasPendingTwoFactorEnrollment();
+        $hadPendingEnrollment = $this->mfaService->hasPendingEnrollment($user);
 
         if (! $previousStatus['enabled'] && ! $hadPendingEnrollment) {
             return response()->json([
@@ -744,6 +774,13 @@ class AuthController extends Controller
         return response()->json([
             'message' => __('Resource not found.'),
         ], 404);
+    }
+
+    private function mfaUnavailableResponse(): JsonResponse
+    {
+        return response()->json([
+            'message' => __('Multi-factor authentication is temporarily unavailable. Please try again later.'),
+        ], 503);
     }
 
     /**

--- a/app/Services/MfaService.php
+++ b/app/Services/MfaService.php
@@ -7,11 +7,41 @@ namespace App\Services;
 
 use App\Models\User;
 use Carbon\CarbonImmutable;
+use Illuminate\Support\Facades\Schema;
 use Laragear\TwoFactor\Events\TwoFactorRecoveryCodesDepleted;
 
 class MfaService
 {
+    private ?bool $twoFactorStorageAvailable = null;
+
     public function __construct(private ActivityLogService $activityLogService) {}
+
+    public function isStorageAvailable(): bool
+    {
+        return $this->twoFactorStorageAvailable ??= Schema::hasTable('two_factor_authentications');
+    }
+
+    public function hasEnabledTwoFactor(User $user): bool
+    {
+        if (! $this->isStorageAvailable()) {
+            return false;
+        }
+
+        $user->loadMissing('twoFactorAuth');
+
+        return $user->hasTwoFactorEnabled();
+    }
+
+    public function hasPendingEnrollment(User $user): bool
+    {
+        if (! $this->isStorageAvailable()) {
+            return false;
+        }
+
+        $user->loadMissing('twoFactorAuth');
+
+        return $user->hasPendingTwoFactorEnrollment();
+    }
 
     /**
      * Build the public MFA status payload for the authenticated user.
@@ -20,14 +50,27 @@ class MfaService
      */
     public function buildStatusData(User $user): array
     {
+        if (! $this->isStorageAvailable()) {
+            return [
+                'enabled' => false,
+                'method' => null,
+                'recovery_codes_remaining' => 0,
+                'recovery_codes_generated_at' => null,
+                'enrolled_at' => null,
+            ];
+        }
+
         $user->loadMissing('twoFactorAuth');
+        $hasEnabledTwoFactor = $user->hasTwoFactorEnabled();
+        /** @var \Laragear\TwoFactor\Models\TwoFactorAuthentication|null $twoFactorAuthentication */
+        $twoFactorAuthentication = $user->getRelation('twoFactorAuth');
 
         return [
-            'enabled' => $user->hasTwoFactorEnabled(),
-            'method' => $user->hasTwoFactorEnabled() ? 'totp' : null,
-            'recovery_codes_remaining' => $user->hasTwoFactorEnabled() ? $user->getRemainingTwoFactorRecoveryCodesCount() : 0,
+            'enabled' => $hasEnabledTwoFactor,
+            'method' => $hasEnabledTwoFactor ? 'totp' : null,
+            'recovery_codes_remaining' => $hasEnabledTwoFactor ? $user->getRemainingTwoFactorRecoveryCodesCount() : 0,
             'recovery_codes_generated_at' => $user->getTwoFactorRecoveryCodesGeneratedAt()?->format(DATE_ATOM),
-            'enrolled_at' => $user->twoFactorAuth->enabled_at?->format(DATE_ATOM),
+            'enrolled_at' => $twoFactorAuthentication?->enabled_at?->format(DATE_ATOM),
         ];
     }
 
@@ -55,11 +98,18 @@ class MfaService
      */
     public function pendingEnrollmentExpiresAt(User $user): ?CarbonImmutable
     {
-        if (! $user->hasPendingTwoFactorEnrollment() || $user->twoFactorAuth->created_at === null) {
+        if (! $this->hasPendingEnrollment($user)) {
             return null;
         }
 
-        return CarbonImmutable::instance($user->twoFactorAuth->created_at)
+        /** @var \Laragear\TwoFactor\Models\TwoFactorAuthentication|null $twoFactorAuthentication */
+        $twoFactorAuthentication = $user->getRelation('twoFactorAuth');
+
+        if ($twoFactorAuthentication?->created_at === null) {
+            return null;
+        }
+
+        return CarbonImmutable::instance($twoFactorAuthentication->created_at)
             ->addMinutes($this->pendingEnrollmentLifetimeMinutes());
     }
 
@@ -84,7 +134,7 @@ class MfaService
      */
     public function verifyEnabledTwoFactorCode(User $user, string $method, string $code): bool
     {
-        if (! $user->hasTwoFactorEnabled()) {
+        if (! $this->hasEnabledTwoFactor($user) || $user->twoFactorAuth === null) {
             return false;
         }
 
@@ -100,6 +150,10 @@ class MfaService
      */
     public function revealRecoveryCodes(User $user): array
     {
+        if (! $this->hasEnabledTwoFactor($user)) {
+            return [];
+        }
+
         /** @var list<string> $codes */
         $codes = $user->getRecoveryCodes()
             ->pluck('code')
@@ -114,6 +168,10 @@ class MfaService
      */
     public function regenerateRecoveryCodes(User $user): array
     {
+        if (! $this->hasEnabledTwoFactor($user)) {
+            return [];
+        }
+
         /** @var list<string> $codes */
         $codes = $user->generateRecoveryCodes()
             ->pluck('code')
@@ -125,6 +183,10 @@ class MfaService
 
     private function consumeRecoveryCode(User $user, string $code): bool
     {
+        if (! $this->hasEnabledTwoFactor($user) || $user->twoFactorAuth === null) {
+            return false;
+        }
+
         if (! $user->twoFactorAuth->setRecoveryCodeAsUsed($code)) {
             return false;
         }

--- a/tests/Feature/Auth/MfaApiEndpointsTest.php
+++ b/tests/Feature/Auth/MfaApiEndpointsTest.php
@@ -7,6 +7,7 @@ use App\Models\Activity;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Schema;
 use Laragear\TwoFactor\Models\TwoFactorAuthentication;
 
 uses(RefreshDatabase::class);
@@ -226,6 +227,27 @@ test('authenticated user can read MFA status, regenerate recovery codes, and dis
     expect($disableAudit)->not->toBeNull()
         ->and($disableAudit?->properties['event'])->toBe('mfa_disabled')
         ->and($disableAudit?->properties['verification_method'])->toBe('recovery_code');
+});
+
+test('mfa endpoints return a controlled 503 when MFA storage is unavailable', function () {
+    $user = User::factory()->create([
+        'email' => 'mfa-storage-missing@secpal.dev',
+    ]);
+
+    $this->actingAs($user, 'sanctum');
+    Schema::drop('two_factor_authentications');
+
+    $this->getJson('/v1/me/mfa')
+        ->assertStatus(503)
+        ->assertJson([
+            'message' => 'Multi-factor authentication is temporarily unavailable. Please try again later.',
+        ]);
+
+    $this->postJson('/v1/me/mfa/totp/enrollment')
+        ->assertStatus(503)
+        ->assertJson([
+            'message' => 'Multi-factor authentication is temporarily unavailable. Please try again later.',
+        ]);
 });
 
 test('consuming the final recovery code records an audit event when the backup set is depleted', function () {

--- a/tests/Feature/AuthTest.php
+++ b/tests/Feature/AuthTest.php
@@ -9,6 +9,7 @@ use App\Models\OrganizationalUnit;
 use App\Models\Site;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 
 uses(RefreshDatabase::class);
@@ -133,6 +134,27 @@ describe('SPA Session Login', function () {
         $this->withHeaders(spaHeaders())->getJson('/v1/me')
             ->assertOk()
             ->assertJson(['email' => 'spa@example.com']);
+    });
+
+    test('spa login still succeeds when MFA storage has not been migrated yet', function () {
+        User::factory()->create([
+            'email' => 'spa@example.com',
+            'password' => bcrypt('password123'),
+        ]);
+
+        Schema::drop('two_factor_authentications');
+
+        $this->withHeaders(spaHeaders([
+            'X-XSRF-TOKEN' => issueSpaCsrfToken($this),
+        ]))->postJson('/v1/auth/login', [
+            'email' => 'spa@example.com',
+            'password' => 'password123',
+        ])->assertOk()
+            ->assertJson([
+                'user' => [
+                    'email' => 'spa@example.com',
+                ],
+            ]);
     });
 
     test('spa logout via canonical endpoint clears remember token', function () {
@@ -274,6 +296,32 @@ describe('Auth Token Generation', function () {
 
         expect($response->json('user.email'))->toBe($email);
         expect($user->tokens()->count())->toBe(1);
+    });
+
+    test('token login still succeeds when MFA storage has not been migrated yet', function () {
+        $email = 'token-missing-mfa-storage-'.Str::uuid().'@example.com';
+
+        $user = User::factory()->create([
+            'email' => $email,
+            'password' => bcrypt('password123'),
+        ]);
+
+        Schema::drop('two_factor_authentications');
+
+        $response = $this->postJson('/v1/auth/token', [
+            'email' => $email,
+            'password' => 'password123',
+            'device_name' => 'test-device',
+        ]);
+
+        $response->assertCreated()
+            ->assertJson([
+                'user' => [
+                    'email' => $email,
+                ],
+            ]);
+
+        expect($user->fresh()->tokens()->count())->toBe(1);
     });
 
     test('token generation fails with invalid email', function () {


### PR DESCRIPTION
## Summary
- prevent `POST /v1/auth/login` and `POST /v1/auth/token` from crashing when the `two_factor_authentications` table is missing
- treat missing MFA storage as unavailable during primary login, and return a controlled `503` for MFA-specific endpoints instead of an uncaught SQL error
- add regression coverage for both login paths plus MFA endpoint behavior when the MFA table has not been migrated yet

## Root cause
The live `500` on both login paths came from the shared `hasTwoFactorEnabled()` check introduced with the MFA rollout. In the affected environment the `2026_04_01_093957_create_two_factor_authentications_table` migration had not run, so touching the Laragear relation raised `SQLSTATE[42P01]: Undefined table: 7 ERROR: relation "two_factor_authentications" does not exist` before session or token login could complete.

## Testing
- `vendor/bin/pint --dirty`
- `vendor/bin/phpstan analyse app/Http/Controllers/AuthController.php app/Services/MfaService.php --no-progress`
- `php artisan test tests/Feature/AuthTest.php tests/Feature/Auth/MfaApiEndpointsTest.php`