### PR TITLE
chore: align onboarding test domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- replaced the remaining `@example.com` onboarding test fixtures with `@secpal.dev` so the onboarding suites follow the repository domain policy
 - removed the unused `check.customer.scope` middleware alias from bootstrap registration so the API no longer advertises a non-existent custom middleware
 - validated employee document uploads by MIME type as well as file extension, so renamed plain-text files no longer pass PDF/JPEG/PNG checks
 - aligned nested customer site listings with site visibility rules and documented `type` / `is_active` filters

--- a/tests/Feature/OnboardingCompletionTest.php
+++ b/tests/Feature/OnboardingCompletionTest.php
@@ -90,7 +90,7 @@ test('completes onboarding with valid token', function () {
 test('rejects invalid token', function () {
     $response = $this->withSession([])->postJson('/v1/onboarding/complete', [
         'token' => 'invalid-token-that-does-not-exist',
-        'email' => 'test@example.com',
+        'email' => 'test@secpal.dev',
         'password' => 'SecurePassword123!',
         'first_name' => 'John',
         'last_name' => 'Doe',
@@ -105,7 +105,7 @@ test('rejects invalid token', function () {
 test('rejects expired token', function () {
     /** @var Employee $employee */
     $employee = Employee::factory()->preContract()->create([
-        'email' => 'test@example.com',
+        'email' => 'test@secpal.dev',
     ]);
     $tokenData = EmployeeOnboardingToken::generate($employee);
     $plainToken = $tokenData['plain'];
@@ -115,7 +115,7 @@ test('rejects expired token', function () {
 
     $response = $this->withSession([])->postJson('/v1/onboarding/complete', [
         'token' => $plainToken,
-        'email' => 'test@example.com',
+        'email' => 'test@secpal.dev',
         'password' => 'SecurePassword123!',
         'first_name' => 'John',
         'last_name' => 'Doe',
@@ -167,14 +167,14 @@ test('rejects onboarding for non-pre-contract employee', function () {
     // Create employee with status other than PRE_CONTRACT
     /** @var User $user */
     $user = User::factory()->create([
-        'email' => 'test@example.com',
+        'email' => 'test@secpal.dev',
     ]);
 
     /** @var Employee $employee */
     $employee = Employee::factory()->create([
         'tenant_id' => $this->tenant->id,
         'status' => Employee::STATUS_ACTIVE,
-        'email' => 'test@example.com',
+        'email' => 'test@secpal.dev',
         'user_id' => $user->id,
     ]);
 
@@ -183,7 +183,7 @@ test('rejects onboarding for non-pre-contract employee', function () {
 
     $response = $this->withSession([])->postJson('/v1/onboarding/complete', [
         'token' => $plainToken,
-        'email' => 'test@example.com',
+        'email' => 'test@secpal.dev',
         'password' => 'SecurePassword123!',
         'first_name' => 'John',
         'last_name' => 'Doe',
@@ -205,12 +205,12 @@ test('validates required fields', function () {
 test('validates password strength', function () {
     /** @var User $user */
     $user = User::factory()->create([
-        'email' => 'test@example.com',
+        'email' => 'test@secpal.dev',
     ]);
 
     /** @var Employee $employee */
     $employee = Employee::factory()->preContract()->create([
-        'email' => 'test@example.com',
+        'email' => 'test@secpal.dev',
         'user_id' => $user->id,
     ]);
     $tokenData = EmployeeOnboardingToken::generate($employee);
@@ -218,7 +218,7 @@ test('validates password strength', function () {
 
     $response = $this->withSession([])->postJson('/v1/onboarding/complete', [
         'token' => $plainToken,
-        'email' => 'test@example.com',
+        'email' => 'test@secpal.dev',
         'password' => 'weak', // Too weak password
         'first_name' => 'John',
         'last_name' => 'Doe',
@@ -233,7 +233,7 @@ test('rate limits onboarding attempts', function () {
     for ($i = 0; $i < 4; $i++) {
         $response = $this->withSession([])->postJson('/v1/onboarding/complete', [
             'token' => 'invalid-token',
-            'email' => 'test@example.com',
+            'email' => 'test@secpal.dev',
             'password' => 'SecurePassword123!',
             'first_name' => 'John',
             'last_name' => 'Doe',
@@ -285,12 +285,12 @@ test('validation throttle bucket does not block onboarding completion for the sa
 test('SECURITY: rejects valid token with wrong email', function () {
     /** @var User $user */
     $user = User::factory()->create([
-        'email' => 'correct@example.com',
+        'email' => 'correct@secpal.dev',
     ]);
 
     /** @var Employee $employee */
     $employee = Employee::factory()->preContract()->create([
-        'email' => 'correct@example.com',
+        'email' => 'correct@secpal.dev',
         'user_id' => $user->id,
     ]);
 
@@ -300,7 +300,7 @@ test('SECURITY: rejects valid token with wrong email', function () {
     // Attacker tries to use valid token with different email
     $response = $this->withSession([])->postJson('/v1/onboarding/complete', [
         'token' => $plainToken,
-        'email' => 'attacker@example.com', // Wrong email!
+        'email' => 'attacker@secpal.dev', // Wrong email!
         'password' => 'SecurePassword123!',
         'first_name' => 'Hacker',
         'last_name' => 'McHackface',
@@ -319,12 +319,12 @@ test('SECURITY: rejects valid token with wrong email', function () {
 test('SECURITY: validates email case-sensitively', function () {
     /** @var User $user */
     $user = User::factory()->create([
-        'email' => 'test@example.com',
+        'email' => 'test@secpal.dev',
     ]);
 
     /** @var Employee $employee */
     $employee = Employee::factory()->preContract()->create([
-        'email' => 'test@example.com',
+        'email' => 'test@secpal.dev',
         'user_id' => $user->id,
     ]);
 
@@ -334,7 +334,7 @@ test('SECURITY: validates email case-sensitively', function () {
     // Try with uppercase email
     $response = $this->withSession([])->postJson('/v1/onboarding/complete', [
         'token' => $plainToken,
-        'email' => 'TEST@EXAMPLE.COM', // Wrong case
+        'email' => 'TEST@SECPAL.DEV', // Wrong case
         'password' => 'SecurePassword123!',
         'first_name' => 'John',
         'last_name' => 'Doe',
@@ -347,19 +347,19 @@ test('SECURITY: validates email case-sensitively', function () {
 });
 
 test('SECURITY: prevents token hijacking scenario', function () {
-    // Scenario: Attacker intercepts token for victim@example.com
-    // Tries to use it to create account for attacker@example.com
+    // Scenario: Attacker intercepts token for victim@secpal.dev
+    // Tries to use it to create account for attacker@secpal.dev
 
     /** @var User $victimUser */
     $victimUser = User::factory()->create([
-        'email' => 'victim@example.com',
+        'email' => 'victim@secpal.dev',
     ]);
 
     /** @var Employee $victimEmployee */
     $victimEmployee = Employee::factory()->preContract()->create([
         'first_name' => 'Victim',
         'last_name' => 'User',
-        'email' => 'victim@example.com',
+        'email' => 'victim@secpal.dev',
         'user_id' => $victimUser->id,
     ]);
 
@@ -369,7 +369,7 @@ test('SECURITY: prevents token hijacking scenario', function () {
     // Attacker tries to complete onboarding with their own email
     $response = $this->withSession([])->postJson('/v1/onboarding/complete', [
         'token' => $interceptedToken,
-        'email' => 'attacker@example.com',
+        'email' => 'attacker@secpal.dev',
         'password' => 'AttackerPassword123!',
         'first_name' => 'Attacker',
         'last_name' => 'McEvil',
@@ -385,7 +385,7 @@ test('SECURITY: prevents token hijacking scenario', function () {
     $victimEmployee->refresh();
     expect($victimEmployee->first_name)->toBe('Victim');
     expect($victimEmployee->last_name)->toBe('User');
-    expect($victimEmployee->email)->toBe('victim@example.com');
+    expect($victimEmployee->email)->toBe('victim@secpal.dev');
 
     // Verify victim's password was NOT changed
     $victimUser->refresh();
@@ -395,14 +395,14 @@ test('SECURITY: prevents token hijacking scenario', function () {
 test('logs name changes with enhanced activity log', function () {
     /** @var User $user */
     $user = User::factory()->create([
-        'email' => 'test@example.com',
+        'email' => 'test@secpal.dev',
     ]);
 
     /** @var Employee $employee */
     $employee = Employee::factory()->preContract()->create([
         'first_name' => 'OldFirst',
         'last_name' => 'OldLast',
-        'email' => 'test@example.com',
+        'email' => 'test@secpal.dev',
         'user_id' => $user->id,
     ]);
 
@@ -412,7 +412,7 @@ test('logs name changes with enhanced activity log', function () {
     // Complete onboarding with different names
     $response = $this->withSession([])->postJson('/v1/onboarding/complete', [
         'token' => $plainToken,
-        'email' => 'test@example.com',
+        'email' => 'test@secpal.dev',
         'password' => 'SecurePassword123!',
         'first_name' => 'NewFirst',
         'last_name' => 'NewLast',
@@ -438,14 +438,14 @@ test('logs name changes with enhanced activity log', function () {
 test('does not log activity if names unchanged', function () {
     /** @var User $user */
     $user = User::factory()->create([
-        'email' => 'test@example.com',
+        'email' => 'test@secpal.dev',
     ]);
 
     /** @var Employee $employee */
     $employee = Employee::factory()->preContract()->create([
         'first_name' => 'John',
         'last_name' => 'Doe',
-        'email' => 'test@example.com',
+        'email' => 'test@secpal.dev',
         'user_id' => $user->id,
     ]);
 
@@ -455,7 +455,7 @@ test('does not log activity if names unchanged', function () {
     // Complete onboarding with same names
     $response = $this->withSession([])->postJson('/v1/onboarding/complete', [
         'token' => $plainToken,
-        'email' => 'test@example.com',
+        'email' => 'test@secpal.dev',
         'password' => 'SecurePassword123!',
         'first_name' => 'John',
         'last_name' => 'Doe',
@@ -511,13 +511,13 @@ test('creates sanctum token after successful completion', function () {
 
 test('allows minor name correction (typo, >80% similar)', function () {
     /** @var User $user */
-    $user = User::factory()->create(['email' => 'test@example.com']);
+    $user = User::factory()->create(['email' => 'test@secpal.dev']);
 
     /** @var Employee $employee */
     $employee = Employee::factory()->preContract()->create([
         'first_name' => 'Hanns', // Typo
         'last_name' => 'Mueller', // Alternate spelling
-        'email' => 'test@example.com',
+        'email' => 'test@secpal.dev',
         'user_id' => $user->id,
     ]);
 
@@ -527,7 +527,7 @@ test('allows minor name correction (typo, >80% similar)', function () {
     // Minor corrections should be allowed
     $response = $this->withSession([])->postJson('/v1/onboarding/complete', [
         'token' => $plainToken,
-        'email' => 'test@example.com',
+        'email' => 'test@secpal.dev',
         'password' => 'SecurePassword123!',
         'first_name' => 'Hans', // Corrected
         'last_name' => 'Müller', // Corrected with umlaut
@@ -555,13 +555,13 @@ test('allows medium name change with warning (50-80% similar)', function () {
     Illuminate\Support\Facades\Mail::fake();
 
     /** @var User $user */
-    $user = User::factory()->create(['email' => 'test@example.com']);
+    $user = User::factory()->create(['email' => 'test@secpal.dev']);
 
     /** @var Employee $employee */
     $employee = Employee::factory()->preContract()->create([
         'first_name' => 'Hans',
         'last_name' => 'Müller',
-        'email' => 'test@example.com',
+        'email' => 'test@secpal.dev',
         'user_id' => $user->id,
     ]);
 
@@ -571,7 +571,7 @@ test('allows medium name change with warning (50-80% similar)', function () {
     // Medium change: Adding additional name
     $response = $this->withSession([])->postJson('/v1/onboarding/complete', [
         'token' => $plainToken,
-        'email' => 'test@example.com',
+        'email' => 'test@secpal.dev',
         'password' => 'SecurePassword123!',
         'first_name' => 'Hans-Peter', // Added hyphenated name
         'last_name' => 'Müller-Schmidt', // Added double name
@@ -595,13 +595,13 @@ test('allows medium name change with warning (50-80% similar)', function () {
 
 test('blocks major name change (<50% similar)', function () {
     /** @var User $user */
-    $user = User::factory()->create(['email' => 'test@example.com']);
+    $user = User::factory()->create(['email' => 'test@secpal.dev']);
 
     /** @var Employee $employee */
     $employee = Employee::factory()->preContract()->create([
         'first_name' => 'Hans',
         'last_name' => 'Müller',
-        'email' => 'test@example.com',
+        'email' => 'test@secpal.dev',
         'user_id' => $user->id,
     ]);
 
@@ -611,7 +611,7 @@ test('blocks major name change (<50% similar)', function () {
     // Major change: Completely different name
     $response = $this->withSession([])->postJson('/v1/onboarding/complete', [
         'token' => $plainToken,
-        'email' => 'test@example.com',
+        'email' => 'test@secpal.dev',
         'password' => 'SecurePassword123!',
         'first_name' => 'Maria', // Completely different
         'last_name' => 'Schmidt', // Completely different
@@ -633,13 +633,13 @@ test('allows unchanged name without HR notification', function () {
     Illuminate\Support\Facades\Mail::fake();
 
     /** @var User $user */
-    $user = User::factory()->create(['email' => 'test@example.com']);
+    $user = User::factory()->create(['email' => 'test@secpal.dev']);
 
     /** @var Employee $employee */
     $employee = Employee::factory()->preContract()->create([
         'first_name' => 'John',
         'last_name' => 'Doe',
-        'email' => 'test@example.com',
+        'email' => 'test@secpal.dev',
         'user_id' => $user->id,
     ]);
 
@@ -649,7 +649,7 @@ test('allows unchanged name without HR notification', function () {
     // Complete with same names
     $response = $this->withSession([])->postJson('/v1/onboarding/complete', [
         'token' => $plainToken,
-        'email' => 'test@example.com',
+        'email' => 'test@secpal.dev',
         'password' => 'SecurePassword123!',
         'first_name' => 'John',
         'last_name' => 'Doe',
@@ -668,7 +668,7 @@ test('synchronizes user name with employee name after onboarding', function () {
     /** @var User $user */
     $user = User::factory()->create([
         'name' => 'Max Mustermann', // Old name
-        'email' => 'max@example.com',
+        'email' => 'max@secpal.dev',
     ]);
 
     /** @var Employee $employee */
@@ -701,7 +701,7 @@ test('synchronizes user name with employee name after onboarding', function () {
     // Assert: User name was synchronized with employee name (BUG FIX)
     $user->refresh();
     expect($user->name)->toBe('Maximilian Mustermann')
-        ->and($user->email)->toBe('max@example.com');
+        ->and($user->email)->toBe('max@secpal.dev');
 
     // Assert: Response includes updated user name
     $response->assertJson([
@@ -804,7 +804,7 @@ test('automatically logs user in with session after onboarding (no token)', func
 
 // New test: only first name changes (medium severity)
 test('sends HR notification when only first name changes with medium severity', function () {
-    $user = User::factory()->create(['name' => '', 'email' => 'max@example.com']);
+    $user = User::factory()->create(['name' => '', 'email' => 'max@secpal.dev']);
     $employee = Employee::factory()->preContract()->create([
         'first_name' => 'Max',
         'last_name' => 'Mustermann',
@@ -840,7 +840,7 @@ test('sends HR notification when only first name changes with medium severity', 
 
 // New test: only last name changes (medium severity)
 test('sends HR notification when only last name changes with medium severity', function () {
-    $user = User::factory()->create(['name' => '', 'email' => 'hans@example.com']);
+    $user = User::factory()->create(['name' => '', 'email' => 'hans@secpal.dev']);
     $employee = Employee::factory()->preContract()->create([
         'first_name' => 'Hans',
         'last_name' => 'Müller',
@@ -876,7 +876,7 @@ test('sends HR notification when only last name changes with medium severity', f
 
 // New test: mixed severity (first name minor, last name medium)
 test('sends HR notification when mixed severity changes occur', function () {
-    $user = User::factory()->create(['name' => '', 'email' => 'hanz@example.com']);
+    $user = User::factory()->create(['name' => '', 'email' => 'hanz@secpal.dev']);
     $employee = Employee::factory()->preContract()->create([
         'first_name' => 'Hanz',
         'last_name' => 'Schmidt',

--- a/tests/Feature/OnboardingTokenValidationTest.php
+++ b/tests/Feature/OnboardingTokenValidationTest.php
@@ -30,28 +30,28 @@ afterEach(function () {
 test('validates token with correct email and returns employee data', function () {
     /** @var User $user */
     $user = User::factory()->create([
-        'email' => 'test@example.com',
+        'email' => 'test@secpal.dev',
     ]);
 
     /** @var Employee $employee */
     $employee = Employee::factory()->preContract()->create([
         'first_name' => 'Max',
         'last_name' => 'Mustermann',
-        'email' => 'test@example.com',
+        'email' => 'test@secpal.dev',
         'user_id' => $user->id,
     ]);
 
     $tokenData = EmployeeOnboardingToken::generate($employee);
     $plainToken = $tokenData['plain'];
 
-    $response = getJson('/v1/onboarding/validate-token?token='.urlencode($plainToken).'&email='.urlencode('test@example.com'));
+    $response = getJson('/v1/onboarding/validate-token?token='.urlencode($plainToken).'&email='.urlencode('test@secpal.dev'));
 
     $response->assertOk()
         ->assertJson([
             'data' => [
                 'first_name' => 'Max',
                 'last_name' => 'Mustermann',
-                'email' => 'test@example.com',
+                'email' => 'test@secpal.dev',
             ],
         ]);
 });
@@ -59,14 +59,14 @@ test('validates token with correct email and returns employee data', function ()
 test('SECURITY: rejects valid token with wrong email', function () {
     /** @var User $user */
     $user = User::factory()->create([
-        'email' => 'correct@example.com',
+        'email' => 'correct@secpal.dev',
     ]);
 
     /** @var Employee $employee */
     $employee = Employee::factory()->preContract()->create([
         'first_name' => 'Max',
         'last_name' => 'Mustermann',
-        'email' => 'correct@example.com',
+        'email' => 'correct@secpal.dev',
         'user_id' => $user->id,
     ]);
 
@@ -74,7 +74,7 @@ test('SECURITY: rejects valid token with wrong email', function () {
     $plainToken = $tokenData['plain'];
 
     // Attacker tries to use valid token with different email
-    $response = getJson('/v1/onboarding/validate-token?token='.urlencode($plainToken).'&email='.urlencode('attacker@example.com'));
+    $response = getJson('/v1/onboarding/validate-token?token='.urlencode($plainToken).'&email='.urlencode('attacker@secpal.dev'));
 
     $response->assertStatus(422)
         ->assertJson([
@@ -85,14 +85,14 @@ test('SECURITY: rejects valid token with wrong email', function () {
 test('SECURITY: validates email case-sensitively', function () {
     /** @var User $user */
     $user = User::factory()->create([
-        'email' => 'test@example.com',
+        'email' => 'test@secpal.dev',
     ]);
 
     /** @var Employee $employee */
     $employee = Employee::factory()->preContract()->create([
         'first_name' => 'Max',
         'last_name' => 'Mustermann',
-        'email' => 'test@example.com',
+        'email' => 'test@secpal.dev',
         'user_id' => $user->id,
     ]);
 
@@ -100,7 +100,7 @@ test('SECURITY: validates email case-sensitively', function () {
     $plainToken = $tokenData['plain'];
 
     // Try with different case
-    $response = getJson('/v1/onboarding/validate-token?token='.urlencode($plainToken).'&email='.urlencode('TEST@EXAMPLE.COM'));
+    $response = getJson('/v1/onboarding/validate-token?token='.urlencode($plainToken).'&email='.urlencode('TEST@SECPAL.DEV'));
 
     $response->assertStatus(422)
         ->assertJson([
@@ -121,14 +121,14 @@ test('requires email parameter', function () {
 });
 
 test('requires token parameter', function () {
-    $response = getJson('/v1/onboarding/validate-token?email=test@example.com');
+    $response = getJson('/v1/onboarding/validate-token?email=test@secpal.dev');
 
     $response->assertStatus(422)
         ->assertJsonValidationErrors(['token']);
 });
 
 test('rejects invalid token', function () {
-    $response = getJson('/v1/onboarding/validate-token?token=invalid-token&email=test@example.com');
+    $response = getJson('/v1/onboarding/validate-token?token=invalid-token&email=test@secpal.dev');
 
     $response->assertStatus(422)
         ->assertJson([
@@ -139,12 +139,12 @@ test('rejects invalid token', function () {
 test('rejects expired token', function () {
     /** @var User $user */
     $user = User::factory()->create([
-        'email' => 'test@example.com',
+        'email' => 'test@secpal.dev',
     ]);
 
     /** @var Employee $employee */
     $employee = Employee::factory()->preContract()->create([
-        'email' => 'test@example.com',
+        'email' => 'test@secpal.dev',
         'user_id' => $user->id,
     ]);
 
@@ -154,7 +154,7 @@ test('rejects expired token', function () {
     // Expire token
     $tokenData['model']->update(['expires_at' => now()->subDay()]);
 
-    $response = getJson('/v1/onboarding/validate-token?token='.urlencode($plainToken).'&email=test@example.com');
+    $response = getJson('/v1/onboarding/validate-token?token='.urlencode($plainToken).'&email=test@secpal.dev');
 
     $response->assertStatus(422)
         ->assertJson([
@@ -165,12 +165,12 @@ test('rejects expired token', function () {
 test('rejects already completed token', function () {
     /** @var User $user */
     $user = User::factory()->create([
-        'email' => 'test@example.com',
+        'email' => 'test@secpal.dev',
     ]);
 
     /** @var Employee $employee */
     $employee = Employee::factory()->preContract()->create([
-        'email' => 'test@example.com',
+        'email' => 'test@secpal.dev',
         'user_id' => $user->id,
     ]);
 
@@ -180,7 +180,7 @@ test('rejects already completed token', function () {
     // Mark token as completed
     $tokenData['model']->markAsCompleted('127.0.0.1', 'test-agent');
 
-    $response = getJson('/v1/onboarding/validate-token?token='.urlencode($plainToken).'&email=test@example.com');
+    $response = getJson('/v1/onboarding/validate-token?token='.urlencode($plainToken).'&email=test@secpal.dev');
 
     $response->assertStatus(422)
         ->assertJson([
@@ -191,13 +191,13 @@ test('rejects already completed token', function () {
 test('rejects token for non-pre-contract employee', function () {
     /** @var User $user */
     $user = User::factory()->create([
-        'email' => 'test@example.com',
+        'email' => 'test@secpal.dev',
     ]);
 
     /** @var Employee $employee */
     $employee = Employee::factory()->create([
         'tenant_id' => $this->tenant->id,
-        'email' => 'test@example.com',
+        'email' => 'test@secpal.dev',
         'user_id' => $user->id,
         'status' => Employee::STATUS_ACTIVE, // Not PRE_CONTRACT
     ]);
@@ -205,7 +205,7 @@ test('rejects token for non-pre-contract employee', function () {
     $tokenData = EmployeeOnboardingToken::generate($employee);
     $plainToken = $tokenData['plain'];
 
-    $response = getJson('/v1/onboarding/validate-token?token='.urlencode($plainToken).'&email=test@example.com');
+    $response = getJson('/v1/onboarding/validate-token?token='.urlencode($plainToken).'&email=test@secpal.dev');
 
     $response->assertStatus(403)
         ->assertJson([
@@ -216,26 +216,26 @@ test('rejects token for non-pre-contract employee', function () {
 test('handles URL-encoded special characters in email', function () {
     /** @var User $user */
     $user = User::factory()->create([
-        'email' => 'test+tag@example.com',
+        'email' => 'test+tag@secpal.dev',
     ]);
 
     /** @var Employee $employee */
     $employee = Employee::factory()->preContract()->create([
         'first_name' => 'Test',
         'last_name' => 'User',
-        'email' => 'test+tag@example.com',
+        'email' => 'test+tag@secpal.dev',
         'user_id' => $user->id,
     ]);
 
     $tokenData = EmployeeOnboardingToken::generate($employee);
     $plainToken = $tokenData['plain'];
 
-    $response = getJson('/v1/onboarding/validate-token?token='.urlencode($plainToken).'&email='.urlencode('test+tag@example.com'));
+    $response = getJson('/v1/onboarding/validate-token?token='.urlencode($plainToken).'&email='.urlencode('test+tag@secpal.dev'));
 
     $response->assertOk()
         ->assertJson([
             'data' => [
-                'email' => 'test+tag@example.com',
+                'email' => 'test+tag@secpal.dev',
             ],
         ]);
 });
@@ -243,14 +243,14 @@ test('handles URL-encoded special characters in email', function () {
 test('does not rate limit repeated successful token validations', function () {
     /** @var User $user */
     $user = User::factory()->create([
-        'email' => 'repeat@example.com',
+        'email' => 'repeat@secpal.dev',
     ]);
 
     /** @var Employee $employee */
     $employee = Employee::factory()->preContract()->create([
         'first_name' => 'Repeat',
         'last_name' => 'Visitor',
-        'email' => 'repeat@example.com',
+        'email' => 'repeat@secpal.dev',
         'user_id' => $user->id,
     ]);
 
@@ -258,7 +258,7 @@ test('does not rate limit repeated successful token validations', function () {
     $plainToken = $tokenData['plain'];
 
     for ($i = 0; $i < 6; $i++) {
-        $response = getJson('/v1/onboarding/validate-token?token='.urlencode($plainToken).'&email='.urlencode('repeat@example.com'));
+        $response = getJson('/v1/onboarding/validate-token?token='.urlencode($plainToken).'&email='.urlencode('repeat@secpal.dev'));
 
         $response->assertOk();
     }
@@ -267,7 +267,7 @@ test('does not rate limit repeated successful token validations', function () {
 test('rate limits repeated failed validation attempts', function () {
     // Failed validations should still be throttled to slow down abuse.
     for ($i = 0; $i < 4; $i++) {
-        $response = getJson('/v1/onboarding/validate-token?token=invalid-token&email=test@example.com');
+        $response = getJson('/v1/onboarding/validate-token?token=invalid-token&email=test@secpal.dev');
     }
 
     // 4th request should be rate limited


### PR DESCRIPTION
## Summary
- replace the remaining `@example.com` onboarding test fixtures with `@secpal.dev`
- keep the onboarding validation and completion suites aligned with the repository domain policy
- record the cleanup in the changelog

## Validation
- php artisan test tests/Feature/OnboardingTokenValidationTest.php tests/Feature/OnboardingCompletionTest.php
- vendor/bin/pint --dirty
- editor diagnostics for the changed onboarding test files

Refs #759