### PR TITLE
fix: silence isolated worktree dotenv warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- stopped isolated API worktree test runs from emitting missing-`.env` phpdotenv warnings by creating a temporary bootstrap stub only for the lifetime of the test process when no local environment file exists
 - made `tenant:setup` fail fast with a targeted unreadable-KEK error instead of falling through to the generic invalid-file path when the current process cannot read the KEK file
 - equalized the password reset request response floor with a minimum configurable delay so existing-account and missing-account paths are harder to distinguish via timing measurements
 - sanitized employee document filenames before persisting them and before emitting `Content-Disposition`, so uploaded names can no longer inject or reshape download headers

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,10 +1,11 @@
 <?php
 
-// SPDX-FileCopyrightText: 2025 SecPal Contributors
+// SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 namespace Tests;
 
+use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
@@ -13,6 +14,8 @@ use Spatie\Permission\PermissionRegistrar;
 abstract class TestCase extends BaseTestCase
 {
     private static bool $postgresTestDatabasesEnsured = false;
+
+    private static ?string $temporaryBootstrapEnvironmentFile = null;
 
     /**
      * @var array<string, string>|null
@@ -24,6 +27,16 @@ abstract class TestCase extends BaseTestCase
         self::ensurePostgresTestDatabasesExist();
 
         parent::setUpBeforeClass();
+    }
+
+    public function createApplication(): Application
+    {
+        self::ensureBootstrapEnvironmentFileExists();
+
+        /** @var Application $app */
+        $app = parent::createApplication();
+
+        return $app;
     }
 
     /**
@@ -161,6 +174,54 @@ abstract class TestCase extends BaseTestCase
         }
 
         return $default;
+    }
+
+    protected static function bootstrapEnvironmentPath(): string
+    {
+        return dirname(__DIR__);
+    }
+
+    protected static function ensureBootstrapEnvironmentFileExists(): void
+    {
+        $environmentPath = static::bootstrapEnvironmentPath();
+        $defaultEnvironmentFile = $environmentPath.'/.env';
+
+        if (self::$temporaryBootstrapEnvironmentFile !== null) {
+            if (self::$temporaryBootstrapEnvironmentFile === $defaultEnvironmentFile && is_file($defaultEnvironmentFile)) {
+                return;
+            }
+
+            self::cleanupBootstrapEnvironmentFile();
+        }
+
+        if (is_file($defaultEnvironmentFile)) {
+            return;
+        }
+
+        $stubContents = "# Temporary test bootstrap stub to avoid phpdotenv missing-file warnings in isolated worktrees\n";
+
+        if (file_put_contents($defaultEnvironmentFile, $stubContents) === false) {
+            throw new \RuntimeException('Unable to create temporary test environment file at: '.$defaultEnvironmentFile);
+        }
+
+        self::$temporaryBootstrapEnvironmentFile = $defaultEnvironmentFile;
+
+        register_shutdown_function(static function (): void {
+            self::cleanupBootstrapEnvironmentFile();
+        });
+    }
+
+    protected static function cleanupBootstrapEnvironmentFile(): void
+    {
+        if (self::$temporaryBootstrapEnvironmentFile === null) {
+            return;
+        }
+
+        if (is_file(self::$temporaryBootstrapEnvironmentFile)) {
+            unlink(self::$temporaryBootstrapEnvironmentFile);
+        }
+
+        self::$temporaryBootstrapEnvironmentFile = null;
     }
 
     /**

--- a/tests/Unit/TestCaseBootstrapEnvironmentFileTest.php
+++ b/tests/Unit/TestCaseBootstrapEnvironmentFileTest.php
@@ -1,0 +1,81 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class TestCaseBootstrapEnvironmentProbe extends TestCase
+{
+    private static ?string $probeEnvironmentPath = null;
+
+    public static function useProbeEnvironmentPath(string $path): void
+    {
+        self::$probeEnvironmentPath = $path;
+    }
+
+    public static function createBootstrapEnvironmentStub(): void
+    {
+        parent::ensureBootstrapEnvironmentFileExists();
+    }
+
+    public static function removeBootstrapEnvironmentStub(): void
+    {
+        parent::cleanupBootstrapEnvironmentFile();
+    }
+
+    public static function clearProbeEnvironmentPath(): void
+    {
+        self::$probeEnvironmentPath = null;
+    }
+
+    protected static function bootstrapEnvironmentPath(): string
+    {
+        return self::$probeEnvironmentPath ?? parent::bootstrapEnvironmentPath();
+    }
+}
+
+afterEach(function (): void {
+    TestCaseBootstrapEnvironmentProbe::removeBootstrapEnvironmentStub();
+    TestCaseBootstrapEnvironmentProbe::clearProbeEnvironmentPath();
+});
+
+test('creates a temporary .env stub when no local env files exist', function (): void {
+    $probeDirectory = storage_path('framework/testing/bootstrap-env-'.Str::uuid());
+
+    mkdir($probeDirectory, 0700, true);
+    TestCaseBootstrapEnvironmentProbe::useProbeEnvironmentPath($probeDirectory);
+
+    $environmentFile = $probeDirectory.'/.env';
+
+    expect(is_file($environmentFile))->toBeFalse();
+
+    TestCaseBootstrapEnvironmentProbe::createBootstrapEnvironmentStub();
+
+    expect(is_file($environmentFile))->toBeTrue()
+        ->and(file_get_contents($environmentFile))->toContain('Temporary test bootstrap stub');
+
+    TestCaseBootstrapEnvironmentProbe::removeBootstrapEnvironmentStub();
+
+    expect(is_file($environmentFile))->toBeFalse();
+
+    rmdir($probeDirectory);
+});
+
+test('does not create a temporary bootstrap stub when a local .env already exists', function (): void {
+    $probeDirectory = storage_path('framework/testing/bootstrap-env-'.Str::uuid());
+
+    mkdir($probeDirectory, 0700, true);
+    file_put_contents($probeDirectory.'/.env', "APP_ENV=testing\n");
+
+    TestCaseBootstrapEnvironmentProbe::useProbeEnvironmentPath($probeDirectory);
+    TestCaseBootstrapEnvironmentProbe::createBootstrapEnvironmentStub();
+
+    expect(file_get_contents($probeDirectory.'/.env'))->toBe("APP_ENV=testing\n");
+
+    unlink($probeDirectory.'/.env');
+    rmdir($probeDirectory);
+});


### PR DESCRIPTION
## Summary
- create a temporary test-process .env stub when an isolated API worktree has no local environment file
- remove the temporary stub automatically after the test process exits so the worktree stays clean
- cover the bootstrap helper behavior with a focused unit test and verify the original password-reset worktree repro is warning-free

## Testing
- source /home/secpal/code/SecPal/api/.env && vendor/bin/pest tests/Unit/TestCaseBootstrapEnvironmentFileTest.php tests/Feature/Auth/PasswordResetRequestTest.php --display-warnings
- vendor/bin/pint --dirty
- vendor/bin/phpstan analyse --memory-limit=1G

Refs #729