### PR TITLE
test: lock in issue 836 search escaping regressions

### DIFF
--- a/tests/Feature/Controllers/Api/V1/CustomerControllerTest.php
+++ b/tests/Feature/Controllers/Api/V1/CustomerControllerTest.php
@@ -12,8 +12,10 @@ use App\Models\Site;
 use App\Models\SiteAssignment;
 use App\Models\TenantKey;
 use App\Models\User;
+use App\Support\LikePattern;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
 use Spatie\Permission\PermissionRegistrar;
 
 /**
@@ -151,6 +153,32 @@ describe('GET /v1/customers', function () {
 
         $response->assertOk();
         expect($response->json('data'))->toHaveCount(0);
+    });
+
+    test('binds escaped like patterns for literal backslash wildcard customer searches', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'customers.read');
+
+        Customer::factory()->create([
+            'tenant_id' => $this->tenant->id,
+            'name' => 'Literal foo\\%_bar customer',
+        ]);
+
+        DB::enableQueryLog();
+
+        $response = $this->withToken($this->token)
+            ->getJson('/v1/customers?search='.urlencode('foo\%_bar'));
+
+        $queries = DB::getQueryLog();
+        DB::disableQueryLog();
+
+        $response->assertOk();
+
+        $bindings = collect($queries)
+            ->pluck('bindings')
+            ->flatten(1)
+            ->filter(fn (mixed $binding): bool => is_string($binding));
+
+        expect($bindings)->toContain('%'.LikePattern::escape('foo\%_bar').'%');
     });
 
     test('user without permission only sees assigned customers', function (): void {

--- a/tests/Feature/Controllers/EmployeeControllerTest.php
+++ b/tests/Feature/Controllers/EmployeeControllerTest.php
@@ -13,8 +13,10 @@ use App\Models\OrganizationalUnit;
 use App\Models\Permission;
 use App\Models\TenantKey;
 use App\Models\User;
+use App\Support\LikePattern;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Storage;
 use Spatie\Activitylog\Models\Activity;
@@ -333,6 +335,33 @@ describe('GET /v1/employees', function () {
 
         $response->assertStatus(200);
         expect($response->json('data'))->toHaveCount(0);
+    });
+
+    test('binds escaped like patterns for literal backslash wildcard employee searches', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'employee.read');
+
+        Employee::factory()->create([
+            'tenant_id' => $this->tenant->id,
+            'organizational_unit_id' => $this->organizationalUnit->id,
+            'email' => 'foo\\%_bar@secpal.dev',
+        ]);
+
+        DB::enableQueryLog();
+
+        $response = $this->withToken($this->token)
+            ->getJson('/v1/employees?search='.urlencode('foo\%_bar'));
+
+        $queries = DB::getQueryLog();
+        DB::disableQueryLog();
+
+        $response->assertOk();
+
+        $bindings = collect($queries)
+            ->pluck('bindings')
+            ->flatten(1)
+            ->filter(fn (mixed $binding): bool => is_string($binding));
+
+        expect($bindings)->toContain('%'.LikePattern::escape('foo\%_bar').'%');
     });
 });
 


### PR DESCRIPTION
## Summary

- re-check Issue #836 against current `main` and confirm the index-filter validation findings are already implemented in production code
- add employee and customer controller regressions that assert literal backslash wildcard search input is bound through the shared `LikePattern` escaping path
- keep the issue closure honest by proving the remaining risk area with endpoint-level query binding coverage instead of reintroducing stale code from the old issue branch

## Testing

- php artisan test tests/Feature/Controllers/EmployeeControllerTest.php tests/Feature/Controllers/Api/V1/CustomerControllerTest.php
- vendor/bin/pint --dirty

## Related

- Closes #836
- Part of #848

## Notes

- `CHANGELOG.md` already contains the production fix entry for the search escaping and filter-validation work; this PR adds the missing regression proof layer only.

## Checklist

- [x] Single topic
- [x] Targeted regression coverage added and validated locally
- [x] No stale issue-836 branch code was revived over newer mainline behavior
