### PR TITLE
fix: add hsts preload directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - hardened `.gitignore` so `.key` files are ignored both directly under `storage/` and in nested storage subdirectories, reducing the chance that key material is committed from deeper runtime paths
 - enforced `0600` KEK file permissions at runtime by making `TenantKey::loadKek()` reject insecure key files and aligning `tenant:setup` plus `app:validate-setup` to fail fast on permissive KEK modes
 - validated the `email` query value on `GET /v1/tenants/{tenant}/persons/by-email` so malformed addresses now fail fast with `422` instead of reaching blind-index lookup logic
+- added the HSTS `preload` directive to the API security-header baseline so secure clients can enforce HTTPS from first contact once the domain is enrolled in browser preload lists
 - added `Cache-Control: no-store, no-cache, must-revalidate, private` and `Pragma: no-cache` to the API security-header baseline so sensitive responses are less likely to persist in browser or intermediary caches
 - configured Sanctum personal access tokens to expire after `1440` minutes by default, documented `SANCTUM_TOKEN_EXPIRY_MINUTES` in `.env.example`, and added regression coverage that expired bearer tokens are rejected with `401 Unauthorized`
 - aligned `.env.example` with the production session default by documenting `SESSION_DRIVER=database`, so fresh deployments no longer advertise a cookie-session configuration that the runtime config does not actually default to

--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -21,7 +21,7 @@ class SecurityHeaders
 
     private const PERMISSIONS_POLICY = 'accelerometer=(), autoplay=(), camera=(), clipboard-read=(), clipboard-write=(), display-capture=(), fullscreen=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()';
 
-    private const STRICT_TRANSPORT_SECURITY = 'max-age=63072000; includeSubDomains';
+    private const STRICT_TRANSPORT_SECURITY = 'max-age=63072000; includeSubDomains; preload';
 
     /**
      * Handle an incoming request.

--- a/tests/Feature/Middleware/SecurityHeadersTest.php
+++ b/tests/Feature/Middleware/SecurityHeadersTest.php
@@ -37,7 +37,7 @@ describe('Security Headers Middleware', function () {
             'HTTPS' => 'on',
         ])->get('/sanctum/csrf-cookie');
 
-        expect($response->headers->get('Strict-Transport-Security'))->toBe('max-age=63072000; includeSubDomains');
+        expect($response->headers->get('Strict-Transport-Security'))->toBe('max-age=63072000; includeSubDomains; preload');
     });
 
     test('api responses include the full hardening baseline', function () {


### PR DESCRIPTION
## Summary
- add the HSTS `preload` directive to the API security header baseline
- keep the existing HTTPS-only HSTS behavior and two-year max-age policy unchanged
- update the middleware regression test to assert the stricter header value

## Testing
- source /home/secpal/code/SecPal/api/.env && vendor/bin/pest tests/Feature/Middleware/SecurityHeadersTest.php
- vendor/bin/pint --dirty
- vendor/bin/phpstan analyse --memory-limit=1G

Closes #693