### PR TITLE
chore: add changelog.secpal.app to domain policy and check-domains allowlist

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -26,7 +26,7 @@ Do not assume instructions from sibling repositories or comment-based inheritanc
 - Treat warnings, audit findings, and deprecations as actionable. Fix them in scope or track them immediately.
 - Never reply to Copilot review comments with GitHub comment tools. Fix the code, push, and resolve threads through the approved non-comment workflow.
 - Keep `SPDX-FileCopyrightText` years current in edited files or companion `.license` sidecars.
-- Domain policy is strict: `secpal.app` for the public homepage and real email addresses, `apk.secpal.app` for the canonical Android artifact and release-metadata host, `api.secpal.dev` for the API, `app.secpal.dev` for the PWA/frontend, `secpal.dev` for dev, staging, testing, and examples, and `app.secpal` only as the Android application identifier.
+- Domain policy is strict: `secpal.app` for the public homepage and real email addresses, `changelog.secpal.app` for the public changelog site, `apk.secpal.app` for the canonical Android artifact and release-metadata host, `api.secpal.dev` for the API, `app.secpal.dev` for the PWA/frontend, `secpal.dev` for dev, staging, testing, and examples, and `app.secpal` only as the Android application identifier.
 - After every merge, immediately return the local repo to a ready state:
   switch to `main`, pull with fast-forward only, delete the merged topic
   branch, prune remotes, refresh Composer dependencies where applicable, run

--- a/scripts/check-domains.sh
+++ b/scripts/check-domains.sh
@@ -53,7 +53,7 @@ matches=$(grep -r -n -E "secpal\.[A-Za-z0-9.-]+" \
 # api.secpal.app (reported separately below).
 # This catches unknown domains (e.g. secpal.xyz) that a denylist-only check would miss.
 violations=$(printf '%s\n' "$matches" | \
-    grep -Ev '(^|[^A-Za-z0-9.-])secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])changelog\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])apk\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])(\*\.|\.)?([ A-Za-z0-9-]+\.)*secpal\.dev(\.[ A-Za-z0-9_-]+)*($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])api\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)' | \
+    grep -Ev '(^|[^A-Za-z0-9.-])secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])changelog\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])apk\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])(\*\.|\.)?([A-Za-z0-9-]+\.)*secpal\.dev(\.[A-Za-z0-9_-]+)*($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])api\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)' | \
     grep -v -- '.evil.example' | \
     grep -E 'secpal\.' || true)
 

--- a/scripts/check-domains.sh
+++ b/scripts/check-domains.sh
@@ -16,9 +16,10 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 echo -e "${BLUE}=== Domain Policy Check ===${NC}"
-echo "Allowed: secpal.app, apk.secpal.app, secpal.dev"
+echo "Allowed: secpal.app, changelog.secpal.app, apk.secpal.app, secpal.dev"
 echo "Active web hosts: api.secpal.dev, app.secpal.dev"
 echo "Android artifact host: apk.secpal.app"
+echo "Changelog site: changelog.secpal.app"
 echo "Identifier-only: app.secpal (Android application ID)"
 echo "Deprecated web hosts: api.secpal.app"
 echo "Forbidden: secpal.com, secpal.org, secpal.net, secpal.io, secpal.example, ANY other"
@@ -52,7 +53,7 @@ matches=$(grep -r -n -E "secpal\.[A-Za-z0-9.-]+" \
 # api.secpal.app (reported separately below).
 # This catches unknown domains (e.g. secpal.xyz) that a denylist-only check would miss.
 violations=$(printf '%s\n' "$matches" | \
-    grep -Ev '(^|[^A-Za-z0-9.-])secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])apk\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])(\*\.|\.)?([A-Za-z0-9-]+\.)*secpal\.dev(\.[A-Za-z0-9_-]+)*($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])api\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)' | \
+    grep -Ev '(^|[^A-Za-z0-9.-])secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])changelog\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])apk\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])(\*\.|\.)?([ A-Za-z0-9-]+\.)*secpal\.dev(\.[ A-Za-z0-9_-]+)*($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])api\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)' | \
     grep -v -- '.evil.example' | \
     grep -E 'secpal\.' || true)
 
@@ -103,6 +104,7 @@ else
     fi
     echo -e "${YELLOW}Policy:${NC}"
     echo "  - secpal.app: public homepage and real email addresses"
+    echo "  - changelog.secpal.app: public changelog site"
     echo "  - apk.secpal.app: canonical Android artifact and release-metadata host"
     echo "  - api.secpal.dev: live API host"
     echo "  - app.secpal.dev: live PWA/frontend host"


### PR DESCRIPTION
Add `changelog.secpal.app` (public changelog site) to the domain policy line in `.github/copilot-instructions.md` and to the `scripts/check-domains.sh` allowlist.

## Why

`changelog.secpal.app` is the new live public changelog (EPIC SecPal/.github#334). Without explicit allowlisting, the domain check flags any reference as an unknown domain violation (particularly on lines that do not also include bare `secpal.app`).

## Changes

- `.github/copilot-instructions.md`: one-line domain policy update
- `scripts/check-domains.sh`: allowlist regex, echo description, and policy summary

## Validation

`bash scripts/check-domains.sh` → ✅ Domain Policy Check PASSED

## Checklist

- [x] Single topic
- [x] No tests required (script / policy change only)
- [x] Shellcheck passes
- [x] check-domains.sh passes
- [x] CHANGELOG not required (governance-only change)
- [x] GPG-signed commits
- [x] REUSE not affected
- [x] 4-pass review: clean
- [x] No bypass

Closes SecPal/changelog#11 (partial — api scope)