### PR TITLE
test: remove onboarding template tenant coupling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- replaced the onboarding form template factory's implicit `TenantKey::first()` fallback with an explicit `TenantKey::factory()` default so onboarding tests no longer depend on pre-seeded tenant state
 - replaced the remaining `@example.com` onboarding test fixtures with `@secpal.dev` so the onboarding suites follow the repository domain policy
 - removed the unused `check.customer.scope` middleware alias from bootstrap registration so the API no longer advertises a non-existent custom middleware
 - validated employee document uploads by MIME type as well as file extension, so renamed plain-text files no longer pass PDF/JPEG/PNG checks

--- a/database/factories/OnboardingFormTemplateFactory.php
+++ b/database/factories/OnboardingFormTemplateFactory.php
@@ -1,6 +1,6 @@
 <?php
 
-// SPDX-FileCopyrightText: 2025 SecPal Contributors
+// SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 namespace Database\Factories;
@@ -20,18 +20,8 @@ class OnboardingFormTemplateFactory extends Factory
      */
     public function definition(): array
     {
-        // Get existing tenant from first test (created by setUp)
-        $tenant = TenantKey::first();
-        if (! $tenant) {
-            if (! file_exists(TenantKey::getKekPath())) {
-                TenantKey::generateKek();
-            }
-            $keys = TenantKey::generateEnvelopeKeys();
-            $tenant = TenantKey::create($keys);
-        }
-
         return [
-            'tenant_id' => $tenant->id,
+            'tenant_id' => TenantKey::factory(),
             'name' => fake()->sentence(3),
             'description' => fake()->sentence(),
             'form_schema' => [

--- a/tests/Unit/Factories/OnboardingFormTemplateFactoryTest.php
+++ b/tests/Unit/Factories/OnboardingFormTemplateFactoryTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use App\Models\OnboardingFormTemplate;
+use App\Models\TenantKey;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class)->group('factory', 'unit');
+
+beforeEach(function (): void {
+    TenantKey::setKekPath(getTestKekPath());
+    TenantKey::generateKek();
+});
+
+afterEach(function (): void {
+    cleanupTestKekFile();
+    TenantKey::setKekPath(null);
+});
+
+test('onboarding form template factory creates a tenant when none exists', function (): void {
+    expect(TenantKey::count())->toBe(0);
+
+    $template = OnboardingFormTemplate::factory()->create();
+
+    expect($template->tenant_id)->not->toBeNull()
+        ->and(TenantKey::count())->toBe(1)
+        ->and($template->tenant)->toBeInstanceOf(TenantKey::class);
+});
+
+test('onboarding form template factory respects an explicit tenant id', function (): void {
+    $tenant = TenantKey::factory()->create();
+
+    $template = OnboardingFormTemplate::factory()->create([
+        'tenant_id' => $tenant->id,
+    ]);
+
+    expect($template->tenant_id)->toBe($tenant->id)
+        ->and(TenantKey::count())->toBe(1);
+});
+
+test('system onboarding form template state stays tenantless', function (): void {
+    $template = OnboardingFormTemplate::factory()->systemTemplate()->create();
+
+    expect($template->tenant_id)->toBeNull()
+        ->and($template->is_system_template)->toBeTrue()
+        ->and(TenantKey::count())->toBe(0);
+});


### PR DESCRIPTION
## Summary
- replace the onboarding form template factory's implicit `TenantKey::first()` dependency with an explicit `TenantKey::factory()` default
- keep system templates tenantless while preserving explicit tenant overrides in tests and callers
- add focused factory coverage for autonomous tenant creation, explicit tenant reuse, and the tenantless system-template state

## Validation
- `php artisan test tests/Unit/Factories/OnboardingFormTemplateFactoryTest.php tests/Unit/Models/OnboardingFormSubmissionTest.php`
- `vendor/bin/pint --dirty`

Closes #329