### PR TITLE
feat: delete expired employee records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- added the `employees:delete-expired` retention command for BewachV §21 / GDPR employee erasure, including tenant-scoped dry-run support, hard deletion of expired terminated employee records, local storage cleanup for employee and onboarding uploads, linked-user anonymization, and a daily scheduler hook after activity retention processing
 - Added the initial Android enrollment API slice for Epic SecPal/.github#327, including tenant-bound enrollment session storage, private QR/bootstrap token issuance, admin create/list/read/revoke endpoints, a public bootstrap exchange endpoint, and audited provisioning lifecycle events
 - added `PATCH /v1/onboarding/submissions/{submission}` so authenticated pre-contract employees can update their own draft or rejected onboarding submissions by id without resending `form_template_id`; omitting `status` on a rejected submission now defaults to draft; state-specific 409 messages are returned for submitted and approved submissions; and a pre-contract employee guard is enforced for consistency with the existing upsert path
 - added the phase-2 passkey backend foundation with WebAuthn-backed browser sign-in and self-service passkey management endpoints, persisted passkey credentials plus challenge state, and regression coverage for session establishment, validation failures, and throttled invalid passkey verification attempts

--- a/app/Console/Commands/DeleteExpiredEmployees.php
+++ b/app/Console/Commands/DeleteExpiredEmployees.php
@@ -1,0 +1,60 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace App\Console\Commands;
+
+use App\Services\ExpiredEmployeeDeletionService;
+use Illuminate\Console\Command;
+
+class DeleteExpiredEmployees extends Command
+{
+    protected $signature = 'employees:delete-expired
+        {--tenant= : Only process a single tenant ID}
+        {--dry-run : Report matching employees without deleting them}';
+
+    protected $description = 'Delete terminated employee records whose legal retention period has expired';
+
+    public function __construct(private readonly ExpiredEmployeeDeletionService $expiredEmployeeDeletionService)
+    {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $tenantOption = $this->option('tenant');
+        $tenantId = null;
+
+        if (($tenantOption !== null) && ($tenantOption !== '')) {
+            $tenantValue = (string) $tenantOption;
+
+            if (! ctype_digit($tenantValue)) {
+                $this->error('The --tenant option must be a numeric tenant ID.');
+
+                return self::FAILURE;
+            }
+
+            $tenantId = (int) $tenantValue;
+        }
+
+        $dryRun = (bool) $this->option('dry-run');
+        $stats = $this->expiredEmployeeDeletionService->deleteExpiredEmployees($tenantId, $dryRun);
+
+        if ($tenantId !== null) {
+            $this->line('Tenant scope: '.$tenantId);
+        }
+
+        if ($dryRun) {
+            $this->info('Would delete '.$stats['matched'].' expired employee record(s)');
+
+            return self::SUCCESS;
+        }
+
+        $this->info('Deleted '.$stats['deleted'].' expired employee record(s)');
+        $this->line('Linked user(s) anonymized: '.$stats['users_anonymized']);
+        $this->line('Local file(s) deleted: '.$stats['files_deleted']);
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Models/Employee.php
+++ b/app/Models/Employee.php
@@ -68,6 +68,8 @@ use Spatie\Activitylog\Support\LogOptions;
  * @property string $status applicant|pre_contract|active|on_leave|terminated
  * @property ?\Illuminate\Support\Carbon $hire_date
  * @property ?\Illuminate\Support\Carbon $contract_start_date
+ * @property ?\Illuminate\Support\Carbon $employment_end_date
+ * @property ?\Illuminate\Support\Carbon $retention_period_end
  * @property ?\Illuminate\Support\Carbon $termination_date
  * @property ?\Illuminate\Support\Carbon $last_working_day
  * @property string $contract_type full_time|part_time|minijob|freelance

--- a/app/Services/ExpiredEmployeeDeletionService.php
+++ b/app/Services/ExpiredEmployeeDeletionService.php
@@ -6,6 +6,9 @@
 namespace App\Services;
 
 use App\Models\Employee;
+use App\Models\EmployeeDocument;
+use App\Models\OnboardingFormSubmission;
+use App\Models\OnboardingSubmissionFile;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Carbon;
@@ -72,13 +75,7 @@ class ExpiredEmployeeDeletionService
             /** @var Employee|null $employee */
             $employee = Employee::query()
                 ->withTrashed()
-                ->with([
-                    'documents' => fn ($query) => $query->withTrashed(),
-                    'onboardingSubmissions' => fn ($query) => $query->withTrashed()->with([
-                        'files' => fn ($fileQuery) => $fileQuery->withTrashed(),
-                    ]),
-                    'user.passkeyCredentials',
-                ])
+                ->with('user.passkeyCredentials')
                 ->where('tenant_id', $tenantId)
                 ->whereKey($employeeId)
                 ->lockForUpdate()
@@ -145,19 +142,26 @@ class ExpiredEmployeeDeletionService
             $paths[] = $employee->id_document_copy_path;
         }
 
-        foreach ($employee->documents as $document) {
-            if (is_string($document->file_path) && $document->file_path !== '') {
-                $paths[] = $document->file_path;
-            }
-        }
+        $documentPaths = EmployeeDocument::query()
+            ->withTrashed()
+            ->where('employee_id', $employee->id)
+            ->pluck('file_path')
+            ->filter(fn (mixed $path): bool => is_string($path) && $path !== '')
+            ->all();
 
-        foreach ($employee->onboardingSubmissions as $submission) {
-            foreach ($submission->files as $file) {
-                if (is_string($file->file_path) && $file->file_path !== '') {
-                    $paths[] = $file->file_path;
-                }
-            }
-        }
+        $submissionIds = OnboardingFormSubmission::query()
+            ->withTrashed()
+            ->where('employee_id', $employee->id)
+            ->pluck('id');
+
+        $submissionFilePaths = OnboardingSubmissionFile::query()
+            ->withTrashed()
+            ->whereIn('onboarding_form_submission_id', $submissionIds)
+            ->pluck('file_path')
+            ->filter(fn (mixed $path): bool => is_string($path) && $path !== '')
+            ->all();
+
+        $paths = [...$paths, ...$documentPaths, ...$submissionFilePaths];
 
         return array_values(array_unique($paths));
     }

--- a/app/Services/ExpiredEmployeeDeletionService.php
+++ b/app/Services/ExpiredEmployeeDeletionService.php
@@ -1,0 +1,237 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace App\Services;
+
+use App\Models\Employee;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+
+class ExpiredEmployeeDeletionService
+{
+    /**
+     * @return array{matched: int, deleted: int, users_anonymized: int, files_deleted: int}
+     */
+    public function deleteExpiredEmployees(?int $tenantId = null, bool $dryRun = false): array
+    {
+        $query = $this->expiredEmployeesQuery($tenantId);
+
+        $stats = [
+            'matched' => (clone $query)->count(),
+            'deleted' => 0,
+            'users_anonymized' => 0,
+            'files_deleted' => 0,
+        ];
+
+        if ($dryRun || $stats['matched'] === 0) {
+            return $stats;
+        }
+
+        $query
+            ->orderBy('id')
+            ->chunkById(50, function ($employees) use (&$stats): void {
+                foreach ($employees as $employee) {
+                    $result = $this->deleteExpiredEmployee($employee->id, $employee->tenant_id);
+
+                    $stats['deleted'] += $result['deleted'];
+                    $stats['users_anonymized'] += $result['users_anonymized'];
+                    $stats['files_deleted'] += $this->deleteStoredPaths($result['file_paths']);
+                }
+            }, 'id');
+
+        return $stats;
+    }
+
+    /**
+     * @return Builder<Employee>
+     */
+    public function expiredEmployeesQuery(?int $tenantId = null): Builder
+    {
+        return Employee::query()
+            ->withTrashed()
+            ->where('status', Employee::STATUS_TERMINATED)
+            ->whereNotNull('retention_period_end')
+            ->whereDate('retention_period_end', '<', Carbon::today()->toDateString())
+            ->when($tenantId !== null, fn (Builder $query) => $query->where('tenant_id', $tenantId));
+    }
+
+    /**
+     * @return array{deleted: int, users_anonymized: int, file_paths: list<string>}
+     */
+    private function deleteExpiredEmployee(string $employeeId, int $tenantId): array
+    {
+        return DB::transaction(function () use ($employeeId, $tenantId): array {
+            /** @var Employee|null $employee */
+            $employee = Employee::query()
+                ->withTrashed()
+                ->with([
+                    'documents' => fn ($query) => $query->withTrashed(),
+                    'onboardingSubmissions' => fn ($query) => $query->withTrashed()->with([
+                        'files' => fn ($fileQuery) => $fileQuery->withTrashed(),
+                    ]),
+                    'user.passkeyCredentials',
+                ])
+                ->where('tenant_id', $tenantId)
+                ->whereKey($employeeId)
+                ->lockForUpdate()
+                ->first();
+
+            if (! $employee instanceof Employee || ! $this->isEligibleForDeletion($employee)) {
+                return [
+                    'deleted' => 0,
+                    'users_anonymized' => 0,
+                    'file_paths' => [],
+                ];
+            }
+
+            $filePaths = $this->collectStoredPaths($employee);
+            $usersAnonymized = 0;
+
+            if ($employee->user instanceof User) {
+                $this->anonymizeLinkedUser($employee->user);
+                $employee->user()->dissociate();
+                $employee->saveQuietly();
+                $usersAnonymized = 1;
+            }
+
+            activity('employee_changes')
+                ->performedOn($employee)
+                ->withProperties([
+                    'action' => 'employee_retention_delete',
+                    'employee_id' => $employee->id,
+                    'employee_number' => $employee->employee_number,
+                    'tenant_id' => $employee->tenant_id,
+                    'employment_end_date' => $employee->employment_end_date?->toDateString(),
+                    'retention_period_end' => $employee->retention_period_end?->toDateString(),
+                    'legal_basis' => 'BewachV § 21 Abs. 4 / GDPR Art. 17',
+                    'deleted_file_count' => count($filePaths),
+                    'linked_user_anonymized' => $usersAnonymized === 1,
+                ])
+                ->log('Employee data deleted after retention period');
+
+            $employee->forceDelete();
+
+            return [
+                'deleted' => 1,
+                'users_anonymized' => $usersAnonymized,
+                'file_paths' => $filePaths,
+            ];
+        });
+    }
+
+    private function isEligibleForDeletion(Employee $employee): bool
+    {
+        return $employee->status === Employee::STATUS_TERMINATED
+            && $employee->retention_period_end !== null
+            && $employee->retention_period_end->isBefore(Carbon::today());
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function collectStoredPaths(Employee $employee): array
+    {
+        $paths = [];
+
+        if (is_string($employee->id_document_copy_path) && $employee->id_document_copy_path !== '') {
+            $paths[] = $employee->id_document_copy_path;
+        }
+
+        foreach ($employee->documents as $document) {
+            if (is_string($document->file_path) && $document->file_path !== '') {
+                $paths[] = $document->file_path;
+            }
+        }
+
+        foreach ($employee->onboardingSubmissions as $submission) {
+            foreach ($submission->files as $file) {
+                if (is_string($file->file_path) && $file->file_path !== '') {
+                    $paths[] = $file->file_path;
+                }
+            }
+        }
+
+        return array_values(array_unique($paths));
+    }
+
+    /**
+     * @param  list<string>  $paths
+     */
+    private function deleteStoredPaths(array $paths): int
+    {
+        $storage = Storage::disk('local');
+        $deletedFiles = 0;
+
+        foreach ($paths as $path) {
+            if (! $storage->exists($path)) {
+                continue;
+            }
+
+            if ($storage->delete($path)) {
+                $deletedFiles++;
+
+                continue;
+            }
+
+            Log::warning('Failed to delete expired employee retention file from local storage', [
+                'file_path' => $path,
+            ]);
+        }
+
+        return $deletedFiles;
+    }
+
+    private function anonymizeLinkedUser(User $user): void
+    {
+        DB::table('model_has_roles')
+            ->where('model_type', User::class)
+            ->where('model_id', $user->id)
+            ->delete();
+
+        DB::table('model_has_permissions')
+            ->where('model_type', User::class)
+            ->where('model_id', $user->id)
+            ->delete();
+
+        DB::table('user_internal_organizational_scopes')
+            ->where('user_id', $user->id)
+            ->delete();
+
+        DB::table('customer_assignments')
+            ->where('user_id', $user->id)
+            ->delete();
+
+        DB::table('site_assignments')
+            ->where('user_id', $user->id)
+            ->delete();
+
+        DB::table('sessions')
+            ->where('user_id', $user->id)
+            ->delete();
+
+        DB::table('two_factor_authentications')
+            ->where('authenticatable_type', User::class)
+            ->where('authenticatable_id', $user->id)
+            ->delete();
+
+        $user->tokens()->delete();
+        $user->passkeyCredentials()->delete();
+
+        $user->forceFill([
+            'name' => 'Deleted User',
+            'email' => 'deleted-user+'.$user->id.'@secpal.dev',
+            'email_verified_at' => null,
+            'password' => Hash::make(Str::random(64)),
+            'remember_token' => null,
+            'preferred_locale' => null,
+        ])->save();
+    }
+}

--- a/app/Services/ExpiredEmployeeDeletionService.php
+++ b/app/Services/ExpiredEmployeeDeletionService.php
@@ -175,34 +175,79 @@ class ExpiredEmployeeDeletionService
         $deletedFiles = 0;
 
         foreach ($paths as $path) {
-            if (! $storage->exists($path)) {
+            $safePath = $this->validateEmployeeStoragePath($path);
+
+            if ($safePath === null) {
+                Log::warning('Refused to delete suspicious employee retention file path from local storage', [
+                    'file_path' => $path,
+                ]);
+
                 continue;
             }
 
-            if ($storage->delete($path)) {
+            if (! $storage->exists($safePath)) {
+                continue;
+            }
+
+            if ($storage->delete($safePath)) {
                 $deletedFiles++;
 
                 continue;
             }
 
             Log::warning('Failed to delete expired employee retention file from local storage', [
-                'file_path' => $path,
+                'file_path' => $safePath,
             ]);
         }
 
         return $deletedFiles;
     }
 
+    private function validateEmployeeStoragePath(string $path): ?string
+    {
+        $normalized = str_replace('\\', '/', ltrim(trim($path), '/'));
+
+        if ($normalized === '') {
+            return null;
+        }
+
+        // Reject absolute paths (Unix or Windows drive-letter)
+        if (str_starts_with($path, '/') || (strlen($path) >= 3 && $path[1] === ':')) {
+            return null;
+        }
+
+        // Reject directory traversal
+        foreach (explode('/', $normalized) as $segment) {
+            if ($segment === '.' || $segment === '..') {
+                return null;
+            }
+        }
+
+        // Enforce employees/ prefix allowlist
+        if (! str_starts_with($normalized, 'employees/')) {
+            return null;
+        }
+
+        return $normalized;
+    }
+
     private function anonymizeLinkedUser(User $user): void
     {
-        DB::table('model_has_roles')
+        $raw = config('permission.table_names.model_has_roles', 'model_has_roles');
+        $modelHasRolesTable = is_string($raw) ? $raw : 'model_has_roles';
+        $raw = config('permission.table_names.model_has_permissions', 'model_has_permissions');
+        $modelHasPermissionsTable = is_string($raw) ? $raw : 'model_has_permissions';
+        $raw = config('permission.column_names.model_morph_key', 'model_id');
+        $modelMorphKey = is_string($raw) ? $raw : 'model_id';
+
+        DB::table($modelHasRolesTable)
             ->where('model_type', User::class)
-            ->where('model_id', $user->id)
+            ->where($modelMorphKey, $user->id)
             ->delete();
 
-        DB::table('model_has_permissions')
+        DB::table($modelHasPermissionsTable)
             ->where('model_type', User::class)
-            ->where('model_id', $user->id)
+            ->where($modelMorphKey, $user->id)
             ->delete();
 
         DB::table('user_internal_organizational_scopes')
@@ -228,6 +273,12 @@ class ExpiredEmployeeDeletionService
 
         $user->tokens()->delete();
         $user->passkeyCredentials()->delete();
+
+        // Clear password reset tokens for the current (pre-anonymization) email to prevent
+        // token reuse if the address is later registered again.
+        DB::table('password_reset_tokens')
+            ->where('email', $user->email)
+            ->delete();
 
         $user->forceFill([
             'name' => 'Deleted User',

--- a/routes/console.php
+++ b/routes/console.php
@@ -44,6 +44,10 @@ Schedule::job(App\Jobs\UpgradeOpenTimestampProofs::class)->hourly()->name('ots-p
 // BewachV §21 Abs. 4 + GDPR Article 5(1)(e) compliance
 Schedule::command('activity:apply-retention')->dailyAt('02:00')->name('activity-retention');
 
+// Schedule: Delete expired terminated employee data daily at 02:30
+// Runs after activity retention so the deletion event itself starts a fresh retention window.
+Schedule::command('employees:delete-expired')->dailyAt('02:30')->name('employee-retention-deletion');
+
 // Schedule: Monitor OpenTimestamp health every 6 hours
 // Checks library version, calendar server availability, and functionality
 // Logs warnings if servers are down or updates are available

--- a/tests/Feature/Commands/DeleteExpiredEmployeesCommandTest.php
+++ b/tests/Feature/Commands/DeleteExpiredEmployeesCommandTest.php
@@ -179,3 +179,63 @@ test('it deletes every expired employee across multiple chunks', function (): vo
 
     expect(Employee::query()->count())->toBe(0);
 });
+
+test('it skips and logs suspicious file paths that fall outside the employees/ prefix', function (): void {
+    $tenant = TenantKey::factory()->create();
+
+    $employee = Employee::factory()
+        ->for($tenant, 'tenant')
+        ->terminated()
+        ->create([
+            'status' => Employee::STATUS_TERMINATED,
+            'employment_end_date' => now()->subYears(4)->toDateString(),
+            'retention_period_end' => now()->subDay()->toDateString(),
+            'id_document_copy_path' => '../etc/passwd',
+        ]);
+
+    Storage::disk('local')->put('employees/safe.enc', 'safe-content');
+
+    Log::spy();
+
+    $this->artisan('employees:delete-expired')
+        ->expectsOutputToContain('Deleted 1 expired employee record(s)')
+        ->assertSuccessful();
+
+    $this->assertDatabaseMissing('employees', ['id' => $employee->id]);
+
+    Log::shouldHaveReceived('warning')
+        ->once()
+        ->withArgs(fn (string $msg) => str_contains($msg, 'suspicious'));
+
+    Storage::disk('local')->assertExists('employees/safe.enc');
+});
+
+test('it clears password reset tokens for the pre-anonymization email', function (): void {
+    $tenant = TenantKey::factory()->create();
+    $user = User::factory()->create([
+        'tenant_id' => $tenant->id,
+        'email' => 'jane.doe@secpal.dev',
+    ]);
+
+    DB::table('password_reset_tokens')->insert([
+        'email' => $user->email,
+        'token' => Hash::make('some-token'),
+        'created_at' => now()->subMinutes(10),
+    ]);
+
+    $employee = Employee::factory()
+        ->for($tenant, 'tenant')
+        ->terminated()
+        ->create([
+            'user_id' => $user->id,
+            'status' => Employee::STATUS_TERMINATED,
+            'employment_end_date' => now()->subYears(4)->toDateString(),
+            'retention_period_end' => now()->subDay()->toDateString(),
+        ]);
+
+    $this->artisan('employees:delete-expired')
+        ->expectsOutputToContain('Deleted 1 expired employee record(s)')
+        ->assertSuccessful();
+
+    expect(DB::table('password_reset_tokens')->where('email', 'jane.doe@secpal.dev')->exists())->toBeFalse();
+});

--- a/tests/Feature/Commands/DeleteExpiredEmployeesCommandTest.php
+++ b/tests/Feature/Commands/DeleteExpiredEmployeesCommandTest.php
@@ -1,0 +1,181 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+use App\Models\Employee;
+use App\Models\EmployeeDocument;
+use App\Models\OnboardingFormSubmission;
+use App\Models\OnboardingSubmissionFile;
+use App\Models\TenantKey;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Storage;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function (): void {
+    Storage::fake('local');
+});
+
+test('it deletes expired terminated employees, removes local files, and anonymizes linked users', function (): void {
+    $tenant = TenantKey::factory()->create();
+    $user = User::factory()->create([
+        'tenant_id' => $tenant->id,
+        'name' => 'Jane Doe',
+        'email' => 'jane.doe@secpal.dev',
+    ]);
+
+    $employee = Employee::factory()
+        ->for($tenant, 'tenant')
+        ->terminated()
+        ->create([
+            'user_id' => $user->id,
+            'status' => Employee::STATUS_TERMINATED,
+            'user_account_active' => false,
+            'employment_end_date' => now()->subYears(4)->toDateString(),
+            'retention_period_end' => now()->subDay()->toDateString(),
+            'id_document_copy_path' => 'employees/expired/id_document.enc',
+        ]);
+
+    Storage::disk('local')->put('employees/expired/id_document.enc', 'encrypted-id-copy');
+
+    $document = EmployeeDocument::factory()->create([
+        'employee_id' => $employee->id,
+        'uploaded_by' => $user->id,
+        'file_path' => 'employees/expired/documents/contract.enc',
+    ]);
+
+    Storage::disk('local')->put($document->file_path, 'encrypted-document');
+
+    $submission = OnboardingFormSubmission::factory()->submitted()->create([
+        'employee_id' => $employee->id,
+    ]);
+
+    $submissionFile = OnboardingSubmissionFile::create([
+        'onboarding_form_submission_id' => $submission->id,
+        'uploaded_by' => $user->id,
+        'document_type' => 'contract',
+        'file_path' => 'employees/expired/onboarding/supporting.enc',
+        'file_name' => 'supporting.pdf',
+        'mime_type' => 'application/pdf',
+        'file_size' => 128,
+    ]);
+
+    Storage::disk('local')->put($submissionFile->file_path, 'encrypted-submission-file');
+
+    $user->createToken('expired-user-device');
+    DB::table('sessions')->insert([
+        'id' => 'session-expired-user',
+        'user_id' => $user->id,
+        'ip_address' => '127.0.0.1',
+        'user_agent' => 'Pest',
+        'payload' => 'payload',
+        'last_activity' => now()->timestamp,
+    ]);
+
+    $this->artisan('employees:delete-expired')
+        ->expectsOutputToContain('Deleted 1 expired employee record(s)')
+        ->assertSuccessful();
+
+    $this->assertDatabaseMissing('employees', ['id' => $employee->id]);
+    $this->assertDatabaseMissing('employee_documents', ['id' => $document->id]);
+    $this->assertDatabaseMissing('onboarding_form_submissions', ['id' => $submission->id]);
+    $this->assertDatabaseMissing('onboarding_submission_files', ['id' => $submissionFile->id]);
+
+    Storage::disk('local')->assertMissing('employees/expired/id_document.enc');
+    Storage::disk('local')->assertMissing($document->file_path);
+    Storage::disk('local')->assertMissing($submissionFile->file_path);
+
+    $user->refresh();
+
+    expect($user->name)->toBe('Deleted User')
+        ->and($user->email)->toBe('deleted-user+'.$user->id.'@secpal.dev')
+        ->and($user->email_verified_at)->toBeNull()
+        ->and(Hash::check('password', $user->password))->toBeFalse();
+
+    expect(DB::table('sessions')->where('user_id', $user->id)->exists())->toBeFalse();
+    expect($user->tokens()->count())->toBe(0);
+
+    $activity = DB::table('activity_log')
+        ->where('description', 'Employee data deleted after retention period')
+        ->where('subject_id', $employee->id)
+        ->first();
+
+    expect($activity)->not->toBeNull();
+});
+
+test('it supports dry run without deleting employee records', function (): void {
+    $tenant = TenantKey::factory()->create();
+
+    $employee = Employee::factory()
+        ->for($tenant, 'tenant')
+        ->terminated()
+        ->create([
+            'status' => Employee::STATUS_TERMINATED,
+            'employment_end_date' => now()->subYears(4)->toDateString(),
+            'retention_period_end' => now()->subDay()->toDateString(),
+        ]);
+
+    $this->artisan('employees:delete-expired --dry-run')
+        ->expectsOutputToContain('Would delete 1 expired employee record(s)')
+        ->assertSuccessful();
+
+    $this->assertDatabaseHas('employees', ['id' => $employee->id]);
+});
+
+test('it limits deletion to the selected tenant', function (): void {
+    $tenantA = TenantKey::factory()->create();
+    $tenantB = TenantKey::factory()->create();
+
+    $employeeA = Employee::factory()
+        ->for($tenantA, 'tenant')
+        ->terminated()
+        ->create([
+            'status' => Employee::STATUS_TERMINATED,
+            'employment_end_date' => now()->subYears(4)->toDateString(),
+            'retention_period_end' => now()->subDay()->toDateString(),
+        ]);
+
+    $employeeB = Employee::factory()
+        ->for($tenantB, 'tenant')
+        ->terminated()
+        ->create([
+            'status' => Employee::STATUS_TERMINATED,
+            'employment_end_date' => now()->subYears(4)->toDateString(),
+            'retention_period_end' => now()->subDay()->toDateString(),
+        ]);
+
+    $this->artisan('employees:delete-expired', ['--tenant' => $tenantA->id])
+        ->expectsOutputToContain('Deleted 1 expired employee record(s)')
+        ->assertSuccessful();
+
+    $this->assertDatabaseMissing('employees', ['id' => $employeeA->id]);
+    $this->assertDatabaseHas('employees', ['id' => $employeeB->id]);
+});
+
+test('it deletes every expired employee across multiple chunks', function (): void {
+    $tenant = TenantKey::factory()->create();
+
+    Employee::factory()
+        ->count(55)
+        ->for($tenant, 'tenant')
+        ->terminated()
+        ->create([
+            'status' => Employee::STATUS_TERMINATED,
+            'employment_end_date' => now()->subYears(4)->toDateString(),
+            'retention_period_end' => now()->subDay()->toDateString(),
+        ]);
+
+    $this->artisan('employees:delete-expired')
+        ->expectsOutputToContain('Deleted 55 expired employee record(s)')
+        ->assertSuccessful();
+
+    expect(Employee::query()->count())->toBe(0);
+});


### PR DESCRIPTION
## Summary
- add an automated employees:delete-expired command for terminated employee records whose legal retention period has elapsed
- hard-delete expired employee data, remove local employee and onboarding uploads, and anonymize linked users before dissociating them
- schedule the command daily after activity retention and cover dry-run, tenant scoping, and multi-chunk processing with Pest tests

## Testing
- php artisan test tests/Feature/Commands/DeleteExpiredEmployeesCommandTest.php tests/Unit/Observers/EmployeeObserverBewachvTest.php
- vendor/bin/pint --dirty
- vendor/bin/phpstan analyse app/Services/ExpiredEmployeeDeletionService.php app/Models/Employee.php --no-progress
- reuse lint

Refs #470
