### PR TITLE
fix: block BWR field bypass on employee patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- blocked direct `PATCH /v1/employees/{employee}` writes to `bwr_status`, `bwr_id`, `bwr_notes`, and `bwr_registered_at` so BWR transitions and their audit trail must go through the dedicated `PUT /v1/employees/{employee}/bwr/status` endpoint (fixes `api#881`)
 - centralized employee compliance alert status values in `EmployeeComplianceService` and reused those constants in `IndexEmployeeRequest` validation/messages so filter rules stay synchronized with compliance business logic
 - added dedicated index request validation for qualification, organizational-unit, customer-assignment, and site-assignment filters so invalid category, type, parent, and role query values now fail fast with `422` responses instead of silently producing empty or ambiguous results
 

--- a/app/Http/Requests/UpdateEmployeeRequest.php
+++ b/app/Http/Requests/UpdateEmployeeRequest.php
@@ -217,11 +217,6 @@ class UpdateEmployeeRequest extends FormRequest
             'bwr_notes.missing' => __('BWR fields must be changed via the dedicated BWR status endpoint.'),
             'termination_date.after_or_equal' => __('Termination date must be after or equal to contract start date'),
 
-            // BWR-ID validation
-            'bwr_id.size' => 'Die Bewacher-ID muss exakt 7 Ziffern haben.',
-            'bwr_id.regex' => 'Die Bewacher-ID darf nur Ziffern enthalten (0000000-9999999).',
-            'bwr_id.unique' => 'Diese Bewacher-ID ist bereits vergeben.',
-
             // ISO country codes
             'birth_country.size' => 'Geburtsland muss ISO-Code mit 2 Buchstaben sein (z.B. DE, PL).',
             'birth_country.regex' => 'Geburtsland muss aus 2 Großbuchstaben bestehen.',

--- a/app/Http/Requests/UpdateEmployeeRequest.php
+++ b/app/Http/Requests/UpdateEmployeeRequest.php
@@ -52,18 +52,11 @@ class UpdateEmployeeRequest extends FormRequest
             'photo_path' => ['sometimes', 'nullable', 'string', 'max:255'],
 
             // BewachV § 16 Abs. 2 Nr. 1: BWR Tracking
-            'bwr_id' => [
-                'sometimes',
-                'nullable',
-                'string',
-                'size:7',
-                'regex:/^[0-9]{7}$/',
-                Rule::unique('employees', 'bwr_id')->ignore($employeeId),
-            ],
-            'bwr_status' => ['sometimes', 'nullable', Rule::in(['not_registered', 'pending', 'active', 'suspended', 'revoked'])],
-            'bwr_registered_at' => ['sometimes', 'nullable', 'date'],
+            'bwr_id' => ['missing'],
+            'bwr_status' => ['missing'],
+            'bwr_registered_at' => ['missing'],
             'bwr_submission_date' => ['sometimes', 'nullable', 'date'],
-            'bwr_notes' => ['sometimes', 'nullable', 'string', 'max:1000'],
+            'bwr_notes' => ['missing'],
 
             // BewachV § 16 Abs. 2 Nr. 2: Identity Data
             'gender' => ['sometimes', 'nullable', Rule::in(['male', 'female', 'diverse'])],
@@ -218,6 +211,10 @@ class UpdateEmployeeRequest extends FormRequest
             'email.email' => __('Email address must be valid'),
             'email.unique' => __('Email address is already in use'),
             'status.missing' => __('Employee status transitions must use the dedicated activate, leave, return-from-leave, or terminate endpoints.'),
+            'bwr_id.missing' => __('BWR fields must be changed via the dedicated BWR status endpoint.'),
+            'bwr_status.missing' => __('BWR fields must be changed via the dedicated BWR status endpoint.'),
+            'bwr_registered_at.missing' => __('BWR fields must be changed via the dedicated BWR status endpoint.'),
+            'bwr_notes.missing' => __('BWR fields must be changed via the dedicated BWR status endpoint.'),
             'termination_date.after_or_equal' => __('Termination date must be after or equal to contract start date'),
 
             // BWR-ID validation

--- a/tests/Feature/BewachvEmployeeFieldsValidationTest.php
+++ b/tests/Feature/BewachvEmployeeFieldsValidationTest.php
@@ -328,6 +328,7 @@ test('UpdateEmployeeRequest rejects direct bwr transition fields', function () {
 
     expect($validator->fails())->toBeTrue()
         ->and($validator->errors()->has('bwr_status'))->toBeTrue()
+        ->and($validator->errors()->first('bwr_status'))->toContain('BWR fields must be changed via the dedicated BWR status endpoint.')
         ->and($validator->errors()->has('bwr_id'))->toBeTrue()
         ->and($validator->errors()->has('bwr_notes'))->toBeTrue()
         ->and($validator->errors()->has('bwr_registered_at'))->toBeTrue();

--- a/tests/Feature/BewachvEmployeeFieldsValidationTest.php
+++ b/tests/Feature/BewachvEmployeeFieldsValidationTest.php
@@ -312,6 +312,27 @@ test('UpdateEmployeeRequest enforces work permit rules when patching employee in
     expect($validValidator->passes())->toBeTrue();
 });
 
+test('UpdateEmployeeRequest rejects direct bwr transition fields', function () {
+    $employee = Employee::factory()->create([
+        'tenant_id' => $this->tenant->id,
+        'organizational_unit_id' => $this->organizationalUnit->id,
+        'bwr_status' => 'pending',
+    ]);
+
+    $validator = makeUpdateEmployeeValidator($this, $employee, [
+        'bwr_status' => 'active',
+        'bwr_id' => '1234567',
+        'bwr_notes' => 'Attempted bypass',
+        'bwr_registered_at' => now()->toDateString(),
+    ]);
+
+    expect($validator->fails())->toBeTrue()
+        ->and($validator->errors()->has('bwr_status'))->toBeTrue()
+        ->and($validator->errors()->has('bwr_id'))->toBeTrue()
+        ->and($validator->errors()->has('bwr_notes'))->toBeTrue()
+        ->and($validator->errors()->has('bwr_registered_at'))->toBeTrue();
+});
+
 test('certification expiry dates must be after their issue dates', function () {
     $validator = makeStoreEmployeeValidator($this, validStoreEmployeeData($this, [
         'email' => 'certifications@example.com',

--- a/tests/Feature/Controllers/EmployeeControllerTest.php
+++ b/tests/Feature/Controllers/EmployeeControllerTest.php
@@ -1039,7 +1039,7 @@ describe('PATCH /v1/employees/{employee}', function () {
 
         $response->assertStatus(422)
             ->assertJsonValidationErrors([
-                'bwr_status',
+                'bwr_status' => 'BWR fields must be changed via the dedicated BWR status endpoint.',
                 'bwr_id',
                 'bwr_notes',
                 'bwr_registered_at',

--- a/tests/Feature/Controllers/EmployeeControllerTest.php
+++ b/tests/Feature/Controllers/EmployeeControllerTest.php
@@ -999,6 +999,65 @@ describe('PATCH /v1/employees/{employee}', function () {
 
         expect($employee->fresh()->status)->toBe(Employee::STATUS_ACTIVE);
     });
+
+    test('rejects direct bwr field changes via patch and preserves audit trail invariants', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'employee.write');
+
+        $this->user->organizationalScopes()->create([
+            'organizational_unit_id' => $this->organizationalUnit->id,
+            'access_level' => 'manage',
+            'include_descendants' => true,
+            'min_viewable_rank' => 0,
+            'max_viewable_rank' => 0,
+            'allow_self_access' => true,
+        ]);
+        $this->user->organizationalScopes()->create([
+            'organizational_unit_id' => $this->organizationalUnit->id,
+            'access_level' => 'manage',
+            'include_descendants' => true,
+            'min_viewable_rank' => 1,
+            'max_viewable_rank' => 255,
+            'allow_self_access' => true,
+        ]);
+
+        $employee = Employee::factory()->create([
+            'tenant_id' => $this->tenant->id,
+            'organizational_unit_id' => $this->organizationalUnit->id,
+            'bwr_status' => 'pending',
+            'bwr_id' => null,
+            'bwr_notes' => null,
+            'bwr_registered_at' => null,
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->patchJson("/v1/employees/{$employee->id}", [
+                'bwr_status' => 'active',
+                'bwr_id' => '1234567',
+                'bwr_notes' => 'Attempted bypass',
+                'bwr_registered_at' => now()->toDateString(),
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors([
+                'bwr_status',
+                'bwr_id',
+                'bwr_notes',
+                'bwr_registered_at',
+            ]);
+
+        $employee->refresh();
+
+        expect($employee->bwr_status)->toBe('pending')
+            ->and($employee->bwr_id)->toBeNull()
+            ->and($employee->bwr_notes)->toBeNull()
+            ->and($employee->bwr_registered_at)->toBeNull();
+
+        $this->assertDatabaseMissing('activity_log', [
+            'description' => 'BWR status updated',
+            'subject_type' => Employee::class,
+            'subject_id' => $employee->id,
+        ]);
+    });
 });
 
 describe('POST /v1/employees/{employee}/bwr/export', function (): void {


### PR DESCRIPTION
## Summary
- block direct BWR transition field writes on PATCH /v1/employees/{employee}
- return explicit validation errors that direct callers to the dedicated BWR status endpoint
- add regression coverage for the request contract and the PATCH endpoint audit invariant

## Testing
- php artisan test tests/Feature/Controllers/EmployeeControllerTest.php tests/Feature/BewachvEmployeeFieldsValidationTest.php
- vendor/bin/pint --dirty

Closes #881
