### PR TITLE
Expose email verification state in auth payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- exposed `emailVerified` consistently in auth payloads, taught the seeded local Test User to remain verified on repeat seed runs, and unblocked the frontend from handling unverified accounts with a dedicated gate instead of surfacing raw route-level verification errors deep inside the app
 - added explicit `/v1/employees/{employee}/leave` and `/v1/employees/{employee}/return-from-leave` transitions that snapshot the employee's prior runtime role/direct-permission state, reduce on-leave access to a seeded read-only baseline, and restore the prior access model atomically when the employee returns; termination now also clears direct permissions so runtime access is fully revoked
 - encrypted employee phone storage at rest by moving the field to `phone_enc` plus tenant-scoped `phone_idx`, backfilling existing rows in a migration, and keeping the public API field name `phone` unchanged while documenting why employee and user email still remain plaintext for auth-critical lookups
 - moved employee activation and termination side effects into an explicit lifecycle service used by the employee controller and scheduled status-update command, so status changes now run inside a single transaction for role assignment or access revocation instead of relying on hidden observer-driven account mutations

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -744,6 +744,7 @@ class AuthController extends Controller
      * - hasOrganizationalScopes: Whether user has any organizational scope assignments
      * - hasCustomerAccess: Whether user can access the customer collection globally or via scoped access
      * - hasSiteAccess: Whether user can access the site collection globally or via scoped access
+     * - emailVerified: Whether the user's email address has been verified
      *
      * The hasOrganizationalScopes flag is used by the frontend to determine
      * whether to show organization/customer management navigation items.
@@ -751,7 +752,7 @@ class AuthController extends Controller
      * Note: Admin users have maximum organizational scopes (0-255) granting
      * access to all leadership levels and non-leadership employees.
      *
-     * @return array{id: string, name: string, email: string, roles: list<string>, permissions: list<string>, hasOrganizationalScopes: bool, hasCustomerAccess: bool, hasSiteAccess: bool}
+     * @return array{id: string, name: string, email: string, emailVerified: bool, roles: list<string>, permissions: list<string>, hasOrganizationalScopes: bool, hasCustomerAccess: bool, hasSiteAccess: bool}
      */
     private function buildUserAuthorizationData(User $user): array
     {
@@ -771,6 +772,7 @@ class AuthController extends Controller
             'id' => $user->id,
             'name' => $user->name,
             'email' => $user->email,
+            'emailVerified' => $user->hasVerifiedEmail(),
             'roles' => $roles,
             'permissions' => $permissions,
             'hasOrganizationalScopes' => $user->organizationalScopes->isNotEmpty(),
@@ -853,7 +855,7 @@ class AuthController extends Controller
     /**
      * Build the final successful login payload returned after MFA challenge verification.
      *
-     * @return array{user: array{id: string, name: string, email: string, roles: list<string>, permissions: list<string>, hasOrganizationalScopes: bool, hasCustomerAccess: bool, hasSiteAccess: bool}, authentication: array{mode: string, mfa_completed: bool}, token?: string}
+     * @return array{user: array{id: string, name: string, email: string, emailVerified: bool, roles: list<string>, permissions: list<string>, hasOrganizationalScopes: bool, hasCustomerAccess: bool, hasSiteAccess: bool}, authentication: array{mode: string, mfa_completed: bool}, token?: string}
      */
     private function buildCompletedLoginResponse(User $user, string $mode, ?string $token = null): array
     {

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -42,9 +42,16 @@ class DatabaseSeeder extends Seeder
             [
                 'name' => 'Test User',
                 'password' => bcrypt('password'),
+                'email_verified_at' => now(),
                 'tenant_id' => $tenantId,
             ]
         );
+
+        if (! $testUser->hasVerifiedEmail()) {
+            $testUser->forceFill([
+                'email_verified_at' => now(),
+            ])->save();
+        }
 
         // Assign Admin role to test user (within tenant context)
         if (! $testUser->hasRole('Admin')) {

--- a/tests/Feature/AuthTest.php
+++ b/tests/Feature/AuthTest.php
@@ -88,6 +88,7 @@ describe('SPA Session Login', function () {
                     'id',
                     'name',
                     'email',
+                    'emailVerified',
                     'roles',
                     'permissions',
                     'hasOrganizationalScopes',
@@ -99,6 +100,7 @@ describe('SPA Session Login', function () {
                 'user' => [
                     'name' => 'SPA User',
                     'email' => 'spa@secpal.dev',
+                    'emailVerified' => true,
                 ],
             ]);
     });
@@ -274,10 +276,11 @@ describe('Auth Token Generation', function () {
         $response->assertCreated()
             ->assertJsonStructure([
                 'token',
-                'user' => ['id', 'name', 'email', 'roles', 'permissions', 'hasOrganizationalScopes', 'hasCustomerAccess', 'hasSiteAccess'],
+                'user' => ['id', 'name', 'email', 'emailVerified', 'roles', 'permissions', 'hasOrganizationalScopes', 'hasCustomerAccess', 'hasSiteAccess'],
             ]);
 
         expect($response->json('user.email'))->toBe($email);
+        expect($response->json('user.emailVerified'))->toBeTrue();
         expect($user->tokens()->count())->toBe(1);
         expect($user->tokens()->first()?->can(User::API_ACCESS_ABILITY))->toBeTrue();
     });
@@ -730,6 +733,34 @@ describe('Token Security', function () {
 });
 
 describe('Email Verification', function () {
+    test('auth payloads expose the email verification state for unverified browser sessions', function () {
+        User::factory()->unverified()->create([
+            'email' => 'unverified-spa@secpal.dev',
+            'password' => bcrypt('password123'),
+        ]);
+
+        $this->withHeaders(spaHeaders([
+            'X-XSRF-TOKEN' => issueSpaCsrfToken($this),
+        ]))->postJson('/v1/auth/login', [
+            'email' => 'unverified-spa@secpal.dev',
+            'password' => 'password123',
+        ])->assertOk()
+            ->assertJson([
+                'user' => [
+                    'email' => 'unverified-spa@secpal.dev',
+                    'emailVerified' => false,
+                ],
+            ]);
+
+        $this->withHeaders(spaHeaders())
+            ->getJson('/v1/me')
+            ->assertOk()
+            ->assertJson([
+                'email' => 'unverified-spa@secpal.dev',
+                'emailVerified' => false,
+            ]);
+    });
+
     test('unverified users can request a fresh verification email', function () {
         Notification::fake();
 


### PR DESCRIPTION
## Summary
- expose `emailVerified` in auth payloads used by login and `/v1/me`
- keep the seeded local test user verified on repeat seed runs
- add focused auth coverage for verified and unverified payload handling

## Validation
- `vendor/bin/pint --dirty`
- `php artisan test tests/Feature/AuthTest.php`

## Review
- Local 4-pass self-review completed: correctness, domain/policy, best practices, security
