### PR TITLE
fix: scope role validation to tenant context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - added a dedicated `health` rate limiter for `/health`, `/health/live`, and `/health/ready` so unauthenticated health probes now return `429` after repeated abuse from the same IP and route bucket
 
 - switched role and permission management writes to validated request payloads so those controllers no longer read raw input after form-request validation
+- scoped role-name uniqueness validation to the active tenant plus `sanctum` guard so different tenants can reuse the same role names without tripping false `422` conflicts on create or update
 - reduced the public health surface by removing the `/health` version field and by limiting `/health/ready` responses to the readiness status plus timestamp instead of exposing database, key-management, scheduler, and queue-worker details
 - standardized API V1 delete endpoints on `response()->noContent()` so successful `204` responses are implemented consistently across employee, document, qualification, assignment, customer, site, organizational-unit, and cost-center deletes
 - serialized employee number generation per tenant inside the employee create transaction, locking the tenant row plus the current-year employee number lookup so concurrent `POST /v1/employees` requests cannot derive duplicate `employee_number` values; the existing global unique constraint on `employee_number` remains in place as a last-resort safeguard (note: the constraint is currently global across tenants, not scoped per tenant — tracked in SecPal/api#867)

--- a/app/Http/Requests/Api/V1/CreateRoleRequest.php
+++ b/app/Http/Requests/Api/V1/CreateRoleRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * SPDX-FileCopyrightText: 2025 SecPal Contributors
+ * SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
@@ -10,6 +10,8 @@ namespace App\Http\Requests\Api\V1;
 
 use App\Models\Permission;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\Unique;
 
 class CreateRoleRequest extends FormRequest
 {
@@ -29,7 +31,7 @@ class CreateRoleRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'name' => ['required', 'string', 'max:255', 'unique:roles,name'],
+            'name' => ['required', 'string', 'max:255', $this->roleNameUniqueRule()],
             'permissions' => ['nullable', 'array'],
             'permissions.*' => [
                 'required',
@@ -46,6 +48,25 @@ class CreateRoleRequest extends FormRequest
                 },
             ],
         ];
+    }
+
+    private function roleNameUniqueRule(): Unique
+    {
+        $rolesTable = (string) config('permission.table_names.roles', 'roles');
+        $teamColumn = (string) config('permission.column_names.team_foreign_key', 'tenant_id');
+        $tenantId = $this->user()?->tenant_id ?? $this->input($teamColumn);
+
+        return Rule::unique($rolesTable, 'name')->where(function ($query) use ($teamColumn, $tenantId): void {
+            $query->where('guard_name', 'sanctum');
+
+            if ($tenantId === null) {
+                $query->whereNull($teamColumn);
+
+                return;
+            }
+
+            $query->where($teamColumn, $tenantId);
+        });
     }
 
     /**

--- a/app/Http/Requests/Api/V1/CreateRoleRequest.php
+++ b/app/Http/Requests/Api/V1/CreateRoleRequest.php
@@ -66,7 +66,8 @@ class CreateRoleRequest extends FormRequest
 
         /** @var User $user */
         $user = $this->user();
-        $tenantId = $this->input($teamColumn, $user->tenant_id);
+
+        $tenantId = $user->tenant_id;
         if (is_numeric($tenantId)) {
             $tenantId = (int) $tenantId;
         } else {

--- a/app/Http/Requests/Api/V1/CreateRoleRequest.php
+++ b/app/Http/Requests/Api/V1/CreateRoleRequest.php
@@ -9,6 +9,8 @@
 namespace App\Http\Requests\Api\V1;
 
 use App\Models\Permission;
+use App\Models\User;
+use Illuminate\Database\Query\Builder;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\Unique;
@@ -52,11 +54,26 @@ class CreateRoleRequest extends FormRequest
 
     private function roleNameUniqueRule(): Unique
     {
-        $rolesTable = (string) config('permission.table_names.roles', 'roles');
-        $teamColumn = (string) config('permission.column_names.team_foreign_key', 'tenant_id');
-        $tenantId = $this->user()?->tenant_id ?? $this->input($teamColumn);
+        $rolesTable = config('permission.table_names.roles');
+        if (! is_string($rolesTable) || $rolesTable === '') {
+            $rolesTable = 'roles';
+        }
 
-        return Rule::unique($rolesTable, 'name')->where(function ($query) use ($teamColumn, $tenantId): void {
+        $teamColumn = config('permission.column_names.team_foreign_key');
+        if (! is_string($teamColumn) || $teamColumn === '') {
+            $teamColumn = 'tenant_id';
+        }
+
+        /** @var User $user */
+        $user = $this->user();
+        $tenantId = $this->input($teamColumn, $user->tenant_id);
+        if (is_numeric($tenantId)) {
+            $tenantId = (int) $tenantId;
+        } else {
+            $tenantId = null;
+        }
+
+        return Rule::unique($rolesTable, 'name')->where(function (Builder $query) use ($teamColumn, $tenantId): void {
             $query->where('guard_name', 'sanctum');
 
             if ($tenantId === null) {

--- a/app/Http/Requests/Api/V1/UpdateRoleRequest.php
+++ b/app/Http/Requests/Api/V1/UpdateRoleRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * SPDX-FileCopyrightText: 2025 SecPal Contributors
+ * SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
@@ -11,6 +11,7 @@ namespace App\Http\Requests\Api\V1;
 use App\Models\Permission;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\Unique;
 
 class UpdateRoleRequest extends FormRequest
 {
@@ -37,7 +38,7 @@ class UpdateRoleRequest extends FormRequest
                 'required',
                 'string',
                 'max:255',
-                Rule::unique('roles', 'name')->ignore($roleId),
+                $this->roleNameUniqueRule()->ignore($roleId),
             ],
             'permissions' => ['array'],
             'permissions.*' => [
@@ -55,6 +56,25 @@ class UpdateRoleRequest extends FormRequest
                 },
             ],
         ];
+    }
+
+    private function roleNameUniqueRule(): Unique
+    {
+        $rolesTable = (string) config('permission.table_names.roles', 'roles');
+        $teamColumn = (string) config('permission.column_names.team_foreign_key', 'tenant_id');
+        $tenantId = $this->user()?->tenant_id ?? $this->input($teamColumn);
+
+        return Rule::unique($rolesTable, 'name')->where(function ($query) use ($teamColumn, $tenantId): void {
+            $query->where('guard_name', 'sanctum');
+
+            if ($tenantId === null) {
+                $query->whereNull($teamColumn);
+
+                return;
+            }
+
+            $query->where($teamColumn, $tenantId);
+        });
     }
 
     /**

--- a/app/Http/Requests/Api/V1/UpdateRoleRequest.php
+++ b/app/Http/Requests/Api/V1/UpdateRoleRequest.php
@@ -74,7 +74,8 @@ class UpdateRoleRequest extends FormRequest
 
         /** @var User $user */
         $user = $this->user();
-        $tenantId = $this->input($teamColumn, $user->tenant_id);
+
+        $tenantId = $user->tenant_id;
         if (is_numeric($tenantId)) {
             $tenantId = (int) $tenantId;
         } else {

--- a/app/Http/Requests/Api/V1/UpdateRoleRequest.php
+++ b/app/Http/Requests/Api/V1/UpdateRoleRequest.php
@@ -9,6 +9,8 @@
 namespace App\Http\Requests\Api\V1;
 
 use App\Models\Permission;
+use App\Models\User;
+use Illuminate\Database\Query\Builder;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\Unique;
@@ -60,11 +62,26 @@ class UpdateRoleRequest extends FormRequest
 
     private function roleNameUniqueRule(): Unique
     {
-        $rolesTable = (string) config('permission.table_names.roles', 'roles');
-        $teamColumn = (string) config('permission.column_names.team_foreign_key', 'tenant_id');
-        $tenantId = $this->user()?->tenant_id ?? $this->input($teamColumn);
+        $rolesTable = config('permission.table_names.roles');
+        if (! is_string($rolesTable) || $rolesTable === '') {
+            $rolesTable = 'roles';
+        }
 
-        return Rule::unique($rolesTable, 'name')->where(function ($query) use ($teamColumn, $tenantId): void {
+        $teamColumn = config('permission.column_names.team_foreign_key');
+        if (! is_string($teamColumn) || $teamColumn === '') {
+            $teamColumn = 'tenant_id';
+        }
+
+        /** @var User $user */
+        $user = $this->user();
+        $tenantId = $this->input($teamColumn, $user->tenant_id);
+        if (is_numeric($tenantId)) {
+            $tenantId = (int) $tenantId;
+        } else {
+            $tenantId = null;
+        }
+
+        return Rule::unique($rolesTable, 'name')->where(function (Builder $query) use ($teamColumn, $tenantId): void {
             $query->where('guard_name', 'sanctum');
 
             if ($tenantId === null) {

--- a/tests/Feature/RoleManagementApiTest.php
+++ b/tests/Feature/RoleManagementApiTest.php
@@ -6,6 +6,8 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+use App\Http\Requests\Api\V1\CreateRoleRequest;
+use App\Http\Requests\Api\V1\UpdateRoleRequest;
 use App\Models\Permission;
 use App\Models\TenantKey;
 use App\Models\User;
@@ -155,6 +157,44 @@ describe('POST /v1/roles - Create Role', function () {
             ->assertJsonValidationErrors(['name']);
     });
 
+    test('ignores spoofed tenant input when validating role creation uniqueness', function (): void {
+        Role::create(['name' => 'Manager', 'guard_name' => 'sanctum']);
+        $otherTenant = TenantKey::create(TenantKey::generateEnvelopeKeys());
+
+        $request = CreateRoleRequest::create('/v1/roles', 'POST', [
+            'name' => 'Manager',
+            'permissions' => ['employees.read'],
+            'tenant_id' => $otherTenant->id,
+        ]);
+        $request->setContainer(app());
+        $request->setUserResolver(fn (): User => $this->user);
+
+        $validator = validator($request->all(), $request->rules(), $request->messages());
+
+        expect($validator->fails())->toBeTrue();
+        expect($validator->errors()->keys())->toContain('name');
+    });
+
+    test('allows creating a sanctum role when the same name exists only under another guard', function (): void {
+        $this->user->givePermissionTo('roles.create');
+        Role::create(['name' => 'Manager', 'guard_name' => 'web']);
+
+        $response = $this->withToken($this->token)
+            ->postJson('/v1/roles', [
+                'name' => 'Manager',
+                'permissions' => ['employees.read'],
+            ]);
+
+        $response->assertCreated()
+            ->assertJsonFragment(['name' => 'Manager']);
+
+        expect(Role::query()
+            ->where('name', 'Manager')
+            ->where('guard_name', 'sanctum')
+            ->where('tenant_id', $this->tenant->id)
+            ->exists())->toBeTrue();
+    });
+
     test('allows creating a role when the same name exists in another tenant', function (): void {
         $this->user->givePermissionTo('roles.create');
 
@@ -174,7 +214,22 @@ describe('POST /v1/roles - Create Role', function () {
         $response->assertCreated()
             ->assertJsonFragment(['name' => 'Manager']);
 
-        expect(Role::query()->where('name', 'Manager')->count())->toBe(2);
+        expect(Role::query()
+            ->where('name', 'Manager')
+            ->where('guard_name', 'sanctum')
+            ->where('tenant_id', $otherTenant->id)
+            ->exists())->toBeTrue();
+
+        expect(Role::query()
+            ->where('name', 'Manager')
+            ->where('guard_name', 'sanctum')
+            ->where('tenant_id', $this->tenant->id)
+            ->exists())->toBeTrue();
+
+        expect(Role::query()
+            ->where('name', 'Manager')
+            ->where('guard_name', 'sanctum')
+            ->count())->toBe(2);
     });
 
     test('returns 422 when permissions array contains non-existent permission', function (): void {
@@ -319,6 +374,40 @@ describe('PATCH /v1/roles/{id} - Update Role', function () {
             ->assertJsonValidationErrors(['name']);
     });
 
+    test('ignores spoofed tenant input when validating role updates', function (): void {
+        Role::create(['name' => 'Manager', 'guard_name' => 'sanctum']);
+        Role::create(['name' => 'Guard', 'guard_name' => 'sanctum']);
+        $otherTenant = TenantKey::create(TenantKey::generateEnvelopeKeys());
+
+        $request = UpdateRoleRequest::create('/v1/roles/1', 'PATCH', [
+            'name' => 'Manager',
+            'tenant_id' => $otherTenant->id,
+        ]);
+        $request->setContainer(app());
+        $request->setUserResolver(fn (): User => $this->user);
+
+        $validator = validator($request->all(), $request->rules(), $request->messages());
+
+        expect($validator->fails())->toBeTrue();
+        expect($validator->errors()->keys())->toContain('name');
+    });
+
+    test('allows updating a sanctum role when the target name exists only under another guard', function (): void {
+        $this->user->givePermissionTo('roles.update');
+        Role::create(['name' => 'Manager', 'guard_name' => 'web']);
+        $role = Role::create(['name' => 'Guard', 'guard_name' => 'sanctum']);
+
+        $response = $this->withToken($this->token)
+            ->patchJson("/v1/roles/{$role->id}", [
+                'name' => 'Manager',
+            ]);
+
+        $response->assertOk()
+            ->assertJsonFragment(['name' => 'Manager']);
+
+        expect($role->fresh()?->name)->toBe('Manager');
+    });
+
     test('allows updating a role when the target name exists in another tenant', function (): void {
         $this->user->givePermissionTo('roles.update');
         $role = Role::create(['name' => 'Guard', 'guard_name' => 'sanctum']);
@@ -338,7 +427,22 @@ describe('PATCH /v1/roles/{id} - Update Role', function () {
         $response->assertOk()
             ->assertJsonFragment(['name' => 'Manager']);
 
-        expect(Role::query()->where('name', 'Manager')->count())->toBe(2);
+        expect(Role::query()
+            ->where('name', 'Manager')
+            ->where('guard_name', 'sanctum')
+            ->where('tenant_id', $otherTenant->id)
+            ->exists())->toBeTrue();
+
+        expect(Role::query()
+            ->where('name', 'Manager')
+            ->where('guard_name', 'sanctum')
+            ->where('tenant_id', $this->tenant->id)
+            ->exists())->toBeTrue();
+
+        expect(Role::query()
+            ->where('name', 'Manager')
+            ->where('guard_name', 'sanctum')
+            ->count())->toBe(2);
     });
 
     test('updates role name successfully', function (): void {

--- a/tests/Feature/RoleManagementApiTest.php
+++ b/tests/Feature/RoleManagementApiTest.php
@@ -155,6 +155,28 @@ describe('POST /v1/roles - Create Role', function () {
             ->assertJsonValidationErrors(['name']);
     });
 
+    test('allows creating a role when the same name exists in another tenant', function (): void {
+        $this->user->givePermissionTo('roles.create');
+
+        $otherTenant = TenantKey::create(TenantKey::generateEnvelopeKeys());
+
+        $this->registrar->setPermissionsTeamId($otherTenant->id);
+        Role::create(['name' => 'Manager', 'guard_name' => 'sanctum']);
+        $this->registrar->setPermissionsTeamId($this->tenant->id);
+        $this->registrar->forgetCachedPermissions();
+
+        $response = $this->withToken($this->token)
+            ->postJson('/v1/roles', [
+                'name' => 'Manager',
+                'permissions' => ['employees.read'],
+            ]);
+
+        $response->assertCreated()
+            ->assertJsonFragment(['name' => 'Manager']);
+
+        expect(Role::query()->where('name', 'Manager')->count())->toBe(2);
+    });
+
     test('returns 422 when permissions array contains non-existent permission', function (): void {
         $this->user->givePermissionTo('roles.create');
 
@@ -295,6 +317,28 @@ describe('PATCH /v1/roles/{id} - Update Role', function () {
 
         $response->assertStatus(422)
             ->assertJsonValidationErrors(['name']);
+    });
+
+    test('allows updating a role when the target name exists in another tenant', function (): void {
+        $this->user->givePermissionTo('roles.update');
+        $role = Role::create(['name' => 'Guard', 'guard_name' => 'sanctum']);
+
+        $otherTenant = TenantKey::create(TenantKey::generateEnvelopeKeys());
+
+        $this->registrar->setPermissionsTeamId($otherTenant->id);
+        Role::create(['name' => 'Manager', 'guard_name' => 'sanctum']);
+        $this->registrar->setPermissionsTeamId($this->tenant->id);
+        $this->registrar->forgetCachedPermissions();
+
+        $response = $this->withToken($this->token)
+            ->patchJson("/v1/roles/{$role->id}", [
+                'name' => 'Manager',
+            ]);
+
+        $response->assertOk()
+            ->assertJsonFragment(['name' => 'Manager']);
+
+        expect(Role::query()->where('name', 'Manager')->count())->toBe(2);
     });
 
     test('updates role name successfully', function (): void {


### PR DESCRIPTION
## Summary
- scope role-name uniqueness validation to the active tenant and the sanctum guard in the create and update form requests
- add regression coverage proving that different tenants can reuse the same role name on create and update
- record the fix in the API changelog

## Testing
- APP_KEY="base64:…" APP_ENV=testing DB_CONNECTION=pgsql DB_HOST=/var/run/postgresql DB_PORT=5432 DB_DATABASE=testing DB_USERNAME=holger php artisan test tests/Feature/RoleManagementApiTest.php
- vendor/bin/phpstan analyse app/Http/Requests/Api/V1/CreateRoleRequest.php app/Http/Requests/Api/V1/UpdateRoleRequest.php --no-progress
- vendor/bin/pint --dirty

Closes #926
Part of #929
