### PR TITLE
feat: add non-EU work permit core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- added the first `api#472` non-EU work-permit core slice: encrypted `work_permit_number` storage, richer work-permit types, conditional non-EU validation, work-authorization and expiring-document computed fields, factory states for permit-bearing employees, and GDPR-driven work-permit copy deletion when BWR approval or permanent authorization makes the copy unnecessary
 - added localized onboarding template schema responses for `/v1/onboarding/templates*`, including backend-managed English/German labels, descriptions, and enum display names with `preferred_locale` / `Accept-Language` fallback handling, so onboarding form text no longer needs to be frontend-owned
 - added the `employees:delete-expired` retention command for BewachV §21 / GDPR employee erasure, including tenant-scoped dry-run support, hard deletion of expired terminated employee records, local storage cleanup for employee and onboarding uploads, linked-user anonymization, and a daily scheduler hook after activity retention processing
 - Added the initial Android enrollment API slice for Epic SecPal/.github#327, including tenant-bound enrollment session storage, private QR/bootstrap token issuance, admin create/list/read/revoke endpoints, a public bootstrap exchange endpoint, and audited provisioning lifecycle events

--- a/app/Http/Requests/Concerns/InteractsWithWorkPermitValidation.php
+++ b/app/Http/Requests/Concerns/InteractsWithWorkPermitValidation.php
@@ -1,0 +1,76 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace App\Http\Requests\Concerns;
+
+use App\Models\Employee;
+
+trait InteractsWithWorkPermitValidation
+{
+    private function routeEmployee(): ?Employee
+    {
+        $employee = $this->route('employee');
+
+        return $employee instanceof Employee ? $employee : null;
+    }
+
+    private function mergedEmployeeValue(string $field): mixed
+    {
+        if ($this->exists($field)) {
+            return $this->input($field);
+        }
+
+        return $this->routeEmployee()?->getAttribute($field);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function mergedNationalities(): array
+    {
+        $nationalities = $this->mergedEmployeeValue('nationalities');
+        if (! is_array($nationalities)) {
+            return [];
+        }
+
+        return array_values(array_filter($nationalities, static fn (mixed $country): bool => is_string($country) && $country !== ''));
+    }
+
+    private function mergedWorkPermitType(): ?string
+    {
+        $type = $this->mergedEmployeeValue('work_permit_type');
+
+        return is_string($type) && $type !== '' ? $type : null;
+    }
+
+    private function requiresWorkPermitForCurrentPayload(): bool
+    {
+        foreach ($this->mergedNationalities() as $country) {
+            if (! in_array(strtoupper($country), Employee::NO_WORK_PERMIT_COUNTRIES, true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function requiresWorkPermitDetailsForCurrentPayload(): bool
+    {
+        $type = $this->mergedWorkPermitType();
+
+        return $this->requiresWorkPermitForCurrentPayload()
+            && is_string($type)
+            && $type !== Employee::WORK_PERMIT_TYPE_NONE;
+    }
+
+    private function requiresWorkPermitExpiryForCurrentPayload(): bool
+    {
+        $type = $this->mergedWorkPermitType();
+
+        return is_string($type)
+            && in_array($type, Employee::WORK_PERMIT_TYPES_REQUIRING_EXPIRY, true)
+            && $this->requiresWorkPermitForCurrentPayload();
+    }
+}

--- a/app/Http/Requests/Concerns/InteractsWithWorkPermitValidation.php
+++ b/app/Http/Requests/Concerns/InteractsWithWorkPermitValidation.php
@@ -73,4 +73,22 @@ trait InteractsWithWorkPermitValidation
             && in_array($type, Employee::WORK_PERMIT_TYPES_REQUIRING_EXPIRY, true)
             && $this->requiresWorkPermitForCurrentPayload();
     }
+
+    private function mergedValueIsBlank(string $field): bool
+    {
+        $value = $this->mergedEmployeeValue($field);
+
+        if ($value === null) {
+            return true;
+        }
+
+        return is_string($value) && trim($value) === '';
+    }
+
+    private function mergedWorkPermitTypeIsNoneOrBlank(): bool
+    {
+        $type = $this->mergedWorkPermitType();
+
+        return $type === null || $type === Employee::WORK_PERMIT_TYPE_NONE;
+    }
 }

--- a/app/Http/Requests/StoreEmployeeRequest.php
+++ b/app/Http/Requests/StoreEmployeeRequest.php
@@ -5,6 +5,7 @@
 
 namespace App\Http\Requests;
 
+use App\Http\Requests\Concerns\InteractsWithWorkPermitValidation;
 use App\Models\Employee;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
@@ -16,6 +17,8 @@ use Illuminate\Validation\Rule;
  */
 class StoreEmployeeRequest extends FormRequest
 {
+    use InteractsWithWorkPermitValidation;
+
     /**
      * Determine if the user is authorized to make this request.
      */
@@ -168,9 +171,29 @@ class StoreEmployeeRequest extends FormRequest
             'sachkunde_issued_date' => ['nullable', 'date'], // Certificate issue date
 
             // Work & Residence Permits
-            'work_permit_type' => ['nullable', Rule::in(['unlimited', 'limited', 'none'])],
-            'work_permit_number' => ['nullable', 'string', 'max:255'],
-            'work_permit_expiry' => ['nullable', 'date'],
+            'work_permit_type' => [
+                Rule::requiredIf(fn (): bool => $this->requiresWorkPermitForCurrentPayload()),
+                'nullable',
+                Rule::in(Employee::VALID_WORK_PERMIT_TYPES),
+            ],
+            'work_permit_number' => [
+                Rule::requiredIf(fn (): bool => $this->requiresWorkPermitDetailsForCurrentPayload()),
+                'nullable',
+                'string',
+                'max:255',
+            ],
+            'work_permit_expiry' => [
+                Rule::requiredIf(fn (): bool => $this->requiresWorkPermitExpiryForCurrentPayload()),
+                'nullable',
+                'date',
+                'after:today',
+            ],
+            'work_permit_issued_by' => [
+                Rule::requiredIf(fn (): bool => $this->requiresWorkPermitDetailsForCurrentPayload()),
+                'nullable',
+                'string',
+                'max:255',
+            ],
             'residence_permit_type' => ['nullable', Rule::in(['unlimited', 'limited', 'none'])],
             'residence_permit_number' => ['nullable', 'string', 'max:255'],
             'residence_permit_expiry' => ['nullable', 'date'],
@@ -263,6 +286,14 @@ class StoreEmployeeRequest extends FormRequest
             'address_history.*.city.required' => 'Stadt für Adresshistorie erforderlich.',
             'address_history.*.postal_code.required' => 'PLZ für Adresshistorie erforderlich.',
             'address_history.*.country.required' => 'Land für Adresshistorie erforderlich.',
+
+            // Work permits
+            'work_permit_type.required' => 'Arbeitserlaubnis-Typ ist für nicht freizügigkeitsberechtigte Staatsangehörigkeiten verpflichtend.',
+            'work_permit_type.in' => 'Arbeitserlaubnis-Typ ist ungültig.',
+            'work_permit_number.required' => 'Nummer der Arbeitserlaubnis ist verpflichtend.',
+            'work_permit_issued_by.required' => 'Ausstellende Behörde der Arbeitserlaubnis ist verpflichtend.',
+            'work_permit_expiry.required' => 'Ablaufdatum der Arbeitserlaubnis ist für befristete Arbeitserlaubnisse verpflichtend.',
+            'work_permit_expiry.after' => 'Ablaufdatum der Arbeitserlaubnis muss in der Zukunft liegen.',
         ];
     }
 }

--- a/app/Http/Requests/UpdateEmployeeRequest.php
+++ b/app/Http/Requests/UpdateEmployeeRequest.php
@@ -145,24 +145,24 @@ class UpdateEmployeeRequest extends FormRequest
 
             // Work & Residence Permits
             'work_permit_type' => [
-                Rule::requiredIf(fn (): bool => $this->touchesWorkPermitContext() && $this->requiresWorkPermitForCurrentPayload()),
+                Rule::requiredIf(fn (): bool => $this->touchesWorkPermitContext() && $this->requiresWorkPermitForCurrentPayload() && $this->mergedWorkPermitTypeIsNoneOrBlank()),
                 'nullable',
                 Rule::in(Employee::VALID_WORK_PERMIT_TYPES),
             ],
             'work_permit_number' => [
-                Rule::requiredIf(fn (): bool => $this->touchesWorkPermitContext() && $this->requiresWorkPermitDetailsForCurrentPayload()),
+                Rule::requiredIf(fn (): bool => $this->touchesWorkPermitContext() && $this->requiresWorkPermitDetailsForCurrentPayload() && $this->mergedValueIsBlank('work_permit_number')),
                 'nullable',
                 'string',
                 'max:255',
             ],
             'work_permit_expiry' => [
-                Rule::requiredIf(fn (): bool => $this->touchesWorkPermitContext() && $this->requiresWorkPermitExpiryForCurrentPayload()),
+                Rule::requiredIf(fn (): bool => $this->touchesWorkPermitContext() && $this->requiresWorkPermitExpiryForCurrentPayload() && $this->mergedEmployeeValue('work_permit_expiry') === null),
                 'nullable',
                 'date',
                 'after:today',
             ],
             'work_permit_issued_by' => [
-                Rule::requiredIf(fn (): bool => $this->touchesWorkPermitContext() && $this->requiresWorkPermitDetailsForCurrentPayload()),
+                Rule::requiredIf(fn (): bool => $this->touchesWorkPermitContext() && $this->requiresWorkPermitDetailsForCurrentPayload() && $this->mergedValueIsBlank('work_permit_issued_by')),
                 'nullable',
                 'string',
                 'max:255',

--- a/app/Http/Requests/UpdateEmployeeRequest.php
+++ b/app/Http/Requests/UpdateEmployeeRequest.php
@@ -5,6 +5,7 @@
 
 namespace App\Http\Requests;
 
+use App\Http\Requests\Concerns\InteractsWithWorkPermitValidation;
 use App\Models\Employee;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
@@ -17,6 +18,8 @@ use Illuminate\Validation\Rule;
  */
 class UpdateEmployeeRequest extends FormRequest
 {
+    use InteractsWithWorkPermitValidation;
+
     /**
      * Determine if the user is authorized to make this request.
      */
@@ -141,9 +144,29 @@ class UpdateEmployeeRequest extends FormRequest
             'sachkunde_issued_date' => ['sometimes', 'nullable', 'date'],
 
             // Work & Residence Permits
-            'work_permit_type' => ['sometimes', 'nullable', Rule::in(['unlimited', 'limited', 'none'])],
-            'work_permit_number' => ['sometimes', 'nullable', 'string', 'max:255'],
-            'work_permit_expiry' => ['sometimes', 'nullable', 'date'],
+            'work_permit_type' => [
+                Rule::requiredIf(fn (): bool => $this->touchesWorkPermitContext() && $this->requiresWorkPermitForCurrentPayload()),
+                'nullable',
+                Rule::in(Employee::VALID_WORK_PERMIT_TYPES),
+            ],
+            'work_permit_number' => [
+                Rule::requiredIf(fn (): bool => $this->touchesWorkPermitContext() && $this->requiresWorkPermitDetailsForCurrentPayload()),
+                'nullable',
+                'string',
+                'max:255',
+            ],
+            'work_permit_expiry' => [
+                Rule::requiredIf(fn (): bool => $this->touchesWorkPermitContext() && $this->requiresWorkPermitExpiryForCurrentPayload()),
+                'nullable',
+                'date',
+                'after:today',
+            ],
+            'work_permit_issued_by' => [
+                Rule::requiredIf(fn (): bool => $this->touchesWorkPermitContext() && $this->requiresWorkPermitDetailsForCurrentPayload()),
+                'nullable',
+                'string',
+                'max:255',
+            ],
             'residence_permit_type' => ['sometimes', 'nullable', Rule::in(['unlimited', 'limited', 'none'])],
             'residence_permit_number' => ['sometimes', 'nullable', 'string', 'max:255'],
             'residence_permit_expiry' => ['sometimes', 'nullable', 'date'],
@@ -210,6 +233,25 @@ class UpdateEmployeeRequest extends FormRequest
 
             // Address history
             'address_history.*.to.after_or_equal' => 'End-Datum muss nach Start-Datum liegen.',
+
+            // Work permits
+            'work_permit_type.required' => 'Arbeitserlaubnis-Typ ist für nicht freizügigkeitsberechtigte Staatsangehörigkeiten verpflichtend.',
+            'work_permit_type.in' => 'Arbeitserlaubnis-Typ ist ungültig.',
+            'work_permit_number.required' => 'Nummer der Arbeitserlaubnis ist verpflichtend.',
+            'work_permit_issued_by.required' => 'Ausstellende Behörde der Arbeitserlaubnis ist verpflichtend.',
+            'work_permit_expiry.required' => 'Ablaufdatum der Arbeitserlaubnis ist für befristete Arbeitserlaubnisse verpflichtend.',
+            'work_permit_expiry.after' => 'Ablaufdatum der Arbeitserlaubnis muss in der Zukunft liegen.',
         ];
+    }
+
+    private function touchesWorkPermitContext(): bool
+    {
+        foreach (['nationalities', 'work_permit_type', 'work_permit_number', 'work_permit_expiry', 'work_permit_issued_by'] as $field) {
+            if ($this->exists($field)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/app/Http/Resources/EmployeeResource.php
+++ b/app/Http/Resources/EmployeeResource.php
@@ -130,9 +130,15 @@ class EmployeeResource extends JsonResource
             'work_permit_type' => $this->work_permit_type,
             'work_permit_number' => $this->when($canReadSensitiveIdentifiers, fn () => $this->work_permit_number),
             'work_permit_expiry' => $this->work_permit_expiry?->toDateString(),
+            'work_permit_copy_path' => $this->work_permit_copy_path,
+            'work_permit_issued_by' => $this->work_permit_issued_by,
+            'work_permit_copy_deleted_at' => $this->work_permit_copy_deleted_at?->toIso8601String(),
             'residence_permit_type' => $this->residence_permit_type,
             'residence_permit_number' => $this->when($canReadSensitiveIdentifiers, fn () => $this->residence_permit_number),
             'residence_permit_expiry' => $this->residence_permit_expiry?->toDateString(),
+            'requires_work_permit' => $this->requiresWorkPermit(),
+            'has_valid_work_authorization' => $this->hasValidWorkAuthorization(),
+            'expiring_documents' => $this->expiring_documents->all(),
 
             // Criminal Record
             'criminal_record_status' => $this->criminal_record_status,

--- a/app/Models/Employee.php
+++ b/app/Models/Employee.php
@@ -15,6 +15,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Collection as SupportCollection;
 use Illuminate\Support\Facades\Auth;
 use Spatie\Activitylog\Models\Concerns\LogsActivity;
 use Spatie\Activitylog\Support\LogOptions;
@@ -85,9 +86,13 @@ use Spatie\Activitylog\Support\LogOptions;
  * @property string|null $sachkunde_ihk_number IHK identification number
  * @property ?\Illuminate\Support\Carbon $sachkunde_exam_date
  * @property ?\Illuminate\Support\Carbon $sachkunde_issued_date
- * @property string $work_permit_type unlimited|limited|none
+ * @property string $work_permit_type none|temporary|permanent|blue_card|seasonal|student
+ * @property string|null $work_permit_number_enc Encrypted work permit number
  * @property string|null $work_permit_number
  * @property ?\Illuminate\Support\Carbon $work_permit_expiry
+ * @property string|null $work_permit_copy_path Storage path for uploaded work permit copy
+ * @property string|null $work_permit_issued_by
+ * @property ?\Illuminate\Support\Carbon $work_permit_copy_deleted_at
  * @property string $residence_permit_type unlimited|limited|none
  * @property string|null $residence_permit_number
  * @property ?\Illuminate\Support\Carbon $residence_permit_expiry
@@ -125,10 +130,12 @@ use Spatie\Activitylog\Support\LogOptions;
  * @property-read string|null $address_city Decrypted city
  * @property-read string|null $address_supplement Decrypted address supplement
  * @property-read string|null $id_document_number Decrypted document number
+ * @property-read string|null $work_permit_number Decrypted work permit number
  * @property-read float|null $hourly_rate Decrypted hourly rate
  * @property-read string|null $tax_id Decrypted tax ID
  * @property-read string|null $social_security_number Decrypted social security number
  * @property-read string $full_name Full name (first + last)
+ * @property-read SupportCollection<int, array{type: string, label: string, expiry: string, status: string, days_until_expiry: int}> $expiring_documents
  * @property-read TenantKey $tenant
  * @property-read User|null $user
  * @property-read OrganizationalUnit|null $organizationalUnit
@@ -193,6 +200,43 @@ class Employee extends Model
     public const WORKFLOW_STATUS_READY_FOR_ACTIVATION = 'ready_for_activation';
 
     public const WORKFLOW_STATUS_ACTIVE = 'active';
+
+    public const WORK_PERMIT_TYPE_NONE = 'none';
+
+    public const WORK_PERMIT_TYPE_TEMPORARY = 'temporary';
+
+    public const WORK_PERMIT_TYPE_PERMANENT = 'permanent';
+
+    public const WORK_PERMIT_TYPE_BLUE_CARD = 'blue_card';
+
+    public const WORK_PERMIT_TYPE_SEASONAL = 'seasonal';
+
+    public const WORK_PERMIT_TYPE_STUDENT = 'student';
+
+    /** @var list<string> */
+    public const VALID_WORK_PERMIT_TYPES = [
+        self::WORK_PERMIT_TYPE_NONE,
+        self::WORK_PERMIT_TYPE_TEMPORARY,
+        self::WORK_PERMIT_TYPE_PERMANENT,
+        self::WORK_PERMIT_TYPE_BLUE_CARD,
+        self::WORK_PERMIT_TYPE_SEASONAL,
+        self::WORK_PERMIT_TYPE_STUDENT,
+    ];
+
+    /** @var list<string> */
+    public const WORK_PERMIT_TYPES_REQUIRING_EXPIRY = [
+        self::WORK_PERMIT_TYPE_TEMPORARY,
+        self::WORK_PERMIT_TYPE_BLUE_CARD,
+        self::WORK_PERMIT_TYPE_SEASONAL,
+        self::WORK_PERMIT_TYPE_STUDENT,
+    ];
+
+    /** @var list<string> */
+    public const NO_WORK_PERMIT_COUNTRIES = [
+        'AT', 'BE', 'BG', 'HR', 'CY', 'CZ', 'DK', 'EE', 'FI', 'FR', 'DE', 'GR', 'HU',
+        'IE', 'IT', 'LV', 'LT', 'LU', 'MT', 'NL', 'PL', 'PT', 'RO', 'SK', 'SI', 'ES', 'SE',
+        'IS', 'LI', 'NO', 'CH',
+    ];
 
     /** @var list<string> */
     public const VALID_WORKFLOW_STATUSES = [
@@ -333,8 +377,11 @@ class Employee extends Model
         'sachkunde_exam_date',
         'sachkunde_issued_date',
         'work_permit_type',
+        'work_permit_number_enc',
         'work_permit_number',
         'work_permit_expiry',
+        'work_permit_issued_by',
+        'work_permit_copy_deleted_at',
         'residence_permit_type',
         'residence_permit_number',
         'residence_permit_expiry',
@@ -381,6 +428,7 @@ class Employee extends Model
         'address_city_enc',
         'address_supplement_enc',
         'id_document_number_enc',
+        'work_permit_number_enc',
         'hourly_rate_enc',
         'tax_id_enc',
         'social_security_number_enc',
@@ -407,6 +455,7 @@ class Employee extends Model
             'address_city_enc' => \App\Casts\EncryptedWithDek::class,
             'address_supplement_enc' => \App\Casts\EncryptedWithDek::class,
             'id_document_number_enc' => \App\Casts\EncryptedWithDek::class,
+            'work_permit_number_enc' => \App\Casts\EncryptedWithDek::class,
             'hourly_rate_enc' => \App\Casts\EncryptedWithDek::class,
             'tax_id_enc' => \App\Casts\EncryptedWithDek::class,
             'social_security_number_enc' => \App\Casts\EncryptedWithDek::class,
@@ -431,6 +480,7 @@ class Employee extends Model
             'id_document_expiry' => 'date',
             'id_document_copy_deleted_at' => 'datetime',
             'work_permit_expiry' => 'date',
+            'work_permit_copy_deleted_at' => 'datetime',
             'residence_permit_expiry' => 'date',
             'criminal_record_check_date' => 'date',
             // Decimals
@@ -586,6 +636,9 @@ class Employee extends Model
             }
             if ($employee->isDirty('id_document_number_enc') && $employee->hasActuallyChanged('id_document_number')) {
                 $changedFields[] = 'id_document_number';
+            }
+            if ($employee->isDirty('work_permit_number_enc') && $employee->hasActuallyChanged('work_permit_number')) {
+                $changedFields[] = 'work_permit_number';
             }
             if ($employee->isDirty('hourly_rate_enc') && $employee->hasActuallyChanged('hourly_rate')) {
                 $changedFields[] = 'hourly_rate';
@@ -968,6 +1021,22 @@ class Employee extends Model
     }
 
     /**
+     * Get decrypted work permit number (via EncryptedWithDek cast).
+     */
+    public function getWorkPermitNumberAttribute(): ?string
+    {
+        return $this->work_permit_number_enc;
+    }
+
+    /**
+     * Set plaintext work permit number - Cast handles encryption.
+     */
+    public function setWorkPermitNumberAttribute(?string $value): void
+    {
+        $this->work_permit_number_enc = $value;
+    }
+
+    /**
      * Get complete structured address as formatted string.
      *
      * @return string|null Formatted address or null if no address data
@@ -986,6 +1055,82 @@ class Employee extends Model
         ]);
 
         return implode(', ', $parts);
+    }
+
+    public function requiresWorkPermit(): bool
+    {
+        $nationalities = $this->nationalities;
+        if (! is_array($nationalities)) {
+            return false;
+        }
+
+        foreach ($nationalities as $country) {
+            if (is_string($country) && ! in_array(strtoupper($country), self::NO_WORK_PERMIT_COUNTRIES, true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function hasValidWorkAuthorization(): bool
+    {
+        if (! $this->requiresWorkPermit()) {
+            return true;
+        }
+
+        if (! is_string($this->work_permit_type)
+            || $this->work_permit_type === self::WORK_PERMIT_TYPE_NONE
+            || ! is_string($this->work_permit_number)
+            || trim($this->work_permit_number) === '') {
+            return false;
+        }
+
+        if ($this->work_permit_type === self::WORK_PERMIT_TYPE_PERMANENT) {
+            return true;
+        }
+
+        return $this->work_permit_expiry?->isFuture() ?? false;
+    }
+
+    /**
+     * @return SupportCollection<int, array{type: string, label: string, expiry: string, status: string, days_until_expiry: int}>
+     */
+    public function getExpiringDocumentsAttribute(): SupportCollection
+    {
+        $documents = [];
+
+        $this->appendExpiringDocument($documents, 'work_permit', 'Work Permit', $this->work_permit_expiry);
+        $this->appendExpiringDocument($documents, 'residence_permit', 'Residence Permit', $this->residence_permit_expiry);
+        $this->appendExpiringDocument($documents, 'id_document', 'ID Document', $this->id_document_expiry);
+
+        /** @var SupportCollection<int, array{type: string, label: string, expiry: string, status: string, days_until_expiry: int}> $collection */
+        $collection = collect($documents)->sortBy('expiry')->values();
+
+        return $collection;
+    }
+
+    /**
+     * @param  array<int, array{type: string, label: string, expiry: string, status: string, days_until_expiry: int}>  $documents
+     */
+    private function appendExpiringDocument(array &$documents, string $type, string $label, mixed $expiry): void
+    {
+        if (! $expiry instanceof \Illuminate\Support\Carbon) {
+            return;
+        }
+
+        $daysUntilExpiry = (int) now()->startOfDay()->diffInDays($expiry->copy()->startOfDay(), false);
+        if ($daysUntilExpiry > 30) {
+            return;
+        }
+
+        $documents[] = [
+            'type' => $type,
+            'label' => $label,
+            'expiry' => $expiry->toDateString(),
+            'status' => $daysUntilExpiry < 0 ? 'expired' : ($daysUntilExpiry <= 7 ? 'critical' : 'warning'),
+            'days_until_expiry' => $daysUntilExpiry,
+        ];
     }
 
     // === STATUS STATE MACHINE ===

--- a/app/Models/Employee.php
+++ b/app/Models/Employee.php
@@ -1120,7 +1120,7 @@ class Employee extends Model
         }
 
         $daysUntilExpiry = (int) now()->startOfDay()->diffInDays($expiry->copy()->startOfDay(), false);
-        if ($daysUntilExpiry > 30) {
+        if ($daysUntilExpiry < -30 || $daysUntilExpiry > 30) {
             return;
         }
 

--- a/app/Observers/EmployeeObserver.php
+++ b/app/Observers/EmployeeObserver.php
@@ -94,6 +94,16 @@ class EmployeeObserver
 
             if ($newBwrStatus === 'active' && $oldBwrStatus !== 'active') {
                 $this->deleteIdDocumentCopy($employee);
+                $this->deleteWorkPermitCopy($employee, 'BWR approved');
+            }
+        }
+
+        if ($employee->isDirty('work_permit_type')) {
+            $oldPermitType = $employee->getOriginal('work_permit_type');
+            $newPermitType = $employee->work_permit_type;
+
+            if ($newPermitType === Employee::WORK_PERMIT_TYPE_PERMANENT && $oldPermitType !== Employee::WORK_PERMIT_TYPE_PERMANENT) {
+                $this->deleteWorkPermitCopy($employee, 'Permanent permit granted');
             }
         }
 
@@ -284,6 +294,66 @@ class EmployeeObserver
             ]);
             // Don't throw - allow BWR status transition to proceed
             // HR can manually delete file via admin panel
+        }
+    }
+
+    /**
+     * Delete work permit copy when BWR approval or a permanent permit makes it unnecessary.
+     */
+    private function deleteWorkPermitCopy(Employee $employee, string $trigger): void
+    {
+        if (! $employee->work_permit_copy_path) {
+            return;
+        }
+
+        if ($employee->work_permit_copy_deleted_at !== null) {
+            return;
+        }
+
+        $normalizedPath = str_replace('\\', '/', $employee->work_permit_copy_path);
+        if (! str_starts_with($normalizedPath, 'work_permits/')
+            && ! str_starts_with($normalizedPath, 'employees/')
+            && ! str_starts_with($normalizedPath, 'documents/')) {
+            Log::warning('Suspicious work_permit_copy_path detected - refusing to delete', [
+                'employee_id' => $employee->id,
+                'employee_number' => $employee->employee_number,
+                'path' => $employee->work_permit_copy_path,
+            ]);
+
+            return;
+        }
+
+        try {
+            if (Storage::exists($employee->work_permit_copy_path)) {
+                Storage::delete($employee->work_permit_copy_path);
+                Log::info('Work permit copy deleted', [
+                    'employee_id' => $employee->id,
+                    'employee_number' => $employee->employee_number,
+                    'trigger' => $trigger,
+                    'file_path' => $employee->work_permit_copy_path,
+                    'legal_basis' => 'GDPR Art. 5(1)(e) - Storage Limitation',
+                ]);
+            }
+
+            $employee->updateQuietly([
+                'work_permit_copy_deleted_at' => now(),
+            ]);
+
+            activity('employee_changes')
+                ->performedOn($employee)
+                ->withProperties([
+                    'action' => 'work_permit_auto_deleted',
+                    'trigger' => $trigger,
+                    'legal_basis' => 'GDPR Art. 5(1)(e) - Storage Limitation',
+                    'reason' => 'Work permit copy no longer necessary for BWR or permanent authorization evidence',
+                ])
+                ->log('Work permit copy automatically deleted');
+        } catch (\Exception $e) {
+            Log::error('Work permit deletion failed', [
+                'employee_id' => $employee->id,
+                'file_path' => $employee->work_permit_copy_path,
+                'error' => $e->getMessage(),
+            ]);
         }
     }
 

--- a/database/factories/EmployeeFactory.php
+++ b/database/factories/EmployeeFactory.php
@@ -166,7 +166,7 @@ class EmployeeFactory extends Factory
     public function withCompleteBewachvData(): static
     {
         $germanCities = ['Berlin', 'Hamburg', 'München', 'Köln', 'Frankfurt', 'Stuttgart', 'Düsseldorf'];
-        $europeanCountries = ['DE', 'PL', 'RO', 'TR', 'IT', 'GR', 'BG'];
+        $europeanCountries = ['DE', 'PL', 'RO', 'IT', 'GR', 'BG'];
 
         return $this->state(fn (array $attributes) => [
             // BWR Registration
@@ -181,7 +181,7 @@ class EmployeeFactory extends Factory
             'previous_names' => fake()->optional(0.2)->randomElements([fake()->lastName(), fake()->lastName()], 1), // 20% have previous names
             'birth_city' => fake()->randomElement($germanCities),
             'birth_country' => fake()->randomElement($europeanCountries),
-            'nationalities' => fake()->randomElement([['DE'], ['DE', 'PL'], ['DE', 'TR']]), // Dual citizenship
+            'nationalities' => fake()->randomElement([['DE'], ['DE', 'PL'], ['DE', 'IT']]), // Dual citizenship
 
             // Structured Address
             'address_street' => fake()->streetName(),
@@ -272,10 +272,53 @@ class EmployeeFactory extends Factory
     {
         return $this->state(fn (array $attributes) => [
             'sachkunde_type' => fake()->randomElement(['§34a_old', '§34a_new', 'none']),
-            'sachkunde_certificate_number' => fake()->bothify('SK-#######'),
+            'sachkunde_certificate' => fake()->bothify('SK-#######'),
             'sachkunde_issued_date' => fake()->date('Y-m-d', '-2 years'),
-            'work_permit' => fake()->boolean(80), // 80% have work permit
-            'work_permit_expiry' => fake()->date('Y-m-d', '+1 year'),
+        ]);
+    }
+
+    /**
+     * Indicate that the employee is a non-EU worker with a valid work permit.
+     */
+    public function withNonEuWorkPermit(): static
+    {
+        $permitType = fake()->randomElement([
+            Employee::WORK_PERMIT_TYPE_TEMPORARY,
+            Employee::WORK_PERMIT_TYPE_PERMANENT,
+            Employee::WORK_PERMIT_TYPE_BLUE_CARD,
+            Employee::WORK_PERMIT_TYPE_SEASONAL,
+            Employee::WORK_PERMIT_TYPE_STUDENT,
+        ]);
+
+        return $this->state(function (array $attributes) use ($permitType): array {
+            $nationality = fake()->randomElement(['TR', 'RS', 'UA', 'IN']);
+
+            return [
+                'birth_country' => $nationality,
+                'nationalities' => [$nationality],
+                'work_permit_type' => $permitType,
+                'work_permit_number' => fake()->bothify('WP-######'),
+                'work_permit_expiry' => $permitType === Employee::WORK_PERMIT_TYPE_PERMANENT
+                    ? null
+                    : fake()->dateTimeBetween('+2 months', '+2 years'),
+                'work_permit_copy_path' => 'work_permits/'.fake()->uuid().'.pdf',
+                'work_permit_issued_by' => fake()->randomElement([
+                    'Auslaenderbehoerde Berlin',
+                    'Auslaenderbehoerde Hamburg',
+                    'Auslaenderbehoerde Muenchen',
+                ]),
+            ];
+        });
+    }
+
+    /**
+     * Indicate that the employee has a work permit expiring soon.
+     */
+    public function withExpiringWorkPermit(): static
+    {
+        return $this->withNonEuWorkPermit()->state(fn (array $attributes) => [
+            'work_permit_type' => Employee::WORK_PERMIT_TYPE_TEMPORARY,
+            'work_permit_expiry' => fake()->dateTimeBetween('+1 day', '+30 days'),
         ]);
     }
 

--- a/database/migrations/2026_04_12_150000_add_non_eu_work_permit_core_to_employees_table.php
+++ b/database/migrations/2026_04_12_150000_add_non_eu_work_permit_core_to_employees_table.php
@@ -1,0 +1,161 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use App\Models\TenantKey;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('employees', function (Blueprint $table) {
+            $table->text('work_permit_number_enc')->nullable()->after('work_permit_type');
+            $table->string('work_permit_copy_path')->nullable()->after('work_permit_expiry');
+            $table->string('work_permit_issued_by', 255)->nullable()->after('work_permit_copy_path');
+            $table->timestamp('work_permit_copy_deleted_at')->nullable()->after('work_permit_issued_by');
+        });
+
+        /** @var Illuminate\Database\Eloquent\Collection<int, TenantKey> $tenantKeys */
+        $tenantKeys = TenantKey::all()->keyBy('id');
+
+        DB::table('employees')
+            ->select(['id', 'tenant_id', 'work_permit_number'])
+            ->whereNotNull('work_permit_number')
+            ->orderBy('id')
+            ->chunk(100, function ($employees) use ($tenantKeys): void {
+                foreach ($employees as $employee) {
+                    if (! is_string($employee->work_permit_number) || $employee->work_permit_number === '') {
+                        continue;
+                    }
+
+                    $tenantId = $employee->tenant_id;
+                    if (! is_numeric($tenantId)) {
+                        throw new RuntimeException('Unexpected non-numeric tenant_id in employees table.');
+                    }
+
+                    $tenantKey = $tenantKeys->get((int) $tenantId);
+                    if (! $tenantKey instanceof TenantKey) {
+                        throw new RuntimeException("TenantKey not found for tenant {$tenantId}.");
+                    }
+
+                    $encryptedPermit = $tenantKey->encrypt($employee->work_permit_number);
+                    $encodedPermit = json_encode([
+                        'ciphertext' => base64_encode($encryptedPermit['ciphertext']),
+                        'nonce' => base64_encode($encryptedPermit['nonce']),
+                    ]);
+
+                    if ($encodedPermit === false) {
+                        throw new RuntimeException('Failed to encode encrypted work permit number.');
+                    }
+
+                    DB::table('employees')
+                        ->where('id', $employee->id)
+                        ->update([
+                            'work_permit_number_enc' => $encodedPermit,
+                        ]);
+                }
+            });
+
+        DB::statement('ALTER TABLE employees DROP CONSTRAINT IF EXISTS employees_work_permit_type_check');
+
+        DB::table('employees')
+            ->where('work_permit_type', 'unlimited')
+            ->update(['work_permit_type' => 'permanent']);
+
+        DB::table('employees')
+            ->where('work_permit_type', 'limited')
+            ->update(['work_permit_type' => 'temporary']);
+
+        DB::statement(<<<'SQL'
+            ALTER TABLE employees
+            ADD CONSTRAINT employees_work_permit_type_check
+            CHECK (work_permit_type IN ('none', 'temporary', 'permanent', 'blue_card', 'seasonal', 'student'))
+        SQL);
+
+        Schema::table('employees', function (Blueprint $table) {
+            $table->dropColumn('work_permit_number');
+            $table->index('work_permit_expiry', 'idx_employees_work_permit_expiry');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('employees', function (Blueprint $table) {
+            $table->string('work_permit_number')->nullable()->after('work_permit_type');
+        });
+
+        DB::table('employees')
+            ->select(['id', 'tenant_id', 'work_permit_number_enc'])
+            ->whereNotNull('work_permit_number_enc')
+            ->orderBy('id')
+            ->chunk(100, function ($employees): void {
+                foreach ($employees as $employee) {
+                    if (! is_string($employee->work_permit_number_enc)) {
+                        continue;
+                    }
+
+                    $decodedPermit = json_decode($employee->work_permit_number_enc, true);
+                    if (! is_array($decodedPermit)
+                        || ! isset($decodedPermit['ciphertext'], $decodedPermit['nonce'])
+                        || ! is_string($decodedPermit['ciphertext'])
+                        || ! is_string($decodedPermit['nonce'])) {
+                        throw new RuntimeException('Invalid encrypted work permit payload.');
+                    }
+
+                    $ciphertext = base64_decode($decodedPermit['ciphertext'], true);
+                    $nonce = base64_decode($decodedPermit['nonce'], true);
+
+                    if (! is_string($ciphertext) || ! is_string($nonce)) {
+                        throw new RuntimeException('Failed to decode encrypted work permit payload.');
+                    }
+
+                    /** @var TenantKey $tenantKey */
+                    $tenantKey = TenantKey::findOrFail($employee->tenant_id);
+                    $permitNumber = $tenantKey->decrypt($ciphertext, $nonce);
+
+                    DB::table('employees')
+                        ->where('id', $employee->id)
+                        ->update([
+                            'work_permit_number' => $permitNumber,
+                        ]);
+                }
+            });
+
+        DB::statement('ALTER TABLE employees DROP CONSTRAINT IF EXISTS employees_work_permit_type_check');
+
+        DB::table('employees')
+            ->where('work_permit_type', 'permanent')
+            ->update(['work_permit_type' => 'unlimited']);
+
+        DB::table('employees')
+            ->whereIn('work_permit_type', ['temporary', 'blue_card', 'seasonal', 'student'])
+            ->update(['work_permit_type' => 'limited']);
+
+        DB::statement(<<<'SQL'
+            ALTER TABLE employees
+            ADD CONSTRAINT employees_work_permit_type_check
+            CHECK (work_permit_type IN ('none', 'limited', 'unlimited'))
+        SQL);
+
+        Schema::table('employees', function (Blueprint $table) {
+            $table->dropIndex('idx_employees_work_permit_expiry');
+            $table->dropColumn([
+                'work_permit_number_enc',
+                'work_permit_copy_path',
+                'work_permit_issued_by',
+                'work_permit_copy_deleted_at',
+            ]);
+        });
+    }
+};

--- a/docs/BEWACHV_COMPLIANCE.md
+++ b/docs/BEWACHV_COMPLIANCE.md
@@ -245,6 +245,20 @@ $employee->structured_address;
 // Returns: "Hauptstraße 42, 10115 Berlin, DE"
 ```
 
+### Non-EU Work Authorization Core
+
+SecPal now tracks the P0 work-permit core for non-EU employees directly on the employee record.
+
+- `work_permit_type` supports `temporary`, `permanent`, `blue_card`, `seasonal`, `student`, and `none`
+- `work_permit_number` is encrypted at rest as `work_permit_number_enc`
+- `work_permit_issued_by`, `work_permit_copy_path`, and `work_permit_copy_deleted_at` support operational evidence plus GDPR auditability
+- `requiresWorkPermit()` and `hasValidWorkAuthorization()` enforce the exemption list for EU/EEA/CH nationalities
+- `expiring_documents` exposes work-permit, residence-permit, and ID-document expiries within the next 30 days
+
+**Exempt nationalities (no work permit required):** `AT`, `BE`, `BG`, `HR`, `CY`, `CZ`, `DK`, `EE`, `FI`, `FR`, `DE`, `GR`, `HU`, `IE`, `IT`, `LV`, `LT`, `LU`, `MT`, `NL`, `PL`, `PT`, `RO`, `SK`, `SI`, `ES`, `SE`, `IS`, `LI`, `NO`, `CH`
+
+**Deletion trigger:** uploaded work-permit copies are deleted automatically once BWR status becomes `active` or the permit type changes to `permanent`, matching the same GDPR storage-limitation pattern already used for ID-document copies.
+
 ---
 
 ## Auto-Deletion Workflow

--- a/tests/Feature/BewachvEmployeeFieldsValidationTest.php
+++ b/tests/Feature/BewachvEmployeeFieldsValidationTest.php
@@ -62,6 +62,29 @@ function makeStoreEmployeeValidator(object $testCase, array $data): Illuminate\C
     );
 }
 
+function makeUpdateEmployeeValidator(object $testCase, Employee $employee, array $data): Illuminate\Contracts\Validation\Validator
+{
+    $request = UpdateEmployeeRequest::create("/v1/employees/{$employee->id}", 'PATCH', $data);
+    $request->setUserResolver(fn (): User => $testCase->user);
+    $request->setRouteResolver(function () use ($employee) {
+        return new class($employee)
+        {
+            public function __construct(private Employee $employee) {}
+
+            public function parameter($key)
+            {
+                return $key === 'employee' ? $this->employee : null;
+            }
+        };
+    });
+
+    return Validator::make(
+        $request->all(),
+        $request->rules(),
+        $request->messages()
+    );
+}
+
 test('BWR-ID must be exactly 7 digits', function () {
     $baseData = validStoreEmployeeData($this);
 
@@ -189,6 +212,104 @@ test('nationalities array items must be valid ISO codes', function () {
     expect($validator->errors()->has('nationalities'))->toBeFalse()
         ->and($validator->errors()->has('nationalities.0'))->toBeFalse()
         ->and($validator->errors()->has('nationalities.1'))->toBeFalse();
+});
+
+test('work permit type is required for non exempt nationalities', function () {
+    $validator = makeStoreEmployeeValidator($this, validStoreEmployeeData($this, [
+        'email' => 'turkish.employee@example.com',
+        'nationalities' => ['TR'],
+    ]));
+
+    expect($validator->fails())->toBeTrue()
+        ->and($validator->errors()->has('work_permit_type'))->toBeTrue();
+});
+
+test('temporary non exempt work permits require number issuing authority and future expiry', function () {
+    $validator = makeStoreEmployeeValidator($this, validStoreEmployeeData($this, [
+        'email' => 'temporary.employee@example.com',
+        'nationalities' => ['TR'],
+        'work_permit_type' => 'temporary',
+    ]));
+
+    expect($validator->fails())->toBeTrue()
+        ->and($validator->errors()->has('work_permit_number'))->toBeTrue()
+        ->and($validator->errors()->has('work_permit_issued_by'))->toBeTrue()
+        ->and($validator->errors()->has('work_permit_expiry'))->toBeTrue();
+
+    $expiredValidator = makeStoreEmployeeValidator($this, validStoreEmployeeData($this, [
+        'email' => 'expired.employee@example.com',
+        'nationalities' => ['TR'],
+        'work_permit_type' => 'temporary',
+        'work_permit_number' => 'WP-123456',
+        'work_permit_issued_by' => 'Auslaenderbehoerde Berlin',
+        'work_permit_expiry' => now()->subDay()->toDateString(),
+    ]));
+
+    expect($expiredValidator->fails())->toBeTrue()
+        ->and($expiredValidator->errors()->has('work_permit_expiry'))->toBeTrue();
+
+    $validValidator = makeStoreEmployeeValidator($this, validStoreEmployeeData($this, [
+        'email' => 'valid.employee@example.com',
+        'nationalities' => ['TR'],
+        'work_permit_type' => 'temporary',
+        'work_permit_number' => 'WP-654321',
+        'work_permit_issued_by' => 'Auslaenderbehoerde Berlin',
+        'work_permit_expiry' => now()->addMonths(6)->toDateString(),
+    ]));
+
+    expect($validValidator->passes())->toBeTrue();
+});
+
+test('permanent non exempt work permits do not require an expiry date', function () {
+    $validator = makeStoreEmployeeValidator($this, validStoreEmployeeData($this, [
+        'email' => 'permanent.employee@example.com',
+        'nationalities' => ['TR'],
+        'work_permit_type' => 'permanent',
+        'work_permit_number' => 'WP-777777',
+        'work_permit_issued_by' => 'Auslaenderbehoerde Berlin',
+    ]));
+
+    expect($validator->passes())->toBeTrue();
+});
+
+test('eea and swiss nationalities are exempt from work permit requirement', function () {
+    $swissValidator = makeStoreEmployeeValidator($this, validStoreEmployeeData($this, [
+        'email' => 'swiss.employee@example.com',
+        'nationalities' => ['CH'],
+    ]));
+
+    $norwegianValidator = makeStoreEmployeeValidator($this, validStoreEmployeeData($this, [
+        'email' => 'norwegian.employee@example.com',
+        'nationalities' => ['NO'],
+    ]));
+
+    expect($swissValidator->errors()->has('work_permit_type'))->toBeFalse()
+        ->and($norwegianValidator->errors()->has('work_permit_type'))->toBeFalse();
+});
+
+test('UpdateEmployeeRequest enforces work permit rules when patching employee into non exempt nationality', function () {
+    $employee = Employee::factory()->create([
+        'tenant_id' => $this->tenant->id,
+        'organizational_unit_id' => $this->organizationalUnit->id,
+        'nationalities' => ['DE'],
+        'work_permit_type' => 'none',
+    ]);
+
+    $validator = makeUpdateEmployeeValidator($this, $employee, [
+        'nationalities' => ['TR'],
+    ]);
+
+    expect($validator->fails())->toBeTrue()
+        ->and($validator->errors()->has('work_permit_type'))->toBeTrue();
+
+    $validValidator = makeUpdateEmployeeValidator($this, $employee, [
+        'nationalities' => ['TR'],
+        'work_permit_type' => 'permanent',
+        'work_permit_number' => 'WP-987654',
+        'work_permit_issued_by' => 'Auslaenderbehoerde Berlin',
+    ]);
+
+    expect($validValidator->passes())->toBeTrue();
 });
 
 test('validation messages are in German', function () {

--- a/tests/Unit/Factories/EmployeeFactoryBewachvTest.php
+++ b/tests/Unit/Factories/EmployeeFactoryBewachvTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-// SPDX-FileCopyrightText: 2025 SecPal Contributors
+// SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use App\Models\Employee;
@@ -90,6 +90,24 @@ test('withAddressHistory creates historical addresses', function () {
             ->and($address['postal_code'])->toBeString()
             ->and($address['country'])->toMatch('/^[A-Z]{2}$/');
     }
+});
+
+test('withNonEuWorkPermit creates permit compliant non EU employee data', function () {
+    $employee = Employee::factory()->withNonEuWorkPermit()->create();
+
+    expect($employee->requiresWorkPermit())->toBeTrue()
+        ->and($employee->work_permit_type)->toBeIn(['temporary', 'permanent', 'blue_card', 'seasonal', 'student'])
+        ->and($employee->work_permit_number)->not->toBeNull()
+        ->and($employee->work_permit_issued_by)->not->toBeNull()
+        ->and($employee->hasValidWorkAuthorization())->toBeTrue();
+});
+
+test('withExpiringWorkPermit creates a permit that expires within 30 days', function () {
+    $employee = Employee::factory()->withExpiringWorkPermit()->create();
+
+    expect($employee->work_permit_expiry)->not->toBeNull()
+        ->and($employee->work_permit_expiry->isBefore(now()->addDays(31)))->toBeTrue()
+        ->and($employee->expiring_documents->pluck('type')->all())->toContain('work_permit');
 });
 
 test('terminated factory state sets employment end date', function () {

--- a/tests/Unit/Models/EmployeeModelBewachvFieldsTest.php
+++ b/tests/Unit/Models/EmployeeModelBewachvFieldsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-// SPDX-FileCopyrightText: 2025 SecPal Contributors
+// SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use App\Models\Employee;
@@ -49,6 +49,18 @@ test('it encrypts and decrypts id document number', function () {
     expect($this->employee->id_document_number)->toEqual($docNumber);
 });
 
+test('it encrypts and decrypts work permit number', function () {
+    $permitNumber = 'WP-TR-12345';
+    $this->employee->work_permit_number = $permitNumber;
+    $this->employee->save();
+
+    expect($this->employee->getAttributes()['work_permit_number_enc'])->not->toEqual($permitNumber)
+        ->and($this->employee->getAttributes()['work_permit_number_enc'])->not->toBeNull();
+
+    $this->employee->refresh();
+    expect($this->employee->work_permit_number)->toEqual($permitNumber);
+});
+
 test('it formats structured address correctly', function () {
     $this->employee->update([
         'address_street' => 'Hauptstraße',
@@ -70,6 +82,72 @@ test('it casts nationalities to array', function () {
     $this->employee->refresh();
     expect($this->employee->nationalities)->toBeArray()
         ->and($this->employee->nationalities)->toEqual($nationalities);
+});
+
+test('it determines whether a work permit is required from nationalities', function () {
+    $this->employee->nationalities = ['DE'];
+    $this->employee->save();
+
+    expect($this->employee->requiresWorkPermit())->toBeFalse();
+
+    $this->employee->nationalities = ['TR'];
+    $this->employee->save();
+
+    expect($this->employee->requiresWorkPermit())->toBeTrue();
+});
+
+test('it determines whether work authorization is valid for non eu employees', function () {
+    $this->employee->update([
+        'nationalities' => ['TR'],
+        'work_permit_type' => 'none',
+        'work_permit_number' => null,
+        'work_permit_expiry' => null,
+    ]);
+
+    expect($this->employee->fresh()->hasValidWorkAuthorization())->toBeFalse();
+
+    $this->employee->update([
+        'work_permit_type' => 'permanent',
+        'work_permit_number' => 'WP-VALID-1',
+        'work_permit_issued_by' => 'Auslaenderbehoerde Berlin',
+        'work_permit_expiry' => null,
+    ]);
+
+    expect($this->employee->fresh()->hasValidWorkAuthorization())->toBeTrue();
+
+    $this->employee->update([
+        'work_permit_type' => 'temporary',
+        'work_permit_expiry' => now()->subDay()->toDateString(),
+    ]);
+
+    expect($this->employee->fresh()->hasValidWorkAuthorization())->toBeFalse();
+
+    $this->employee->update([
+        'nationalities' => ['DE'],
+        'work_permit_type' => 'none',
+        'work_permit_number' => null,
+        'work_permit_expiry' => null,
+    ]);
+
+    expect($this->employee->fresh()->hasValidWorkAuthorization())->toBeTrue();
+});
+
+test('it returns expiring compliance documents within 30 days', function () {
+    $this->employee->update([
+        'nationalities' => ['TR'],
+        'work_permit_type' => 'temporary',
+        'work_permit_number' => 'WP-EXP-1',
+        'work_permit_issued_by' => 'Auslaenderbehoerde Berlin',
+        'work_permit_expiry' => now()->addDays(5)->toDateString(),
+        'residence_permit_expiry' => now()->subDay()->toDateString(),
+        'id_document_expiry' => now()->addDays(45)->toDateString(),
+    ]);
+
+    $documents = $this->employee->fresh()->expiring_documents;
+
+    expect($documents)->toBeInstanceOf(Illuminate\Support\Collection::class)
+        ->and($documents->pluck('type')->all())->toContain('work_permit', 'residence_permit')
+        ->and($documents->pluck('type')->all())->not->toContain('id_document');
 });
 
 test('it casts address history to array', function () {

--- a/tests/Unit/Observers/EmployeeObserverBewachvTest.php
+++ b/tests/Unit/Observers/EmployeeObserverBewachvTest.php
@@ -1,6 +1,6 @@
 <?php
 
-// SPDX-FileCopyrightText: 2025 SecPal Contributors
+// SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use App\Models\Employee;
@@ -66,6 +66,38 @@ test('it does not fail when id document copy path is null', function () {
     $employee->save();
 
     expect($employee->fresh()->id_document_copy_deleted_at)->toBeNull();
+});
+
+test('it deletes work permit copy when bwr status becomes active', function () {
+    $employee = Employee::factory()->withNonEuWorkPermit()->create([
+        'bwr_status' => 'pending',
+        'work_permit_copy_path' => 'work_permits/test.pdf',
+    ]);
+    Storage::put('work_permits/test.pdf', 'permit content');
+
+    expect(Storage::exists('work_permits/test.pdf'))->toBeTrue();
+
+    $employee->bwr_status = 'active';
+    $employee->save();
+
+    expect(Storage::exists('work_permits/test.pdf'))->toBeFalse();
+    expect($employee->fresh()->work_permit_copy_deleted_at)->not->toBeNull();
+});
+
+test('it deletes work permit copy when permit becomes permanent', function () {
+    $employee = Employee::factory()->withNonEuWorkPermit()->create([
+        'work_permit_type' => 'temporary',
+        'work_permit_expiry' => now()->addMonths(3)->toDateString(),
+        'work_permit_copy_path' => 'work_permits/permanent.pdf',
+    ]);
+    Storage::put('work_permits/permanent.pdf', 'permit content');
+
+    $employee->work_permit_type = 'permanent';
+    $employee->work_permit_expiry = null;
+    $employee->save();
+
+    expect(Storage::exists('work_permits/permanent.pdf'))->toBeFalse();
+    expect($employee->fresh()->work_permit_copy_deleted_at)->not->toBeNull();
 });
 
 test('it calculates retention period when employee is terminated', function () {

--- a/tests/Unit/Resources/EmployeeResourceBewachvTest.php
+++ b/tests/Unit/Resources/EmployeeResourceBewachvTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-// SPDX-FileCopyrightText: 2025 SecPal Contributors
+// SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use App\Http\Resources\EmployeeResource;
@@ -83,6 +83,17 @@ test('EmployeeResource includes all BewachV fields', function () {
     expect($array)->toHaveKey('sachkunde_ihk_number')
         ->and($array)->toHaveKey('sachkunde_exam_date')
         ->and($array)->toHaveKey('sachkunde_issued_date');
+
+    // Work permit compliance
+    expect($array)->toHaveKey('work_permit_type')
+        ->and($array)->toHaveKey('work_permit_number')
+        ->and($array)->toHaveKey('work_permit_expiry')
+        ->and($array)->toHaveKey('work_permit_issued_by')
+        ->and($array)->toHaveKey('work_permit_copy_path')
+        ->and($array)->toHaveKey('work_permit_copy_deleted_at')
+        ->and($array)->toHaveKey('requires_work_permit')
+        ->and($array)->toHaveKey('has_valid_work_authorization')
+        ->and($array)->toHaveKey('expiring_documents');
 });
 
 test('EmployeeResource formats dates consistently', function () {
@@ -130,6 +141,21 @@ test('EmployeeResource omits regulated identifiers without employees.read_sensit
         'residence_permit_number',
         'sachkunde_ihk_number',
     ]);
+});
+
+test('EmployeeResource includes work authorization compliance context', function () {
+    $employee = Employee::factory()->withNonEuWorkPermit()->create([
+        'work_permit_expiry' => now()->addDays(5)->toDateString(),
+    ]);
+
+    $resource = new EmployeeResource($employee);
+    $array = $resource->resolve(employeeResourceRequest(true));
+
+    expect($array['requires_work_permit'])->toBeTrue()
+        ->and($array['has_valid_work_authorization'])->toBeTrue()
+        ->and($array['work_permit_number'])->toBe($employee->work_permit_number)
+        ->and($array['expiring_documents'])->toBeArray()
+        ->and(collect($array['expiring_documents'])->pluck('type')->all())->toContain('work_permit');
 });
 
 test('EmployeeResource includes computed structured_address property', function () {


### PR DESCRIPTION
## Summary
- add the first api#472 P0 slice for non-EU work permit tracking
- encrypt work permit numbers at rest and expand permit types to temporary/permanent/blue_card/seasonal/student
- enforce non-EU work permit validation on create and relevant PATCH updates
- expose work authorization and expiring document context in EmployeeResource and delete work permit copies on BWR approval or permanent permits

## Testing
- php artisan test tests/Feature/BewachvEmployeeFieldsValidationTest.php tests/Unit/Models/EmployeeModelBewachvFieldsTest.php tests/Unit/Resources/EmployeeResourceBewachvTest.php tests/Unit/Observers/EmployeeObserverBewachvTest.php tests/Unit/Factories/EmployeeFactoryBewachvTest.php
- vendor/bin/pint --dirty
- vendor/bin/phpstan analyse app/Http/Requests/Concerns/InteractsWithWorkPermitValidation.php app/Http/Requests/StoreEmployeeRequest.php app/Http/Requests/UpdateEmployeeRequest.php app/Models/Employee.php app/Http/Resources/EmployeeResource.php app/Observers/EmployeeObserver.php database/factories/EmployeeFactory.php database/migrations/2026_04_12_150000_add_non_eu_work_permit_core_to_employees_table.php tests/Feature/BewachvEmployeeFieldsValidationTest.php tests/Unit/Models/EmployeeModelBewachvFieldsTest.php tests/Unit/Resources/EmployeeResourceBewachvTest.php tests/Unit/Observers/EmployeeObserverBewachvTest.php tests/Unit/Factories/EmployeeFactoryBewachvTest.php
- reuse lint

## Follow-ups
- remaining certification/document-expiry scope is tracked in #869
- parallel PostgreSQL pre-push bootstrap/documentation gap is tracked in #870

## References
- refs #472
- refs #469
