### PR TITLE
fix: centralize activity log search escaping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - normalized generic API `404` responses to `{"message":"Resource not found."}` for unknown `/v1/*` routes in all debug modes, preventing default Laravel HTML or stack-trace payloads from leaking through
 
-- escaped `\\`, `%`, and `_` in customer, site, and employee search terms through a shared LIKE-pattern helper so wildcard-only search input no longer expands into broad `LIKE` / `ILIKE` scans on those endpoints
+- escaped `\\`, `%`, and `_` in customer, site, employee, and activity-log search terms through a shared LIKE-pattern helper so wildcard-only and backslash-escaped search input no longer expands into broad `LIKE` / `ILIKE` scans or drift between endpoints
 
 - capped `/v1/organizational-units` pagination with a dedicated index request so oversized `per_page` values are rejected with `422` instead of allowing unbounded result windows
 

--- a/app/Http/Controllers/Api/V1/ActivityLogController.php
+++ b/app/Http/Controllers/Api/V1/ActivityLogController.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Api\V1\IndexActivityLogRequest;
 use App\Http\Resources\ActivityResource;
 use App\Models\Activity;
+use App\Support\LikePattern;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
@@ -285,9 +286,7 @@ class ActivityLogController extends Controller
 
         // Search in description (case-insensitive)
         if ($request->has('search')) {
-            $search = $request->string('search')->toString();
-            // Escape LIKE wildcards to prevent unintended pattern matching
-            $search = str_replace(['%', '_'], ['\\%', '\\_'], $search);
+            $search = LikePattern::escape($request->string('search')->toString());
             $query->where('description', 'ilike', "%{$search}%");
         }
 

--- a/app/Http/Controllers/Api/V1/ActivityLogController.php
+++ b/app/Http/Controllers/Api/V1/ActivityLogController.php
@@ -1,6 +1,6 @@
 <?php
 
-// SPDX-FileCopyrightText: 2025 SecPal Contributors
+// SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 namespace App\Http\Controllers\Api\V1;

--- a/tests/Feature/Controllers/Api/V1/ActivityLogControllerTest.php
+++ b/tests/Feature/Controllers/Api/V1/ActivityLogControllerTest.php
@@ -6,12 +6,15 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+use App\Http\Controllers\Api\V1\ActivityLogController;
+use App\Http\Requests\Api\V1\IndexActivityLogRequest;
 use App\Models\Activity;
 use App\Models\Employee;
 use App\Models\OrganizationalUnit;
 use App\Models\TenantKey;
 use App\Models\User;
 use App\Models\UserInternalOrganizationalScope;
+use App\Support\LikePattern;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Artisan;
 use Spatie\Permission\PermissionRegistrar;
@@ -384,6 +387,50 @@ describe('GET /v1/activity-logs', function () {
         $response->assertOk();
         expect($response->json('data'))->toHaveCount(1);
         expect($response->json('data')[0]['description'])->toContain('contract');
+    });
+
+    test('treats backslash wildcard sequences in activity search input as literal text', function (): void {
+        ['tenant' => $tenant, 'user' => $user] = createActivityLogContext();
+
+        givePermissionWithTenant($user, $tenant->id, 'activity_log.read');
+        actingAs($user, 'sanctum');
+
+        Activity::factory()->create([
+            'tenant_id' => $tenant->id,
+            'organizational_unit_id' => null,
+            'description' => 'Literal foo\%_bar marker',
+        ]);
+
+        Activity::factory()->create([
+            'tenant_id' => $tenant->id,
+            'organizational_unit_id' => null,
+            'description' => 'Literal fooXbar marker',
+        ]);
+
+        $response = getJson('/v1/activity-logs?search='.urlencode('foo\%_bar'));
+
+        $response->assertOk();
+        expect($response->json('data'))->toHaveCount(1);
+        expect($response->json('data')[0]['description'])->toBe('Literal foo\%_bar marker');
+    });
+
+    test('escapes backslashes in search bindings with the shared like-pattern helper', function (): void {
+        $controller = new class extends ActivityLogController
+        {
+            public function applyFiltersForTest($query, IndexActivityLogRequest $request): void
+            {
+                $this->applyFilters($query, $request);
+            }
+        };
+
+        $request = IndexActivityLogRequest::create('/v1/activity-logs', 'GET', [
+            'search' => 'foo\%_bar',
+        ]);
+
+        $query = Activity::query();
+        $controller->applyFiltersForTest($query, $request);
+
+        expect($query->getBindings())->toContain('%'.LikePattern::escape('foo\%_bar').'%');
     });
 
     test('respects pagination parameters', function (): void {


### PR DESCRIPTION
## Summary

- route activity-log description search through the shared LikePattern helper so backslashes, percent signs, and underscores are escaped consistently with other search endpoints
- add regression coverage for literal backslash wildcard sequences in activity-log search and for the generated LIKE binding
- update the API changelog to reflect activity-log search escaping coverage

## Testing

- php artisan test tests/Feature/Controllers/Api/V1/ActivityLogControllerTest.php
- vendor/bin/pint --dirty

## Related

- Closes #847
- Part of #848

## Checklist

- [x] Single topic
- [x] Targeted tests added before the controller fix
- [x] CHANGELOG updated
