### PR TITLE
docs: clarify clean-main and post-merge readiness guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,7 +10,11 @@ Do not assume instructions from sibling repositories or comment-based inheritanc
 
 ## Always-On Rules
 
-- Run `git status --short --branch` before any write action. Never start implementation on local `main`, and stop if a dirty non-`main` branch contains unrelated work.
+- Run `git status --short --branch` before any write action. New work must start
+  from a clean, up-to-date local `main`: switch to `main`, pull with
+  fast-forward only, verify a clean state, then create the dedicated topic
+  branch. Never start implementation on local `main`, and stop if a dirty
+  non-`main` branch contains unrelated work.
 - TDD is mandatory for behavior and code changes. Write or update the smallest relevant failing Pest test FIRST, then implement, then refactor with tests green.
 - Quality first. Do not trade correctness, review depth, validation depth, or issue tracking for speed.
 - Keep one topic per change. 1 topic = 1 PR = 1 branch. Do not mix unrelated fixes, features, refactors, docs, or governance cleanup.
@@ -23,6 +27,11 @@ Do not assume instructions from sibling repositories or comment-based inheritanc
 - Never reply to Copilot review comments with GitHub comment tools. Fix the code, push, and resolve threads through the approved non-comment workflow.
 - Keep `SPDX-FileCopyrightText` years current in edited files or companion `.license` sidecars.
 - Domain policy is strict: `secpal.app` for the public homepage and real email addresses, `api.secpal.dev` for the API, `app.secpal.dev` for the PWA/frontend, `secpal.dev` for dev, staging, testing, and examples, and `app.secpal` only as the Android application identifier.
+- After every merge, immediately return the local repo to a ready state:
+  switch to `main`, pull with fast-forward only, delete the merged topic
+  branch, prune remotes, refresh Composer dependencies where applicable, run
+  the smallest relevant API readiness command, and confirm the working tree is
+  clean.
 
 ## Design Principles
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added the phase-1 MFA API endpoints for login challenges, TOTP enrollment confirmation, `/me/mfa` status, recovery-code regeneration, and authenticated MFA disablement so the frontend can build against real SecPal API behavior instead of only the contract
 - security audit document (`SECURITY_AUDIT_API_VALIDATION.md`) covering API validation, error handling, and request semantics with 3 HIGH, 6 MEDIUM, 5 LOW findings and 3 best-practice recommendations; includes prioritized fix order and negative test ideas
 
+### Changed
+
+- clarified the repo-local branch-start and post-merge readiness workflow so new API work must start from a clean, updated local `main`, and post-merge cleanup now explicitly returns the repo to `main`, refreshes dependencies where applicable, runs a suitable readiness command, and confirms a clean working tree
+
 ### Fixed
 
 - restored explicit repo-local Copilot governance by making TDD-first, quality-first, one-topic-per-PR, immediate issue creation for out-of-scope findings, and EPIC-plus-sub-issue requirements always-on again; the API runtime overlay now auto-loads repo-wide so these rules remain present while working


### PR DESCRIPTION
## Summary
- clarify the repo-local clean-main branch-start rule
- clarify the repo-local post-merge readiness cleanup workflow
- document the clarification in the changelog

## Validation
- git diff --check
- reuse lint

Refs SecPal/.github#315
