### PR TITLE
fix: update Activity::casts() return type for Laravel 13.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - switched API CI Prettier check to a local reusable workflow (`reusable-prettier.yml`) because GitHub Actions cannot resolve the shared `.github` composite action via `SecPal/.github/.github/actions/` due to the `.github/.github/` path ambiguity when the repository itself is named `.github`; the local workflow preserves the `Formatting Check / Check Code Formatting` check name required by branch protection
 - returned `chain_link_valid` from `GET /v1/activity-logs/{activity}/verify` so the Activity Log detail dialog no longer leaves the hash-link verification dot stuck in pending when the chain has already been processed successfully; corrected genesis validation in `Activity::verifyChainLink()` to check all earlier tenant activities (not just same `log_name`) so the signal stays accurate when the tenant hash chain spans multiple log names
+- updated `Activity::casts()` return type annotation from `array<string, string>` to `array<string, string|\Stringable>` to match `laravel/framework` 13.3.0, which expanded the allowed cast values to include `Stringable` objects
 
 ### Changed
 

--- a/app/Models/Activity.php
+++ b/app/Models/Activity.php
@@ -116,7 +116,7 @@ class Activity extends SpatieActivity
     /**
      * Get the attributes that should be cast.
      *
-     * @return array<string, string>
+     * @return array<string, string|\Stringable>
      */
     protected function casts(): array
     {


### PR DESCRIPTION
## Summary

Laravel 13.3.0 expanded the allowed cast values in `Model::casts()` to include `Stringable` objects ([laravel/framework#59479](https://github.com/laravel/framework/pull/59479)). Larastan v3.9.3 now infers `app/Models/Activity.php#casts()` as returning `array<string, string|\Stringable>` (because it merges with `parent::casts()`), which conflicts with the declared `@return array<string, string>`.

## Changes

- Updated the `@return` annotation on `Activity::casts()` from `array<string, string>` to `array<string, string|\Stringable>`

## Motivation

This unblocks Dependabot PRs #722 (laravel/sail 1.56.0) and #724 (laravel/framework 13.3.0), both of which resolve to laravel/framework 13.3.0 in composer.lock and fail PHPStan CI with the same error.

## Checklist

- [x] PHPStan passes locally (full 270-file sweep)
- [x] `vendor/bin/pint --dirty` clean
- [x] CHANGELOG.md updated
- [x] REUSE compliant
- [x] Pre-push hook passed