### PR TITLE
fix: complete index request coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,26 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- normalized unexpected API exceptions behind a final JSON catch-all so `/v1/*` requests now return a stable `message` payload even with `APP_DEBUG=true`, while 500 responses always use `Internal server error.` instead of leaking stack traces or internal exception details
-
-- normalized generic API `404` responses to `{"message":"Resource not found."}` for unknown `/v1/*` routes in all debug modes, preventing default Laravel HTML or stack-trace payloads from leaking through
-
-- escaped `\\`, `%`, and `_` in customer, site, and employee search terms through a shared LIKE-pattern helper so wildcard-only search input no longer expands into broad `LIKE` / `ILIKE` scans on those endpoints
-
-- capped `/v1/organizational-units` pagination with a dedicated index request so oversized `per_page` values are rejected with `422` instead of allowing unbounded result windows
-
-- switched onboarding submission rejection to persist the validated `reason` payload instead of re-reading raw request input after inline validation
-
-- restricted regulated employee identifiers in `EmployeeResource` behind a new `employees.read_sensitive` permission, seeded a dedicated `HR` role for that access, and stopped non-HR viewers with ordinary employee read access from receiving decrypted tax, social-security, permit, health-insurance, ID-document, and Sachkunde identifier fields
-
-- verified employee email uniqueness enforcement with regression coverage against the unique plaintext `employees.email` column used by `StoreEmployeeRequest`
-
-- added a dedicated `health` rate limiter for `/health`, `/health/live`, and `/health/ready` so unauthenticated health probes now return `429` after repeated abuse from the same IP and route bucket
-
-- switched role and permission management writes to validated request payloads so those controllers no longer read raw input after form-request validation
-- reduced the public health surface by removing the `/health` version field and by limiting `/health/ready` responses to the readiness status plus timestamp instead of exposing database, key-management, scheduler, and queue-worker details
-- standardized API V1 delete endpoints on `response()->noContent()` so successful `204` responses are implemented consistently across employee, document, qualification, assignment, customer, site, organizational-unit, and cost-center deletes
-- serialized employee number generation per tenant inside the employee create transaction, locking the tenant row plus the current-year employee number lookup so concurrent `POST /v1/employees` requests cannot derive duplicate `employee_number` values; the existing global unique constraint on `employee_number` remains in place as a last-resort safeguard (note: the constraint is currently global across tenants, not scoped per tenant — tracked in SecPal/api#867)
+- added dedicated index request validation for qualification, organizational-unit, customer-assignment, and site-assignment filters so invalid category, type, parent, and role query values now fail fast with `422` responses instead of silently producing empty or ambiguous results
 - fixed `buildUserAuthorizationData` returning empty roles and permissions on authentication routes (login, passkey verify, MFA verify) because the global `InjectTenantId` middleware cannot resolve a user before authentication completes, leaving the Spatie PermissionRegistrar with a null team context; the method now explicitly sets the team from the user's `tenant_id` before eager-loading (fixes SecPal/frontend#822)
 - fixed the passkey browser-session model mismatch by keeping registration compatibility-friendly (`resident_key: preferred`) while omitting deprecated `require_resident_key` when it is false, and by letting `/v1/auth/passkeys/challenges` take an optional email address that returns `allow_credentials` for email-scoped fallback sign-in when discoverable credentials are unavailable in the browser or authenticator
 - aligned Android provisioning QR payload download URLs with the per-session `apk.secpal.app/android/channels/{channel}/app.secpal-latest.apk` endpoint model by computing the URL unconditionally from `android.artifact_base_url` + `update_channel`; removed the obsolete `android.package_download_url` config key whose hardcoded `managed_device` default was silently overriding the per-channel computation for all other channels

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - added dedicated index request validation for qualification, organizational-unit, customer-assignment, and site-assignment filters so invalid category, type, parent, and role query values now fail fast with `422` responses instead of silently producing empty or ambiguous results
+
+- normalized unexpected API exceptions behind a final JSON catch-all so `/v1/*` requests now return a stable `message` payload even with `APP_DEBUG=true`, while 500 responses always use `Internal server error.` instead of leaking stack traces or internal exception details
+
+- normalized generic API `404` responses to `{"message":"Resource not found."}` for unknown `/v1/*` routes in all debug modes, preventing default Laravel HTML or stack-trace payloads from leaking through
+
+- escaped `\\`, `%`, and `_` in customer, site, and employee search terms through a shared LIKE-pattern helper so wildcard-only search input no longer expands into broad `LIKE` / `ILIKE` scans on those endpoints
+
+- capped `/v1/organizational-units` pagination with a dedicated index request so oversized `per_page` values are rejected with `422` instead of allowing unbounded result windows
+
+- switched onboarding submission rejection to persist the validated `reason` payload instead of re-reading raw request input after inline validation
+
+- restricted regulated employee identifiers in `EmployeeResource` behind a new `employees.read_sensitive` permission, seeded a dedicated `HR` role for that access, and stopped non-HR viewers with ordinary employee read access from receiving decrypted tax, social-security, permit, health-insurance, ID-document, and Sachkunde identifier fields
+
+- verified employee email uniqueness enforcement with regression coverage against the unique plaintext `employees.email` column used by `StoreEmployeeRequest`
+
+- added a dedicated `health` rate limiter for `/health`, `/health/live`, and `/health/ready` so unauthenticated health probes now return `429` after repeated abuse from the same IP and route bucket
+
+- switched role and permission management writes to validated request payloads so those controllers no longer read raw input after form-request validation
+- reduced the public health surface by removing the `/health` version field and by limiting `/health/ready` responses to the readiness status plus timestamp instead of exposing database, key-management, scheduler, and queue-worker details
+- standardized API V1 delete endpoints on `response()->noContent()` so successful `204` responses are implemented consistently across employee, document, qualification, assignment, customer, site, organizational-unit, and cost-center deletes
+- serialized employee number generation per tenant inside the employee create transaction, locking the tenant row plus the current-year employee number lookup so concurrent `POST /v1/employees` requests cannot derive duplicate `employee_number` values; the existing global unique constraint on `employee_number` remains in place as a last-resort safeguard (note: the constraint is currently global across tenants, not scoped per tenant — tracked in SecPal/api#867)
 - fixed `buildUserAuthorizationData` returning empty roles and permissions on authentication routes (login, passkey verify, MFA verify) because the global `InjectTenantId` middleware cannot resolve a user before authentication completes, leaving the Spatie PermissionRegistrar with a null team context; the method now explicitly sets the team from the user's `tenant_id` before eager-loading (fixes SecPal/frontend#822)
 - fixed the passkey browser-session model mismatch by keeping registration compatibility-friendly (`resident_key: preferred`) while omitting deprecated `require_resident_key` when it is false, and by letting `/v1/auth/passkeys/challenges` take an optional email address that returns `allow_credentials` for email-scoped fallback sign-in when discoverable credentials are unavailable in the browser or authenticator
 - aligned Android provisioning QR payload download URLs with the per-session `apk.secpal.app/android/channels/{channel}/app.secpal-latest.apk` endpoint model by computing the URL unconditionally from `android.artifact_base_url` + `update_channel`; removed the obsolete `android.package_download_url` config key whose hardcoded `managed_device` default was silently overriding the per-channel computation for all other channels

--- a/app/Http/Controllers/Api/V1/CustomerAssignmentController.php
+++ b/app/Http/Controllers/Api/V1/CustomerAssignmentController.php
@@ -8,13 +8,13 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\V1\Assignment\IndexCustomerAssignmentRequest;
 use App\Http\Requests\Api\V1\Assignment\StoreCustomerAssignmentRequest;
 use App\Http\Requests\Api\V1\Assignment\UpdateAssignmentRequest;
 use App\Http\Resources\Api\V1\CustomerAssignmentResource;
 use App\Models\Customer;
 use App\Models\CustomerAssignment;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -42,13 +42,16 @@ class CustomerAssignmentController extends Controller
      *
      * @return JsonResponse Array of CustomerAssignmentResource
      */
-    public function index(Request $request, Customer $customer): JsonResponse
+    public function index(IndexCustomerAssignmentRequest $request, Customer $customer): JsonResponse
     {
         $this->authorize('view', $customer);
 
+        /** @var array{active_only?: mixed, role?: string} $validated */
+        $validated = $request->validated();
+
         $assignments = $customer->assignments()
             ->with(['user', 'customer'])
-            ->when($request->has('role'), fn ($q) => $q->where('role', $request->input('role')))
+            ->when(array_key_exists('role', $validated), fn ($q) => $q->where('role', $validated['role']))
             ->when($request->boolean('active_only'), fn ($q) => $q->currentlyActive())
             ->get();
 

--- a/app/Http/Controllers/Api/V1/CustomerAssignmentController.php
+++ b/app/Http/Controllers/Api/V1/CustomerAssignmentController.php
@@ -48,10 +48,11 @@ class CustomerAssignmentController extends Controller
 
         /** @var array{active_only?: mixed, role?: string} $validated */
         $validated = $request->validated();
+        $role = $validated['role'] ?? null;
 
         $assignments = $customer->assignments()
             ->with(['user', 'customer'])
-            ->when(array_key_exists('role', $validated), fn ($q) => $q->where('role', $validated['role']))
+            ->when(is_string($role), fn ($q) => $q->where('role', $role))
             ->when($request->boolean('active_only'), fn ($q) => $q->currentlyActive())
             ->get();
 

--- a/app/Http/Controllers/Api/V1/OrganizationalUnitController.php
+++ b/app/Http/Controllers/Api/V1/OrganizationalUnitController.php
@@ -37,6 +37,9 @@ class OrganizationalUnitController extends Controller
     {
         $this->authorize('viewAny', OrganizationalUnit::class);
 
+        /** @var array{parent_id?: string, type?: string} $validated */
+        $validated = $request->validated();
+
         /** @var \App\Models\User $user */
         $user = $request->user();
 
@@ -57,13 +60,13 @@ class OrganizationalUnitController extends Controller
             ->where('tenant_id', $tenantId);
 
         // Filter by type if provided
-        if ($request->has('type')) {
-            $query->where('type', $request->input('type'));
+        if (array_key_exists('type', $validated)) {
+            $query->where('type', $validated['type']);
         }
 
         // Filter by parent_id if provided
-        if ($request->has('parent_id')) {
-            $parentId = $request->input('parent_id');
+        if (array_key_exists('parent_id', $validated)) {
+            $parentId = $validated['parent_id'];
             if ($parentId === 'null' || $parentId === null) {
                 // Get root units (units without accessible parents)
                 $query->whereIn('id', $rootUnitIds);
@@ -92,8 +95,8 @@ class OrganizationalUnitController extends Controller
 
         $units = $query->paginate($request->integer('per_page', 15));
 
-        // Store accessible IDs in global request for OrganizationalUnitResource to use (Need-to-Know filtering).
-        // The resource receives the global request instance (not the injected FormRequest), so request() is used here.
+        // Store accessible IDs in request for Resource to use (Need-to-Know filtering)
+        $request->attributes->set('accessible_unit_ids', $accessibleIds);
         request()->attributes->set('accessible_unit_ids', $accessibleIds);
 
         return response()->json([

--- a/app/Http/Controllers/Api/V1/OrganizationalUnitController.php
+++ b/app/Http/Controllers/Api/V1/OrganizationalUnitController.php
@@ -60,7 +60,7 @@ class OrganizationalUnitController extends Controller
             ->where('tenant_id', $tenantId);
 
         // Filter by type if provided
-        if (array_key_exists('type', $validated)) {
+        if (array_key_exists('type', $validated) && $validated['type'] !== null) {
             $query->where('type', $validated['type']);
         }
 
@@ -95,8 +95,7 @@ class OrganizationalUnitController extends Controller
 
         $units = $query->paginate($request->integer('per_page', 15));
 
-        // Store accessible IDs in request for Resource to use (Need-to-Know filtering)
-        $request->attributes->set('accessible_unit_ids', $accessibleIds);
+        // Store accessible IDs on the container request for OrganizationalUnitResource to use (Need-to-Know filtering)
         request()->attributes->set('accessible_unit_ids', $accessibleIds);
 
         return response()->json([

--- a/app/Http/Controllers/Api/V1/QualificationController.php
+++ b/app/Http/Controllers/Api/V1/QualificationController.php
@@ -6,12 +6,12 @@
 namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\IndexQualificationRequest;
 use App\Http\Requests\StoreQualificationRequest;
 use App\Http\Requests\UpdateQualificationRequest;
 use App\Http\Resources\QualificationResource;
 use App\Models\Qualification;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 
 /**
@@ -33,9 +33,12 @@ class QualificationController extends Controller
      * - category
      * - is_mandatory (boolean)
      */
-    public function index(Request $request): JsonResponse
+    public function index(IndexQualificationRequest $request): JsonResponse
     {
         $this->authorize('viewAny', Qualification::class);
+
+        /** @var array{category?: string, is_mandatory?: mixed, is_system_qualification?: mixed} $validated */
+        $validated = $request->validated();
 
         /** @var int $tenantId */
         $tenantId = $request->input('tenant_id');
@@ -47,8 +50,8 @@ class QualificationController extends Controller
         });
 
         // Filter by is_system_qualification
-        if ($request->has('is_system_qualification')) {
-            $isSystem = filter_var($request->input('is_system_qualification'), FILTER_VALIDATE_BOOLEAN);
+        if (array_key_exists('is_system_qualification', $validated)) {
+            $isSystem = $request->boolean('is_system_qualification');
             if ($isSystem) {
                 $query->where('is_system_qualification', true)->whereNull('tenant_id');
             } else {
@@ -57,13 +60,13 @@ class QualificationController extends Controller
         }
 
         // Filter by category
-        if ($request->has('category')) {
-            $query->where('category', $request->input('category'));
+        if (array_key_exists('category', $validated)) {
+            $query->where('category', $validated['category']);
         }
 
         // Filter by is_mandatory
-        if ($request->has('is_mandatory')) {
-            $query->where('is_mandatory', filter_var($request->input('is_mandatory'), FILTER_VALIDATE_BOOLEAN));
+        if (array_key_exists('is_mandatory', $validated)) {
+            $query->where('is_mandatory', $request->boolean('is_mandatory'));
         }
 
         $qualifications = $query->orderBy('sort_order')->orderBy('name')->get();

--- a/app/Http/Controllers/Api/V1/QualificationController.php
+++ b/app/Http/Controllers/Api/V1/QualificationController.php
@@ -60,7 +60,7 @@ class QualificationController extends Controller
         }
 
         // Filter by category
-        if (array_key_exists('category', $validated)) {
+        if (array_key_exists('category', $validated) && $validated['category'] !== null) {
             $query->where('category', $validated['category']);
         }
 

--- a/app/Http/Controllers/Api/V1/SiteAssignmentController.php
+++ b/app/Http/Controllers/Api/V1/SiteAssignmentController.php
@@ -8,13 +8,13 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\V1\Assignment\IndexSiteAssignmentRequest;
 use App\Http\Requests\Api\V1\Assignment\StoreSiteAssignmentRequest;
 use App\Http\Requests\Api\V1\Assignment\UpdateAssignmentRequest;
 use App\Http\Resources\Api\V1\SiteAssignmentResource;
 use App\Models\Site;
 use App\Models\SiteAssignment;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -42,13 +42,16 @@ class SiteAssignmentController extends Controller
      *
      * @return JsonResponse Array of SiteAssignmentResource
      */
-    public function index(Request $request, Site $site): JsonResponse
+    public function index(IndexSiteAssignmentRequest $request, Site $site): JsonResponse
     {
         $this->authorize('view', $site);
 
+        /** @var array{active_only?: mixed, role?: string} $validated */
+        $validated = $request->validated();
+
         $assignments = $site->assignments()
             ->with(['user', 'site'])
-            ->when($request->has('role'), fn ($q) => $q->where('role', $request->input('role')))
+            ->when(array_key_exists('role', $validated), fn ($q) => $q->where('role', $validated['role']))
             ->when($request->boolean('active_only'), fn ($q) => $q->currentlyActive())
             ->get();
 

--- a/app/Http/Controllers/Api/V1/SiteAssignmentController.php
+++ b/app/Http/Controllers/Api/V1/SiteAssignmentController.php
@@ -48,10 +48,11 @@ class SiteAssignmentController extends Controller
 
         /** @var array{active_only?: mixed, role?: string} $validated */
         $validated = $request->validated();
+        $role = $validated['role'] ?? null;
 
         $assignments = $site->assignments()
             ->with(['user', 'site'])
-            ->when(array_key_exists('role', $validated), fn ($q) => $q->where('role', $validated['role']))
+            ->when(is_string($role), fn ($q) => $q->where('role', $role))
             ->when($request->boolean('active_only'), fn ($q) => $q->currentlyActive())
             ->get();
 

--- a/app/Http/Requests/Api/IndexOrganizationalUnitRequest.php
+++ b/app/Http/Requests/Api/IndexOrganizationalUnitRequest.php
@@ -28,6 +28,7 @@ class IndexOrganizationalUnitRequest extends FormRequest
     public function rules(): array
     {
         return [
+            'per_page' => ['nullable', 'integer', 'min:1', 'max:100'],
             'type' => ['nullable', 'string', Rule::in(['holding', 'company', 'region', 'branch', 'division', 'department', 'custom'])],
             'parent_id' => [
                 'nullable',
@@ -40,6 +41,16 @@ class IndexOrganizationalUnitRequest extends FormRequest
                     $fail('The '.$attribute.' field must be a valid UUID or "null".');
                 },
             ],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'per_page.max' => 'Maximum 100 items per page.',
         ];
     }
 }

--- a/app/Http/Requests/Api/IndexOrganizationalUnitRequest.php
+++ b/app/Http/Requests/Api/IndexOrganizationalUnitRequest.php
@@ -7,33 +7,39 @@ namespace App\Http\Requests\Api;
 
 use App\Models\OrganizationalUnit;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Str;
+use Illuminate\Validation\Rule;
 
 class IndexOrganizationalUnitRequest extends FormRequest
 {
+    /**
+     * Determine if the user is authorized to make this request.
+     */
     public function authorize(): bool
     {
         return $this->user()?->can('viewAny', OrganizationalUnit::class) ?? false;
     }
 
     /**
+     * Get the validation rules that apply to the request.
+     *
      * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
      */
     public function rules(): array
     {
         return [
-            'per_page' => ['nullable', 'integer', 'min:1', 'max:100'],
-            'type' => ['nullable', 'string'],
-            'parent_id' => ['nullable', 'string'],
-        ];
-    }
+            'type' => ['nullable', 'string', Rule::in(['holding', 'company', 'region', 'branch', 'division', 'department', 'custom'])],
+            'parent_id' => [
+                'nullable',
+                'string',
+                function (string $attribute, mixed $value, \Closure $fail): void {
+                    if ($value === 'null' || (is_string($value) && Str::isUuid($value))) {
+                        return;
+                    }
 
-    /**
-     * @return array<string, string>
-     */
-    public function messages(): array
-    {
-        return [
-            'per_page.max' => 'Maximum 100 items per page.',
+                    $fail('The '.$attribute.' field must be a valid UUID or "null".');
+                },
+            ],
         ];
     }
 }

--- a/app/Http/Requests/Api/V1/Assignment/IndexCustomerAssignmentRequest.php
+++ b/app/Http/Requests/Api/V1/Assignment/IndexCustomerAssignmentRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\V1\Assignment;
+
+use App\Models\Customer;
+use Illuminate\Foundation\Http\FormRequest;
+
+class IndexCustomerAssignmentRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        $customer = $this->route('customer');
+
+        return $customer instanceof Customer
+            ? ($this->user()?->can('view', $customer) ?? false)
+            : false;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'role' => ['nullable', 'string', 'max:100'],
+            'active_only' => ['nullable', 'boolean'],
+        ];
+    }
+}

--- a/app/Http/Requests/Api/V1/Assignment/IndexSiteAssignmentRequest.php
+++ b/app/Http/Requests/Api/V1/Assignment/IndexSiteAssignmentRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\V1\Assignment;
+
+use App\Models\Site;
+use Illuminate\Foundation\Http\FormRequest;
+
+class IndexSiteAssignmentRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        $site = $this->route('site');
+
+        return $site instanceof Site
+            ? ($this->user()?->can('view', $site) ?? false)
+            : false;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'role' => ['nullable', 'string', 'max:100'],
+            'active_only' => ['nullable', 'boolean'],
+        ];
+    }
+}

--- a/app/Http/Requests/IndexQualificationRequest.php
+++ b/app/Http/Requests/IndexQualificationRequest.php
@@ -1,0 +1,43 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace App\Http\Requests;
+
+use App\Models\Qualification;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class IndexQualificationRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return $this->user()?->can('viewAny', Qualification::class) ?? false;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'is_system_qualification' => ['nullable', 'boolean'],
+            'category' => ['nullable', Rule::in([
+                'bewachv_34a',
+                'first_aid',
+                'fire_safety',
+                'safety_officer',
+                'specialized',
+                'education',
+                'custom',
+            ])],
+            'is_mandatory' => ['nullable', 'boolean'],
+        ];
+    }
+}

--- a/tests/Feature/Controllers/Api/V1/CustomerAssignmentControllerTest.php
+++ b/tests/Feature/Controllers/Api/V1/CustomerAssignmentControllerTest.php
@@ -128,6 +128,16 @@ describe('GET /v1/customers/{customer}/assignments', function () {
         expect($response->json('data')[0]['role'])->toBe('Key Account Manager');
     });
 
+    test('returns 422 when role filter is not a string', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'customers.read');
+
+        $response = $this->withToken($this->token)
+            ->getJson("/v1/customers/{$this->customer->id}/assignments?role[0]=Key%20Account%20Manager");
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['role']);
+    });
+
     test('filters assignments by active status', function (): void {
         givePermissionWithTenant($this->user, $this->tenant->id, 'customers.read');
 

--- a/tests/Feature/Controllers/Api/V1/OrganizationalUnitControllerTest.php
+++ b/tests/Feature/Controllers/Api/V1/OrganizationalUnitControllerTest.php
@@ -156,6 +156,20 @@ describe('OrganizationalUnitController - List', function () {
             ->assertJsonPath('data.0.type', 'department');
     });
 
+    test('list organizational units returns 422 for an invalid type filter', function () {
+        $response = getJson('/v1/organizational-units?type=not-a-real-type');
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['type']);
+    });
+
+    test('list organizational units returns 422 for an invalid parent_id filter', function () {
+        $response = getJson('/v1/organizational-units?parent_id=not-a-uuid');
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['parent_id']);
+    });
+
     test('list organizational units includes parent data when accessible', function () {
         // Arrange: Create child unit under root
         $child = OrganizationalUnit::factory()->create([

--- a/tests/Feature/Controllers/Api/V1/OrganizationalUnitControllerTest.php
+++ b/tests/Feature/Controllers/Api/V1/OrganizationalUnitControllerTest.php
@@ -163,6 +163,21 @@ describe('OrganizationalUnitController - List', function () {
             ->assertJsonValidationErrors(['type']);
     });
 
+    test('list organizational units does not filter by null when type is sent as empty string', function () {
+        $dept = OrganizationalUnit::factory()->create([
+            'tenant_id' => $this->tenant->id,
+            'type' => 'department',
+        ]);
+        $dept->setParent($this->rootUnit);
+
+        // Sending ?type= coerces to null via the nullable rule;
+        // the filter must be skipped so all accessible units are returned.
+        $response = getJson('/v1/organizational-units?type=');
+
+        $response->assertOk();
+        expect($response->json('data'))->toHaveCount(2); // rootUnit + dept
+    });
+
     test('list organizational units returns 422 for an invalid parent_id filter', function () {
         $response = getJson('/v1/organizational-units?parent_id=not-a-uuid');
 

--- a/tests/Feature/Controllers/Api/V1/SiteAssignmentControllerTest.php
+++ b/tests/Feature/Controllers/Api/V1/SiteAssignmentControllerTest.php
@@ -134,6 +134,16 @@ describe('GET /v1/sites/{site}/assignments', function () {
         expect($response->json('data')[0]['role'])->toBe('Site Manager');
     });
 
+    test('returns 422 when role filter is not a string', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'sites.read');
+
+        $response = $this->withToken($this->token)
+            ->getJson("/v1/sites/{$this->site->id}/assignments?role[0]=Site%20Manager");
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['role']);
+    });
+
     test('filters assignments by active status', function (): void {
         givePermissionWithTenant($this->user, $this->tenant->id, 'sites.read');
 

--- a/tests/Feature/Controllers/QualificationControllerTest.php
+++ b/tests/Feature/Controllers/QualificationControllerTest.php
@@ -120,6 +120,16 @@ describe('GET /v1/qualifications', function () {
         expect($response->json('data')[0]['category'])->toBe('first_aid');
     });
 
+    test('returns 422 for an invalid category filter', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'qualification.read');
+
+        $response = $this->withToken($this->token)
+            ->getJson('/v1/qualifications?category=not-a-real-category');
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['category']);
+    });
+
     test('filters by is_mandatory', function (): void {
         givePermissionWithTenant($this->user, $this->tenant->id, 'qualification.read');
 

--- a/tests/Feature/Controllers/QualificationControllerTest.php
+++ b/tests/Feature/Controllers/QualificationControllerTest.php
@@ -130,6 +130,28 @@ describe('GET /v1/qualifications', function () {
             ->assertJsonValidationErrors(['category']);
     });
 
+    test('does not filter by null when category is sent as empty string', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'qualification.read');
+
+        Qualification::factory()->create([
+            'tenant_id' => $this->tenant->id,
+            'category' => 'first_aid',
+        ]);
+
+        Qualification::factory()->create([
+            'tenant_id' => $this->tenant->id,
+            'category' => 'fire_safety',
+        ]);
+
+        // Sending ?category= coerces to null via the nullable rule;
+        // the filter must be skipped so all qualifications are returned.
+        $response = $this->withToken($this->token)
+            ->getJson('/v1/qualifications?category=');
+
+        $response->assertStatus(200);
+        expect($response->json('data'))->toHaveCount(2);
+    });
+
     test('filters by is_mandatory', function (): void {
         givePermissionWithTenant($this->user, $this->tenant->id, 'qualification.read');
 


### PR DESCRIPTION
## Summary
- add dedicated index form requests for qualification, organizational-unit, customer-assignment, and site-assignment listing endpoints
- validate and whitelist the remaining query filters for those endpoints so invalid values fail fast with `422` responses
- keep the existing `IndexCustomerRequest` coverage from `main`; combine this stacked PR with the `per_page` cap base in PR #853 to complete the index-request coverage slice

## Testing
- php artisan test tests/Feature/Controllers/QualificationControllerTest.php tests/Feature/Controllers/Api/V1/OrganizationalUnitControllerTest.php tests/Feature/Controllers/Api/V1/CustomerAssignmentControllerTest.php tests/Feature/Controllers/Api/V1/SiteAssignmentControllerTest.php
- vendor/bin/pint --dirty

## Notes
- This branch is intentionally stacked on top of PR #853.
- The same code also closes the higher-priority validation finding tracked in PR #863; this PR keeps the best-practice issue reviewable on its own dependency chain.

Refs #845
