### PR TITLE
fix: normalize unexpected api exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- normalized unexpected API exceptions behind a final JSON catch-all so `/v1/*` requests now return a stable `message` payload even with `APP_DEBUG=true`, while 500 responses always use `Internal server error.` instead of leaking stack traces or internal exception details
+
 - normalized generic API `404` responses to `{"message":"Resource not found."}` for unknown `/v1/*` routes in all debug modes, preventing default Laravel HTML or stack-trace payloads from leaking through
+
+- escaped `\\`, `%`, and `_` in customer, site, and employee search terms through a shared LIKE-pattern helper so wildcard-only search input no longer expands into broad `LIKE` / `ILIKE` scans on those endpoints
+
+- capped `/v1/organizational-units` pagination with a dedicated index request so oversized `per_page` values are rejected with `422` instead of allowing unbounded result windows
+
+- switched onboarding submission rejection to persist the validated `reason` payload instead of re-reading raw request input after inline validation
+
+- restricted regulated employee identifiers in `EmployeeResource` behind a new `employees.read_sensitive` permission, seeded a dedicated `HR` role for that access, and stopped non-HR viewers with ordinary employee read access from receiving decrypted tax, social-security, permit, health-insurance, ID-document, and Sachkunde identifier fields
+
+- verified employee email uniqueness enforcement with regression coverage against the unique plaintext `employees.email` column used by `StoreEmployeeRequest`
+
+- added a dedicated `health` rate limiter for `/health`, `/health/live`, and `/health/ready` so unauthenticated health probes now return `429` after repeated abuse from the same IP and route bucket
+
+- switched role and permission management writes to validated request payloads so those controllers no longer read raw input after form-request validation
+- reduced the public health surface by removing the `/health` version field and by limiting `/health/ready` responses to the readiness status plus timestamp instead of exposing database, key-management, scheduler, and queue-worker details
+- standardized API V1 delete endpoints on `response()->noContent()` so successful `204` responses are implemented consistently across employee, document, qualification, assignment, customer, site, organizational-unit, and cost-center deletes
+- serialized employee number generation per tenant inside the employee create transaction, locking the tenant row plus the current-year employee number lookup so concurrent `POST /v1/employees` requests cannot derive duplicate `employee_number` values; the existing global unique constraint on `employee_number` remains in place as a last-resort safeguard (note: the constraint is currently global across tenants, not scoped per tenant — tracked in SecPal/api#867)
 - fixed `buildUserAuthorizationData` returning empty roles and permissions on authentication routes (login, passkey verify, MFA verify) because the global `InjectTenantId` middleware cannot resolve a user before authentication completes, leaving the Spatie PermissionRegistrar with a null team context; the method now explicitly sets the team from the user's `tenant_id` before eager-loading (fixes SecPal/frontend#822)
 - fixed the passkey browser-session model mismatch by keeping registration compatibility-friendly (`resident_key: preferred`) while omitting deprecated `require_resident_key` when it is false, and by letting `/v1/auth/passkeys/challenges` take an optional email address that returns `allow_credentials` for email-scoped fallback sign-in when discoverable credentials are unavailable in the browser or authenticator
 - aligned Android provisioning QR payload download URLs with the per-session `apk.secpal.app/android/channels/{channel}/app.secpal-latest.apk` endpoint model by computing the URL unconditionally from `android.artifact_base_url` + `update_channel`; removed the obsolete `android.package_download_url` config key whose hardcoded `managed_device` default was silently overriding the per-channel computation for all other channels

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,23 +24,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - normalized generic API `404` responses to `{"message":"Resource not found."}` for unknown `/v1/*` routes in all debug modes, preventing default Laravel HTML or stack-trace payloads from leaking through
-
-- escaped `\\`, `%`, and `_` in customer, site, and employee search terms through a shared LIKE-pattern helper so wildcard-only search input no longer expands into broad `LIKE` / `ILIKE` scans on those endpoints
-
-- capped `/v1/organizational-units` pagination with a dedicated index request so oversized `per_page` values are rejected with `422` instead of allowing unbounded result windows
-
-- switched onboarding submission rejection to persist the validated `reason` payload instead of re-reading raw request input after inline validation
-
-- restricted regulated employee identifiers in `EmployeeResource` behind a new `employees.read_sensitive` permission, seeded a dedicated `HR` role for that access, and stopped non-HR viewers with ordinary employee read access from receiving decrypted tax, social-security, permit, health-insurance, ID-document, and Sachkunde identifier fields
-
-- verified employee email uniqueness enforcement with regression coverage against the unique plaintext `employees.email` column used by `StoreEmployeeRequest`
-
-- added a dedicated `health` rate limiter for `/health`, `/health/live`, and `/health/ready` so unauthenticated health probes now return `429` after repeated abuse from the same IP and route bucket
-
-- switched role and permission management writes to validated request payloads so those controllers no longer read raw input after form-request validation
-- reduced the public health surface by removing the `/health` version field and by limiting `/health/ready` responses to the readiness status plus timestamp instead of exposing database, key-management, scheduler, and queue-worker details
-- standardized API V1 delete endpoints on `response()->noContent()` so successful `204` responses are implemented consistently across employee, document, qualification, assignment, customer, site, organizational-unit, and cost-center deletes
-- serialized employee number generation per tenant inside the employee create transaction, locking the tenant row plus the current-year employee number lookup so concurrent `POST /v1/employees` requests cannot derive duplicate `employee_number` values; the existing global unique constraint on `employee_number` remains in place as a last-resort safeguard (note: the constraint is currently global across tenants, not scoped per tenant — tracked in SecPal/api#867)
 - fixed `buildUserAuthorizationData` returning empty roles and permissions on authentication routes (login, passkey verify, MFA verify) because the global `InjectTenantId` middleware cannot resolve a user before authentication completes, leaving the Spatie PermissionRegistrar with a null team context; the method now explicitly sets the team from the user's `tenant_id` before eager-loading (fixes SecPal/frontend#822)
 - fixed the passkey browser-session model mismatch by keeping registration compatibility-friendly (`resident_key: preferred`) while omitting deprecated `require_resident_key` when it is false, and by letting `/v1/auth/passkeys/challenges` take an optional email address that returns `allow_credentials` for email-scoped fallback sign-in when discoverable credentials are unavailable in the browser or authenticator
 - aligned Android provisioning QR payload download URLs with the per-session `apk.secpal.app/android/channels/{channel}/app.secpal-latest.apk` endpoint model by computing the URL unconditionally from `android.artifact_base_url` + `update_channel`; removed the obsolete `android.package_download_url` config key whose hardcoded `managed_device` default was silently overriding the per-channel computation for all other channels

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Http\Request;
 use Illuminate\Validation\ValidationException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
@@ -99,7 +100,9 @@ return Application::configure(basePath: dirname(__DIR__))
                 return null;
             }
 
-            if ($e instanceof ValidationException || $e instanceof AuthorizationException) {
+            if ($e instanceof ValidationException
+                || $e instanceof AuthorizationException
+                || $e instanceof HttpResponseException) {
                 return null;
             }
 

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -91,4 +91,20 @@ return Application::configure(basePath: dirname(__DIR__))
                 'message' => 'Resource not found.',
             ], 404);
         });
+
+        $exceptions->render(function (Throwable $e, Request $request) use ($shouldRenderApiJson) {
+            if (! $shouldRenderApiJson($request)) {
+                return null;
+            }
+
+            $status = method_exists($e, 'getStatusCode')
+                ? $e->getStatusCode()
+                : 500;
+
+            return response()->json([
+                'message' => $status >= 500
+                    ? 'Internal server error.'
+                    : ($e->getMessage() !== '' ? $e->getMessage() : 'Request failed.'),
+            ], $status);
+        });
     })->create();

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -3,12 +3,14 @@
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Auth\AuthenticationException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
 use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 return Application::configure(basePath: dirname(__DIR__))
@@ -94,6 +96,10 @@ return Application::configure(basePath: dirname(__DIR__))
 
         $exceptions->render(function (Throwable $e, Request $request) use ($shouldRenderApiJson) {
             if (! $shouldRenderApiJson($request)) {
+                return null;
+            }
+
+            if ($e instanceof ValidationException || $e instanceof AuthorizationException) {
                 return null;
             }
 

--- a/tests/Feature/ApiErrorHandlingTest.php
+++ b/tests/Feature/ApiErrorHandlingTest.php
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Route;
 
 uses(RefreshDatabase::class);
 
@@ -15,6 +16,23 @@ it('returns the normalized JSON 404 payload for unknown api routes regardless of
     $response->assertNotFound()
         ->assertExactJson([
             'message' => 'Resource not found.',
+        ]);
+
+    expect($response->headers->get('content-type'))->toContain('application/json');
+})->with([true, false]);
+
+it('returns the normalized JSON 500 payload for unexpected api exceptions regardless of debug mode', function (bool $debug): void {
+    config(['app.debug' => $debug]);
+
+    Route::middleware('api')->get('/v1/test-runtime-exception', function (): never {
+        throw new RuntimeException('Sensitive failure details');
+    });
+
+    $response = $this->getJson('/v1/test-runtime-exception');
+
+    $response->assertStatus(500)
+        ->assertExactJson([
+            'message' => 'Internal server error.',
         ]);
 
     expect($response->headers->get('content-type'))->toContain('application/json');

--- a/tests/Feature/ApiErrorHandlingTest.php
+++ b/tests/Feature/ApiErrorHandlingTest.php
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
 uses(RefreshDatabase::class);
@@ -34,6 +35,21 @@ it('returns the normalized JSON 500 payload for unexpected api exceptions regard
         ->assertExactJson([
             'message' => 'Internal server error.',
         ]);
+
+    expect($response->headers->get('content-type'))->toContain('application/json');
+})->with([true, false]);
+
+it('passes validation exceptions through the catch-all as 422 with an errors field intact', function (bool $debug): void {
+    config(['app.debug' => $debug]);
+
+    Route::middleware('api')->post('/v1/test-validation-exception', function (Request $request): void {
+        $request->validate(['email' => 'required|email']);
+    });
+
+    $response = $this->postJson('/v1/test-validation-exception', []);
+
+    $response->assertStatus(422)
+        ->assertJsonValidationErrors(['email']);
 
     expect($response->headers->get('content-type'))->toContain('application/json');
 })->with([true, false]);

--- a/tests/Feature/ApiErrorHandlingTest.php
+++ b/tests/Feature/ApiErrorHandlingTest.php
@@ -3,6 +3,10 @@
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
 it('returns the normalized JSON 404 payload for unknown api routes regardless of debug mode', function (bool $debug): void {
     config(['app.debug' => $debug]);
 

--- a/tests/Feature/ApiErrorHandlingTest.php
+++ b/tests/Feature/ApiErrorHandlingTest.php
@@ -53,3 +53,20 @@ it('passes validation exceptions through the catch-all as 422 with an errors fie
 
     expect($response->headers->get('content-type'))->toContain('application/json');
 })->with([true, false]);
+
+it('passes HttpResponseException through the catch-all preserving the wrapped response status', function (bool $debug): void {
+    config(['app.debug' => $debug]);
+
+    Route::middleware('api')->get('/v1/test-http-response-exception', function (): never {
+        throw new Illuminate\Http\Exceptions\HttpResponseException(
+            response()->json(['message' => 'Too Many Attempts.'], 429)
+        );
+    });
+
+    $response = $this->getJson('/v1/test-http-response-exception');
+
+    $response->assertStatus(429)
+        ->assertJson(['message' => 'Too Many Attempts.']);
+
+    expect($response->headers->get('content-type'))->toContain('application/json');
+})->with([true, false]);


### PR DESCRIPTION
## Summary
- add a final API exception handler so unexpected `/v1/*` failures always return a normalized JSON `message` payload
- keep 500 responses on API routes fixed to `Internal server error.` even when `APP_DEBUG=true`
- add regression coverage for unexpected runtime exceptions in both debug modes

## Testing
- php artisan test tests/Feature/ApiErrorHandlingTest.php
- vendor/bin/pint --dirty

## Notes
- This branch is intentionally stacked on top of the generic 404 JSON fix from PR #850.

Closes #846
