### PR TITLE
test: cover duplicate employee email rejection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- verified employee email uniqueness enforcement with regression coverage against the unique plaintext `employees.email` column used by `StoreEmployeeRequest`
+
 - added a dedicated `health` rate limiter for `/health`, `/health/live`, and `/health/ready` so unauthenticated health probes now return `429` after repeated abuse from the same IP and route bucket
 
 - switched role and permission management writes to validated request payloads so those controllers no longer read raw input after form-request validation

--- a/tests/Feature/Controllers/EmployeeControllerTest.php
+++ b/tests/Feature/Controllers/EmployeeControllerTest.php
@@ -337,6 +337,42 @@ describe('POST /v1/employees', function () {
         expect($response->json('data.onboarding_workflow.status'))->toBe(Employee::WORKFLOW_STATUS_INVITED);
     });
 
+    test('returns 422 when employee email is already taken', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'employee.write');
+
+        $payload = [
+            'first_name' => 'John',
+            'last_name' => 'Doe',
+            'email' => 'duplicate.employee@example.com',
+            'date_of_birth' => '1990-01-15',
+            'position' => 'Security Guard',
+            'status' => 'pre_contract',
+            'contract_type' => 'full_time',
+            'contract_start_date' => now()->toDateString(),
+            'weekly_hours' => 40,
+            'hourly_rate' => 15.50,
+            'organizational_unit_id' => $this->organizationalUnit->id,
+            'sachkunde_type' => 'none',
+            'work_permit_type' => 'none',
+            'criminal_record_status' => 'valid',
+            'management_level' => 0,
+        ];
+
+        $this->withToken($this->token)
+            ->postJson('/v1/employees', $payload)
+            ->assertCreated();
+
+        $response = $this->withToken($this->token)
+            ->postJson('/v1/employees', [
+                ...$payload,
+                'first_name' => 'Jane',
+                'last_name' => 'Smith',
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['email']);
+    });
+
     test('creates employee with user account via Observer', function (): void {
         givePermissionWithTenant($this->user, $this->tenant->id, 'employee.write');
 


### PR DESCRIPTION
## Summary

- add regression coverage proving that duplicate employee emails are rejected with `422`
- document in the changelog that `StoreEmployeeRequest` is backed by the unique plaintext `employees.email` column already present in the schema

## Testing

- php artisan test tests/Feature/Controllers/EmployeeControllerTest.php
- vendor/bin/pint --dirty

## Checklist

- [x] Single topic
- [x] Verification / regression coverage added
- [x] CHANGELOG updated

Closes #842
