### PR TITLE
test: harden employee concurrency child exit assertions

### DIFF
--- a/tests/Feature/Controllers/EmployeeNumberConcurrencyTest.php
+++ b/tests/Feature/Controllers/EmployeeNumberConcurrencyTest.php
@@ -101,7 +101,9 @@ test('concurrent employee creation requests produce distinct employee numbers', 
         file_put_contents($startSignalPath, 'go');
 
         foreach ($childPids as $childPid) {
-            pcntl_waitpid($childPid, $status);
+            expect(pcntl_waitpid($childPid, $status))->toBe($childPid);
+            expect(pcntl_wifexited($status))->toBeTrue();
+            expect(pcntl_wifsignaled($status))->toBeFalse();
             expect(pcntl_wexitstatus($status))->toBe(0);
         }
 


### PR DESCRIPTION
## Summary
- assert that each `pcntl_waitpid()` call reaps the expected child PID before checking exit status
- require the forked child process to have exited normally and not via signal before reading `pcntl_wexitstatus()`
- keep the employee concurrency regression aligned with the hardened customer/site concurrency helper expectations

## Validation
- `php -l tests/Feature/Controllers/EmployeeNumberConcurrencyTest.php`
- `vendor/bin/pint --dirty`
- `git push -u origin test/harden-employee-number-concurrency-911` (pre-push: Pint, PHPStan, REUSE, domain policy)
- attempted `php artisan test tests/Feature/Controllers/EmployeeNumberConcurrencyTest.php`, but local validation is currently blocked by missing PostgreSQL maintenance-database connectivity during test bootstrap

Closes #911
