### PR TITLE
docs: clarify parallel postgres test ownership

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -77,8 +77,9 @@ When running tests in **parallel** (e.g., with `php artisan test --parallel`), P
 **Requirements:**
 
 - Local PostgreSQL server reachable via your `.env`
-- The configured PostgreSQL user must be allowed to create databases
-- If parallel `testing_test_*` databases were created manually, they must also be owned by the configured app user so Laravel can create tables in `public`
+- Use one of these PostgreSQL setups for the configured app user:
+  - The user is allowed to create databases
+  - Or an admin has already created the `testing` and any required parallel `testing_test_*` databases, and those databases are owned by the configured app user so Laravel can create tables in `public`
 
 **Configuration:**
 
@@ -123,21 +124,23 @@ php artisan test tests/Feature/HealthCheckTest.php
 If parallel test runs fail with errors such as `permission denied for schema public` after manually creating `testing_test_*` databases, fix the database ownership before rerunning the suite.
 
 ```bash
-# Inspect database owners first
-psql -h 127.0.0.1 -U postgres -d postgres -c '\l testing*'
+# Inspect database owners first (uses local peer auth; adjust if your setup differs)
+sudo -u postgres psql -d postgres -c '\l testing*'
 
-# Preferred: transfer each manually created parallel test database to the app user
-for db in testing_test_3 testing_test_4 testing_test_5 testing_test_6 testing_test_7 testing_test_8; do
-  sudo -u postgres psql -d postgres -c "ALTER DATABASE \"$db\" OWNER TO secpal_app;"
+# Preferred: transfer all manually created parallel test databases to the app user
+# Adjust DB_USERNAME to match your .env (default: secpal_app)
+DB_USERNAME="${DB_USERNAME:-secpal_app}"
+for db in $(sudo -u postgres psql -d postgres -Atc "SELECT datname FROM pg_database WHERE datname LIKE 'testing_test_%';"); do
+  sudo -u postgres psql -d postgres -c "ALTER DATABASE \"$db\" OWNER TO \"$DB_USERNAME\";"
 done
 
 # If schema privileges are already out of sync, repair them explicitly
-for db in testing_test_3 testing_test_4 testing_test_5 testing_test_6 testing_test_7 testing_test_8; do
-  sudo -u postgres psql -d "$db" -c "ALTER SCHEMA public OWNER TO secpal_app; GRANT ALL ON SCHEMA public TO secpal_app;"
+for db in $(sudo -u postgres psql -d postgres -Atc "SELECT datname FROM pg_database WHERE datname LIKE 'testing_test_%';"); do
+  sudo -u postgres psql -d "$db" -c "ALTER SCHEMA public OWNER TO \"$DB_USERNAME\"; GRANT ALL ON SCHEMA public TO \"$DB_USERNAME\";"
 done
 ```
 
-The key point is that manually provisioned parallel databases must not stay owned by `postgres` if your Laravel test user is `secpal_app`; otherwise migrations cannot create tables inside `public` during parallel bootstrap.
+The key point is that manually provisioned parallel databases must not stay owned by `postgres`; the databases must be owned by the configured app user (matching `DB_USERNAME` in your `.env`) so migrations can create tables inside `public` during parallel bootstrap.
 
 ## IDE Configuration
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -78,6 +78,7 @@ When running tests in **parallel** (e.g., with `php artisan test --parallel`), P
 
 - Local PostgreSQL server reachable via your `.env`
 - The configured PostgreSQL user must be allowed to create databases
+- If parallel `testing_test_*` databases were created manually, they must also be owned by the configured app user so Laravel can create tables in `public`
 
 **Configuration:**
 
@@ -118,6 +119,25 @@ psql -h 127.0.0.1 -U "$DB_USERNAME" -d postgres -c '\du'
 # Then rerun the targeted test file
 php artisan test tests/Feature/HealthCheckTest.php
 ```
+
+If parallel test runs fail with errors such as `permission denied for schema public` after manually creating `testing_test_*` databases, fix the database ownership before rerunning the suite.
+
+```bash
+# Inspect database owners first
+psql -h 127.0.0.1 -U postgres -d postgres -c '\l testing*'
+
+# Preferred: transfer each manually created parallel test database to the app user
+for db in testing_test_3 testing_test_4 testing_test_5 testing_test_6 testing_test_7 testing_test_8; do
+  sudo -u postgres psql -d postgres -c "ALTER DATABASE \"$db\" OWNER TO secpal_app;"
+done
+
+# If schema privileges are already out of sync, repair them explicitly
+for db in testing_test_3 testing_test_4 testing_test_5 testing_test_6 testing_test_7 testing_test_8; do
+  sudo -u postgres psql -d "$db" -c "ALTER SCHEMA public OWNER TO secpal_app; GRANT ALL ON SCHEMA public TO secpal_app;"
+done
+```
+
+The key point is that manually provisioned parallel databases must not stay owned by `postgres` if your Laravel test user is `secpal_app`; otherwise migrations cannot create tables inside `public` during parallel bootstrap.
 
 ## IDE Configuration
 


### PR DESCRIPTION
## Summary
- document that manually created parallel testing_test_* databases must be owned by the app user, not left under postgres ownership
- add the explicit database-owner and public-schema repair commands for the common permission denied for schema public failure mode
- clarify the relationship between CREATEDB bootstrap and schema ownership drift in the local PostgreSQL troubleshooting section

## Validation
- git -C /home/holger/code/SecPal/api push -u origin docs/parallel-postgres-bootstrap-870 (pre-push: markdownlint, Pint dry-run, PHPStan, REUSE, domain policy)

Closes #870
