### PR TITLE
fix: remove dead site cost center path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- removed the dead `SiteController::costCenters()` fallback and its stale TODO now that `GET /v1/sites/{site}/cost-centers` is served by the dedicated `CostCenterController` with `CostCenterResource`, so the API no longer carries an unused manual-pagination implementation beside the real endpoint path
 - precomputed customer/site update visibility for `/v1/me/customer-assignments` and `/v1/me/site-assignments` so nested `Api/V1` customer/site resources stop triggering per-record policy queries during collection serialization, with regression coverage that keeps the assignment response query count bounded
 - enabled Laravel email verification on the `User` model, added signed verify/resend endpoints, enforced `verified` middleware on protected non-onboarding application routes, and now send a verification notification when onboarding completes so unverified accounts cannot immediately use the authenticated app surface
 - aligned the nested Api/V1 customer and site assignment payloads with the OpenAPI contract so `/v1/me/customer-assignments` and `/v1/me/site-assignments` now return the documented customer/site fields instead of truncated nested resource objects; standardized all Api/V1 resource timestamps to `toIso8601String()` for a consistent date-time format across the layer

--- a/app/Http/Controllers/Api/V1/SiteController.php
+++ b/app/Http/Controllers/Api/V1/SiteController.php
@@ -12,7 +12,6 @@ use App\Http\Requests\Api\V1\UpdateSiteRequest;
 use App\Http\Resources\SiteResource;
 use App\Models\Site;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 
 /**
@@ -204,47 +203,5 @@ class SiteController extends Controller
         $site->delete();
 
         return response()->json(null, Response::HTTP_NO_CONTENT);
-    }
-
-    /**
-     * List cost centers for a site.
-     *
-     * GET /api/v1/sites/{site}/cost-centers
-     *
-     * Returns paginated list of cost centers belonging to the site.
-     * User must have view access to the site.
-     *
-     * @return JsonResponse Paginated cost center list (temporary manual pagination until CostCenterResource is created)
-     *
-     * @codeCoverageIgnore CostCenterResource will be created in a later issue
-     */
-    public function costCenters(Request $request, Site $site): JsonResponse
-    {
-        $this->authorize('view', $site);
-
-        $perPage = $request->integer('per_page', 15);
-        $costCenters = $site->costCenters()
-            ->with(['site'])
-            ->paginate($perPage);
-
-        // TODO: Replace with CostCenterResource::collection($costCenters) when available
-        return response()->json([
-            'data' => $costCenters->items(),
-            'links' => [
-                'first' => $costCenters->url(1),
-                'last' => $costCenters->url($costCenters->lastPage()),
-                'prev' => $costCenters->previousPageUrl(),
-                'next' => $costCenters->nextPageUrl(),
-            ],
-            'meta' => [
-                'current_page' => $costCenters->currentPage(),
-                'from' => $costCenters->firstItem(),
-                'last_page' => $costCenters->lastPage(),
-                'path' => $costCenters->path(),
-                'per_page' => $costCenters->perPage(),
-                'to' => $costCenters->lastItem(),
-                'total' => $costCenters->total(),
-            ],
-        ]);
     }
 }

--- a/tests/Feature/Controllers/Api/V1/SiteControllerTest.php
+++ b/tests/Feature/Controllers/Api/V1/SiteControllerTest.php
@@ -1037,5 +1037,3 @@ describe('DELETE /v1/sites/{site}', function () {
         $response->assertStatus(404);
     });
 });
-
-// Note: Cost-centers endpoint tests will be implemented when CostCenter CRUD endpoints are created in a later issue


### PR DESCRIPTION
## Summary
- remove the unused `SiteController::costCenters()` fallback that still carried the stale manual-pagination TODO
- drop the now-misleading Site controller test note that claimed cost-center endpoint coverage did not exist yet
- keep the real `/v1/sites/{site}/cost-centers` path exclusively on `CostCenterController` with `CostCenterResource`

## Validation
- `php artisan test tests/Feature/Controllers/Api/V1/SiteControllerTest.php tests/Feature/Controllers/Api/V1/CostCenterControllerTest.php`
- `vendor/bin/pint --dirty`
- `vendor/bin/phpstan analyse app/Http/Controllers/Api/V1/SiteController.php tests/Feature/Controllers/Api/V1/SiteControllerTest.php --memory-limit=1G`
- `reuse lint`

## Follow-up Context
- the only remaining production `TODO` marker is in `MonitorOpenTimestamp`, and its broader operational work is already tracked separately in #681

Closes #460