### PR TITLE
chore: harden AI findings triage guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -68,6 +68,13 @@ At minimum verify:
 - the local 4-pass review was completed, including DRY, KISS, YAGNI, SOLID, quality-first, and issue-management checks
 - no bypass was used
 
+## AI Findings Triage
+
+- Treat AI findings and AI-generated fix PRs as hints, not proof.
+- Before merge, prove the defect with a failing test, a reproducible defect, or a stated invariant and why the current code violates it.
+- Green CI alone is not enough for AI-generated changes, especially test, lifecycle, shell, regex, or refactor diffs; review the semantic risk explicitly.
+- Reject AI-generated test or helper mutations that move executable code across Pest scope boundaries or bypass framework wiring.
+
 ## Repository Conventions
 
 - Stack: Laravel 13, PHP 8.4, Pest 4, PostgreSQL 16, native PHP shell usage.

--- a/.github/instructions/php-laravel.instructions.md
+++ b/.github/instructions/php-laravel.instructions.md
@@ -14,3 +14,9 @@ applyTo: "**/*.php,artisan"
 - Add or update the smallest relevant Pest test for each PHP change, then run the affected tests.
 - Use explicit return types, descriptive names, eager loading when appropriate, and `vendor/bin/pint --dirty` after changes.
 - Use `config()` in application code and keep `env()` confined to config files.
+- In Pest files, keep executable statements inside `beforeEach`, `it`/`test`, or helper functions; never insert side
+  effects at file scope.
+- For AI-suggested security-flow fixes, verify failure paths also invalidate challenges, tokens, or other one-time
+  state and add regression coverage.
+- Resolve application services, observers, and framework-managed collaborators through the container in tests when
+  behavior depends on app wiring.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - converted all findings from the 2026-03-31 security audit to GitHub Issues (#834–#847) tracked under Epic #848
+- strengthened repo-local Copilot governance for AI findings: API work now requires proof of defect before merging AI-generated fix PRs, treats green CI alone as insufficient evidence for semantic test changes, and explicitly rejects Pest file-scope mutations that bypass framework wiring
 
 ### Removed
 


### PR DESCRIPTION
Closes #901
Refs SecPal/.github#367

## Summary

- add AI findings triage guidance to the API repository baseline
- document Pest/Laravel guardrails for file-scope mutations, challenge invalidation, and container-resolved collaborators

## Validation

- `/home/secpal/code/SecPal/.github/scripts/validate-copilot-instructions.sh`
- local pre-push hook via `git push` (`./scripts/preflight.sh`)
