### PR TITLE
fix: paginate compliance alerts after filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- fixed `GET /v1/employees/compliance-alerts` to filter the full alert set before paginating, so warning/critical/expired work-permit and certification entries are no longer hidden behind non-alert employees and the pagination metadata now reports the real alert count (continues `api#472`)
 - made `POST /v1/employees` accept omitted `management_level` values for non-management hires again, defaulting persisted records to `0` so invite-enabled onboarding preparation no longer fails with `422 The management level field is required.` when clients do not send a leadership rank
 - blocked direct `PATCH /v1/employees/{employee}` writes to `bwr_status`, `bwr_id`, `bwr_notes`, and `bwr_registered_at` so BWR transitions and their audit trail must go through the dedicated `PUT /v1/employees/{employee}/bwr/status` endpoint (fixes `api#881`)
 - centralized employee compliance alert status values in `EmployeeComplianceService` and reused those constants in `IndexEmployeeRequest` validation/messages so filter rules stay synchronized with compliance business logic

--- a/README.md
+++ b/README.md
@@ -152,6 +152,29 @@ Operational notes:
 - Successful activation writes the `BWR status updated` audit entry, timestamps `bwr_registered_at`, and auto-deletes the stored ID document copy when it is no longer needed.
 - The auto-deletion also writes `ID document copy automatically deleted (BWR active)` to the audit log and queues the HR notification mail.
 
+### 📋 Compliance Alerts And Assignment Blocking
+
+SecPal exposes operational compliance alerts through `GET /v1/employees/compliance-alerts` for HR and dispatch overview screens.
+
+Supported alert sources include:
+
+- expiring or expired non-EU work permits
+- expiring ID documents
+- expiring firearms, first-aid, fire-safety, and evacuation certifications
+- expiring `additional_certifications` entries
+
+Operational rules:
+
+1. Use `compliance_status=warning`, `critical`, or `expired` to focus the overview on the highest active severity per employee.
+2. Treat `warning` as advance notice only. These employees still remain assignable.
+3. Treat `critical` and `expired` alerts as operational blockers. Site assignment creation rejects those employees with `422` and returns the blocking document list.
+4. Use the daily `php artisan employees:send-compliance-alert-notifications` command to queue the employee-facing warning, critical, and first-day-expired mails.
+
+Implementation notes:
+
+- The compliance-alerts endpoint filters the full alert set before pagination so `meta.total`, page boundaries, and alert visibility stay consistent even when non-alert employees exist in the same tenant scope.
+- Work-permit alerts are derived from the same `expiring_documents` aggregation that drives assignment blocking and notification delivery, so overview, dispatch, and mail flows stay synchronized.
+
 ### 🔒 Envelope Encryption
 
 - PHP 8.4 or higher

--- a/app/Http/Controllers/Api/V1/EmployeeController.php
+++ b/app/Http/Controllers/Api/V1/EmployeeController.php
@@ -25,6 +25,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Http\Response;
+use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 
@@ -66,6 +67,9 @@ class EmployeeController extends Controller
         /** @var string|null $complianceStatus */
         $complianceStatus = $request->input('compliance_status');
 
+        $perPage = $request->integer('per_page', 15);
+        $page = LengthAwarePaginator::resolveCurrentPage();
+
         $employees = $this->buildEmployeeIndexQuery($request)
             ->whereIn('status', [
                 Employee::STATUS_PRE_CONTRACT,
@@ -73,15 +77,22 @@ class EmployeeController extends Controller
                 Employee::STATUS_ON_LEAVE,
             ])
             ->with(['user', 'organizationalUnit'])
-            ->paginate($request->integer('per_page', 15));
+            ->get()
+            ->filter(fn (Employee $employee): bool => $complianceService->hasAlerts($employee, $complianceStatus))
+            ->values();
 
-        $employees->setCollection(
-            $employees->getCollection()
-                ->filter(fn (Employee $employee): bool => $complianceService->hasAlerts($employee, $complianceStatus))
-                ->values()
+        $paginatedEmployees = new LengthAwarePaginator(
+            $employees->forPage($page, $perPage)->values(),
+            $employees->count(),
+            $perPage,
+            $page,
+            [
+                'path' => $request->url(),
+                'query' => $request->query(),
+            ]
         );
 
-        return EmployeeResource::collection($employees);
+        return EmployeeResource::collection($paginatedEmployees);
     }
 
     /**

--- a/tests/Feature/Controllers/EmployeeControllerTest.php
+++ b/tests/Feature/Controllers/EmployeeControllerTest.php
@@ -256,6 +256,37 @@ describe('GET /v1/employees', function () {
             ->toContain('expired');
     });
 
+    test('compliance alerts endpoint paginates after alert filtering', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'employee.read');
+
+        Employee::factory(2)->create([
+            'tenant_id' => $this->tenant->id,
+            'organizational_unit_id' => $this->organizationalUnit->id,
+            'status' => Employee::STATUS_ACTIVE,
+        ]);
+
+        Employee::factory()->withExpiringWorkPermit()->create([
+            'tenant_id' => $this->tenant->id,
+            'organizational_unit_id' => $this->organizationalUnit->id,
+            'status' => Employee::STATUS_ACTIVE,
+            'email' => 'work-permit-alert@example.com',
+            'nationalities' => ['TR'],
+            'work_permit_expiry' => now()->addDays(5)->toDateString(),
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->getJson('/v1/employees/compliance-alerts?per_page=2');
+
+        $response->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.email', 'work-permit-alert@example.com')
+            ->assertJsonPath('meta.total', 1)
+            ->assertJsonPath('meta.per_page', 2);
+
+        expect(collect($response->json('data.0.expiring_documents'))->pluck('type')->all())
+            ->toContain('work_permit');
+    });
+
     test('filters employee compliance alerts by alert status', function (): void {
         givePermissionWithTenant($this->user, $this->tenant->id, 'employee.read');
 


### PR DESCRIPTION
## Summary
- fix the compliance alerts endpoint to filter before pagination so alert counts and page contents stay correct
- add a regression test covering expiring non-EU work permits behind non-alert employees
- document the compliance alert and assignment-blocking workflow in the API README

## Testing
- php artisan test tests/Feature/Controllers/EmployeeControllerTest.php
- php artisan test tests/Feature/Controllers/Api/V1/SiteAssignmentControllerTest.php --filter="critical compliance expiries|warning level compliance alerts only"
- vendor/bin/pint --dirty

Continues #472
