### PR TITLE
fix: strip null values and empty arrays from passkey registration options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- fixed passkey registration options sending `authenticator_attachment: null` and `rp.icon: null` from the webauthn-lib serializer; browsers coerce JSON null to the DOMString `"null"` which is not a valid `AuthenticatorAttachment` enum value, preventing `navigator.credentials.create()` from showing the WebAuthn dialog; the API now strips null values from `authenticator_selection` and `rp`, and omits empty `exclude_credentials` arrays
 - fixed passkey registration and login verification failing with "Undefined array key clientDataJSON" because `Str::camel('client_data_json')` produces `clientDataJson` (lowercase json) while the webauthn-lib denormalizer expects `clientDataJSON` (uppercase JSON); added an explicit override map in `PasskeyService::keysToCamelCase()` with targeted unit tests
 - fixed passkey login challenge returning an empty `allow_credentials` array that caused browsers to reject the WebAuthn discoverable-credential flow with "Resident credentials or empty `allowCredentials` lists are not supported"; the API now omits the field when empty so browsers correctly trigger the resident-key prompt
 - improved TOTP anti-replay UX: recovery-code regeneration and MFA disablement now return a specific "code was already used recently" validation message instead of a generic "invalid code" when the submitted TOTP code was consumed by a recent action in the same time window

--- a/app/Services/PasskeyService.php
+++ b/app/Services/PasskeyService.php
@@ -295,12 +295,29 @@ class PasskeyService
 
         if (isset($formatted['authenticator_selection']) && is_array($formatted['authenticator_selection'])) {
             $formatted['authenticator_selection']['require_resident_key'] = $this->requireResidentKey();
+
+            // Strip null authenticator_attachment so browsers don't receive the
+            // invalid enum value "null" from JSON null → DOMString coercion.
+            if (array_key_exists('authenticator_attachment', $formatted['authenticator_selection'])
+                && $formatted['authenticator_selection']['authenticator_attachment'] === null) {
+                unset($formatted['authenticator_selection']['authenticator_attachment']);
+            }
         }
 
-        // Omit empty allow_credentials so browsers use the discoverable credential flow
-        // instead of rejecting an empty array as unsupported.
+        // Strip the deprecated icon field that webauthn-lib serializes as null.
+        if (isset($formatted['rp']) && is_array($formatted['rp'])
+            && array_key_exists('icon', $formatted['rp']) && $formatted['rp']['icon'] === null) {
+            unset($formatted['rp']['icon']);
+        }
+
+        // Omit empty credential lists so browsers don't choke on zero-length
+        // arrays where the field should be absent per the WebAuthn spec intent.
         if (array_key_exists('allow_credentials', $formatted) && $formatted['allow_credentials'] === []) {
             unset($formatted['allow_credentials']);
+        }
+
+        if (array_key_exists('exclude_credentials', $formatted) && $formatted['exclude_credentials'] === []) {
+            unset($formatted['exclude_credentials']);
         }
 
         return $formatted;

--- a/tests/Feature/Auth/PasskeyAuthTest.php
+++ b/tests/Feature/Auth/PasskeyAuthTest.php
@@ -297,7 +297,6 @@ describe('Passkey Management', function () {
                         'user' => ['id', 'name', 'display_name'],
                         'pub_key_cred_params',
                         'timeout',
-                        'exclude_credentials',
                         'authenticator_selection',
                         'attestation',
                     ],
@@ -306,7 +305,10 @@ describe('Passkey Management', function () {
             ]);
 
         expect($response->json('data.public_key.rp.id'))->toBe('app.secpal.dev')
-            ->and($response->json('data.public_key.attestation'))->toBe('none');
+            ->and($response->json('data.public_key.attestation'))->toBe('none')
+            ->and($response->json('data.public_key'))->not->toHaveKey('exclude_credentials', 'empty exclude_credentials must be omitted')
+            ->and($response->json('data.public_key.authenticator_selection'))->not->toHaveKey('authenticator_attachment', 'null authenticator_attachment must be omitted')
+            ->and($response->json('data.public_key.rp'))->not->toHaveKey('icon', 'null rp.icon must be omitted');
     });
 
     test('authenticated users are rate limited when starting passkey registration challenges', function () {

--- a/tests/Unit/Services/PasskeyServiceTest.php
+++ b/tests/Unit/Services/PasskeyServiceTest.php
@@ -15,6 +15,7 @@ describe('PasskeyService::formatApiPayload', function () {
             'challenge' => 'dGVzdC1jaGFsbGVuZ2U',
             'rp' => [
                 'id' => 'app.secpal.dev',
+                'icon' => null,
                 'name' => 'SecPal',
             ],
             'user' => [
@@ -27,6 +28,7 @@ describe('PasskeyService::formatApiPayload', function () {
                 ['type' => 'public-key', 'alg' => -257],
             ],
             'authenticatorSelection' => [
+                'authenticatorAttachment' => null,
                 'residentKey' => 'preferred',
                 'userVerification' => 'preferred',
             ],
@@ -42,8 +44,9 @@ describe('PasskeyService::formatApiPayload', function () {
             ->and($formatted['user'])->toHaveKey('display_name')
             ->and($formatted['authenticator_selection'])->toHaveKey('resident_key')
             ->and($formatted['authenticator_selection'])->toHaveKey('user_verification')
-            ->and($formatted)->toHaveKey('exclude_credentials')
-            ->and($formatted['exclude_credentials'])->toBe([]);
+            ->and($formatted['authenticator_selection'])->not->toHaveKey('authenticator_attachment', 'null authenticator_attachment must be stripped')
+            ->and($formatted['rp'])->not->toHaveKey('icon', 'null rp.icon must be stripped')
+            ->and($formatted)->not->toHaveKey('exclude_credentials', 'empty excludeCredentials must be omitted');
     });
 
     test('authentication options omit allow_credentials when empty for discoverable credential flow', function () {


### PR DESCRIPTION
## Problem

The webauthn-lib v5 serializer produces `authenticatorAttachment: null` and `rp.icon: null` in the normalized PHP arrays returned by `buildRegistrationOptions()`. When the API sends these values to the browser, JSON `null` is coerced to the DOMString `"null"`, which is **not** a valid `AuthenticatorAttachment` enum value. This prevents `navigator.credentials.create()` from showing the WebAuthn dialog, causing passkey enrollment to hang indefinitely on "Adding passkey...".

Additionally, `exclude_credentials: []` was sent as an empty array instead of being omitted, which some browsers may reject.

## Fix

- Strip null `authenticator_attachment` from `authenticator_selection` in `formatApiPayload()`
- Strip null `icon` from `rp` (deprecated Level 1 property)
- Omit empty `exclude_credentials` arrays (matching existing `allow_credentials` behavior)

## Testing

- Updated unit test to include null `authenticatorAttachment` and null `icon` in input and assert they are stripped
- Updated feature test to assert `exclude_credentials`, `authenticator_attachment`, and `rp.icon` are absent from the registration challenge response
- All 23 passkey tests and 27 MFA tests pass
- Pint + PHPStan clean

## Companion PR

Frontend companion: SecPal/frontend — branch `fix/passkey-webauthn-options-cleanup` (defense-in-depth on the browser side)
