### PR TITLE
fix: default omitted employee management level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- made `POST /v1/employees` accept omitted `management_level` values for non-management hires again, defaulting persisted records to `0` so invite-enabled onboarding preparation no longer fails with `422 The management level field is required.` when clients do not send a leadership rank
 - blocked direct `PATCH /v1/employees/{employee}` writes to `bwr_status`, `bwr_id`, `bwr_notes`, and `bwr_registered_at` so BWR transitions and their audit trail must go through the dedicated `PUT /v1/employees/{employee}/bwr/status` endpoint (fixes `api#881`)
 - centralized employee compliance alert status values in `EmployeeComplianceService` and reused those constants in `IndexEmployeeRequest` validation/messages so filter rules stay synchronized with compliance business logic
 - added dedicated index request validation for qualification, organizational-unit, customer-assignment, and site-assignment filters so invalid category, type, parent, and role query values now fail fast with `422` responses instead of silently producing empty or ambiguous results

--- a/app/Http/Requests/StoreEmployeeRequest.php
+++ b/app/Http/Requests/StoreEmployeeRequest.php
@@ -131,7 +131,7 @@ class StoreEmployeeRequest extends FormRequest
             // Employment Status
             'status' => ['required', Rule::in(Employee::VALID_STATUSES)],
             'position' => ['required', 'string', 'max:255'],
-            'management_level' => ['required', 'integer', 'min:0', 'max:255'],
+            'management_level' => ['sometimes', 'integer', 'min:0', 'max:255'],
             'hire_date' => ['nullable', 'date'],
             'contract_start_date' => ['required', 'date'],
             'termination_date' => ['nullable', 'date', 'after_or_equal:contract_start_date'],

--- a/tests/Feature/Controllers/EmployeeControllerTest.php
+++ b/tests/Feature/Controllers/EmployeeControllerTest.php
@@ -408,6 +408,38 @@ describe('POST /v1/employees', function () {
             ]);
     });
 
+    test('creates a non-management employee when management level is omitted', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'employee.write');
+
+        $response = $this->withToken($this->token)
+            ->postJson('/v1/employees', [
+                'first_name' => 'Nina',
+                'last_name' => 'Newhire',
+                'email' => 'nina.newhire@example.com',
+                'date_of_birth' => '1993-05-15',
+                'position' => 'Security Guard',
+                'status' => Employee::STATUS_PRE_CONTRACT,
+                'contract_type' => 'full_time',
+                'contract_start_date' => now()->addWeek()->toDateString(),
+                'weekly_hours' => 40,
+                'hourly_rate' => 16.50,
+                'organizational_unit_id' => $this->organizationalUnit->id,
+                'sachkunde_type' => 'none',
+                'work_permit_type' => 'none',
+                'criminal_record_status' => 'valid',
+                'send_invitation' => true,
+            ]);
+
+        $response->assertStatus(201)
+            ->assertJsonPath('data.management_level', 0)
+            ->assertJsonPath('data.onboarding_invitation.status', Employee::INVITATION_STATUS_SENT);
+
+        $employee = Employee::findOrFail($response->json('data.id'));
+
+        expect($employee->management_level)->toBe(0)
+            ->and($employee->onboarding_invitation_status)->toBe(Employee::INVITATION_STATUS_SENT);
+    });
+
     test('creates employee with auto-generated employee_number', function (): void {
         givePermissionWithTenant($this->user, $this->tenant->id, 'employee.write');
 


### PR DESCRIPTION
## Summary
- allow `POST /v1/employees` to omit `management_level` for non-management hires
- keep the persisted non-management semantics by relying on the existing `0` default
- add a regression test covering invite-enabled employee creation without an explicit leadership rank

## Validation
- `vendor/bin/pint --dirty`
- `php artisan test tests/Feature/Controllers/EmployeeControllerTest.php --filter="POST /v1/employees"`

## Follow-up
- leadership-rank discoverability for real leadership hires is tracked separately in #904
