### PR TITLE
fix: block direct retention field writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- blocked direct `POST /v1/employees` and `PATCH /v1/employees/{employee}` writes to `employment_end_date` and `retention_period_end` so BewachV / GDPR retention dates remain lifecycle-managed by termination handling and observer-driven calculation instead of client-controlled payloads (continues `api#470`)
 - fixed `GET /v1/employees/compliance-alerts` to filter the full alert set before paginating, so warning/critical/expired work-permit and certification entries are no longer hidden behind non-alert employees and the pagination metadata now reports the real alert count (continues `api#472`)
 - made `POST /v1/employees` accept omitted `management_level` values for non-management hires again, defaulting persisted records to `0` so invite-enabled onboarding preparation no longer fails with `422 The management level field is required.` when clients do not send a leadership rank
 - blocked direct `PATCH /v1/employees/{employee}` writes to `bwr_status`, `bwr_id`, `bwr_notes`, and `bwr_registered_at` so BWR transitions and their audit trail must go through the dedicated `PUT /v1/employees/{employee}/bwr/status` endpoint (fixes `api#881`)

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Admin rule of thumb:
 - Use `pre_contract` if you want to invite the employee into onboarding.
 - Do not rely on form submission to discover the rule. The UI should explain the restriction before submit, and the API rejects `send_invitation: true` for every status other than `pre_contract`.
 - Filtering and validation use the same official status set: `applicant`, `pre_contract`, `active`, `on_leave`, `terminated`.
+- `employment_end_date` and `retention_period_end` are lifecycle-managed retention fields. Do not write them through the generic employee create or patch endpoints; they are derived during the termination / retention workflow.
 
 ### 🛂 BWR Manual Authority Submission Workflow
 

--- a/app/Http/Requests/StoreEmployeeRequest.php
+++ b/app/Http/Requests/StoreEmployeeRequest.php
@@ -121,8 +121,8 @@ class StoreEmployeeRequest extends FormRequest
             // This field is set server-side during file upload via dedicated upload endpoint
 
             // Retention & Employment End (BewachV § 21)
-            'employment_end_date' => ['nullable', 'date'],
-            'retention_period_end' => ['nullable', 'date'], // Auto-calculated by Observer
+            'employment_end_date' => ['missing'],
+            'retention_period_end' => ['missing'],
 
             // Tax & Social Security (will be encrypted)
             'tax_id' => ['nullable', 'string', 'max:255'],
@@ -257,6 +257,8 @@ class StoreEmployeeRequest extends FormRequest
             ]),
             'organizational_unit_id.required' => __('Organizational unit is required'),
             'send_invitation.boolean' => __('Invitation sending must be true or false'),
+            'employment_end_date.missing' => __('Retention fields are managed by the employee lifecycle and cannot be written directly.'),
+            'retention_period_end.missing' => __('Retention fields are managed by the employee lifecycle and cannot be written directly.'),
             'termination_date.after_or_equal' => __('Termination date must be after or equal to contract start date'),
 
             // BWR-ID validation

--- a/app/Http/Requests/UpdateEmployeeRequest.php
+++ b/app/Http/Requests/UpdateEmployeeRequest.php
@@ -103,8 +103,8 @@ class UpdateEmployeeRequest extends FormRequest
             // This field is set server-side during file upload via dedicated upload endpoint
 
             // Retention & Employment End
-            'employment_end_date' => ['sometimes', 'nullable', 'date'],
-            'retention_period_end' => ['sometimes', 'nullable', 'date'],
+            'employment_end_date' => ['missing'],
+            'retention_period_end' => ['missing'],
 
             // Tax & Social Security (will be encrypted)
             'tax_id' => ['sometimes', 'nullable', 'string', 'max:255'],
@@ -215,6 +215,8 @@ class UpdateEmployeeRequest extends FormRequest
             'bwr_status.missing' => __('BWR fields must be changed via the dedicated BWR status endpoint.'),
             'bwr_registered_at.missing' => __('BWR fields must be changed via the dedicated BWR status endpoint.'),
             'bwr_notes.missing' => __('BWR fields must be changed via the dedicated BWR status endpoint.'),
+            'employment_end_date.missing' => __('Retention fields are managed by the employee lifecycle and cannot be written directly.'),
+            'retention_period_end.missing' => __('Retention fields are managed by the employee lifecycle and cannot be written directly.'),
             'termination_date.after_or_equal' => __('Termination date must be after or equal to contract start date'),
 
             // ISO country codes

--- a/tests/Feature/Controllers/EmployeeControllerTest.php
+++ b/tests/Feature/Controllers/EmployeeControllerTest.php
@@ -767,6 +767,41 @@ describe('POST /v1/employees', function () {
         expect($number1)->not->toBe($number2);
         expect($number2)->toMatch('/^EMP-\d{4}-\d{4}$/');
     });
+
+    test('rejects direct retention field writes on employee creation', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'employee.write');
+
+        $response = $this->withToken($this->token)
+            ->postJson('/v1/employees', [
+                'first_name' => 'Rita',
+                'last_name' => 'Retention',
+                'email' => 'rita.retention@example.com',
+                'date_of_birth' => '1990-01-15',
+                'position' => 'Security Guard',
+                'status' => Employee::STATUS_PRE_CONTRACT,
+                'contract_type' => 'full_time',
+                'contract_start_date' => now()->addWeek()->toDateString(),
+                'weekly_hours' => 40,
+                'hourly_rate' => 15.50,
+                'organizational_unit_id' => $this->organizationalUnit->id,
+                'sachkunde_type' => 'none',
+                'work_permit_type' => 'none',
+                'criminal_record_status' => 'valid',
+                'management_level' => 0,
+                'employment_end_date' => now()->toDateString(),
+                'retention_period_end' => now()->addYears(3)->endOfYear()->toDateString(),
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors([
+                'employment_end_date' => 'Retention fields are managed by the employee lifecycle and cannot be written directly.',
+                'retention_period_end',
+            ]);
+
+        $this->assertDatabaseMissing('employees', [
+            'email' => 'rita.retention@example.com',
+        ]);
+    });
 });
 
 describe('GET /v1/employees/{employee}', function () {
@@ -1150,6 +1185,51 @@ describe('PATCH /v1/employees/{employee}', function () {
             'subject_type' => Employee::class,
             'subject_id' => $employee->id,
         ]);
+    });
+
+    test('rejects direct retention field changes via patch', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'employee.write');
+
+        $this->user->organizationalScopes()->create([
+            'organizational_unit_id' => $this->organizationalUnit->id,
+            'access_level' => 'manage',
+            'include_descendants' => true,
+            'min_viewable_rank' => 0,
+            'max_viewable_rank' => 0,
+            'allow_self_access' => true,
+        ]);
+        $this->user->organizationalScopes()->create([
+            'organizational_unit_id' => $this->organizationalUnit->id,
+            'access_level' => 'manage',
+            'include_descendants' => true,
+            'min_viewable_rank' => 1,
+            'max_viewable_rank' => 255,
+            'allow_self_access' => true,
+        ]);
+
+        $employee = Employee::factory()->create([
+            'tenant_id' => $this->tenant->id,
+            'organizational_unit_id' => $this->organizationalUnit->id,
+            'employment_end_date' => null,
+            'retention_period_end' => null,
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->patchJson("/v1/employees/{$employee->id}", [
+                'employment_end_date' => now()->toDateString(),
+                'retention_period_end' => now()->addYears(3)->endOfYear()->toDateString(),
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors([
+                'employment_end_date' => 'Retention fields are managed by the employee lifecycle and cannot be written directly.',
+                'retention_period_end',
+            ]);
+
+        $employee->refresh();
+
+        expect($employee->employment_end_date)->toBeNull()
+            ->and($employee->retention_period_end)->toBeNull();
     });
 });
 


### PR DESCRIPTION
## Summary
- block direct client writes to `employment_end_date` and `retention_period_end` on generic employee create and patch requests
- add focused controller regressions proving retention fields remain lifecycle-managed
- document the lifecycle-managed retention fields in the API README and changelog

## Testing
- php artisan test tests/Feature/Controllers/EmployeeControllerTest.php
- vendor/bin/pint --dirty

Continues #470
