### PR TITLE
refactor: move onboarding template localization boundary

### DIFF
--- a/app/Http/Controllers/Api/V1/OnboardingController.php
+++ b/app/Http/Controllers/Api/V1/OnboardingController.php
@@ -816,7 +816,7 @@ class OnboardingController extends Controller
     private function prepareLocalizedTemplate(OnboardingFormTemplate $template, string $locale): void
     {
         $template->setAttribute(
-            OnboardingFormTemplateResource::LOCALIZED_TEMPLATE_ATTRIBUTE,
+            OnboardingFormTemplate::LOCALIZED_TEMPLATE_ATTRIBUTE,
             $this->onboardingSchemaLocalizationService->localizeTemplate($template, $locale),
         );
     }

--- a/app/Http/Controllers/Api/V1/OnboardingController.php
+++ b/app/Http/Controllers/Api/V1/OnboardingController.php
@@ -770,6 +770,9 @@ class OnboardingController extends Controller
         ]);
     }
 
+    /**
+     * @param  iterable<OnboardingFormTemplate>  $templates
+     */
     private function prepareLocalizedTemplates(iterable $templates, string $locale): void
     {
         foreach ($templates as $template) {
@@ -781,6 +784,9 @@ class OnboardingController extends Controller
         }
     }
 
+    /**
+     * @param  iterable<OnboardingFormSubmission>  $submissions
+     */
     private function prepareLocalizedSubmissionTemplates(iterable $submissions, string $locale): void
     {
         foreach ($submissions as $submission) {

--- a/app/Http/Controllers/Api/V1/OnboardingController.php
+++ b/app/Http/Controllers/Api/V1/OnboardingController.php
@@ -19,6 +19,7 @@ use App\Models\OnboardingFormSubmission;
 use App\Models\OnboardingFormTemplate;
 use App\Models\OnboardingSubmissionFile;
 use App\Services\OnboardingCompletionService;
+use App\Services\OnboardingSchemaLocalizationService;
 use App\Services\OnboardingSubmissionFileStorageService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -44,7 +45,8 @@ use Illuminate\Validation\ValidationException;
 class OnboardingController extends Controller
 {
     public function __construct(
-        private readonly OnboardingSubmissionFileStorageService $submissionFileStorageService
+        private readonly OnboardingSubmissionFileStorageService $submissionFileStorageService,
+        private readonly OnboardingSchemaLocalizationService $onboardingSchemaLocalizationService,
     ) {}
 
     /**
@@ -376,6 +378,8 @@ class OnboardingController extends Controller
             ->orderBy('name')
             ->get();
 
+        $this->prepareLocalizedTemplates($templates, $this->resolveTemplateLocale($request));
+
         return response()->json([
             'data' => OnboardingFormTemplateResource::collection($templates),
         ]);
@@ -386,9 +390,11 @@ class OnboardingController extends Controller
      *
      * GET /api/v1/onboarding/templates/{template}
      */
-    public function getTemplate(OnboardingFormTemplate $template): JsonResponse
+    public function getTemplate(Request $request, OnboardingFormTemplate $template): JsonResponse
     {
         $this->authorize('view', $template);
+
+        $this->prepareLocalizedTemplate($template, $this->resolveTemplateLocale($request));
 
         return response()->json([
             'data' => new OnboardingFormTemplateResource($template),
@@ -419,6 +425,8 @@ class OnboardingController extends Controller
         $submissions = $employee->onboardingSubmissions()
             ->with('formTemplate')
             ->get();
+
+        $this->prepareLocalizedSubmissionTemplates($submissions, $this->resolveTemplateLocale($request));
 
         return response()->json([
             'data' => OnboardingFormSubmissionResource::collection($submissions),
@@ -523,6 +531,8 @@ class OnboardingController extends Controller
             app(OnboardingCompletionService::class)->checkCompletion($employee);
         }
 
+        $this->prepareLocalizedSubmissionTemplate($submission, $this->resolveTemplateLocale($request));
+
         return response()->json([
             'data' => new OnboardingFormSubmissionResource($submission),
         ], $existing ? Response::HTTP_OK : Response::HTTP_CREATED);
@@ -603,6 +613,8 @@ class OnboardingController extends Controller
         if ($status === 'submitted') {
             app(OnboardingCompletionService::class)->checkCompletion($employee);
         }
+
+        $this->prepareLocalizedSubmissionTemplate($submission, $this->resolveTemplateLocale($request));
 
         return response()->json([
             'data' => new OnboardingFormSubmissionResource($submission),
@@ -697,6 +709,8 @@ class OnboardingController extends Controller
         $employee = $submission->employee;
         app(OnboardingCompletionService::class)->checkCompletion($employee);
 
+        $this->prepareLocalizedSubmissionTemplate($fresh, $this->resolveTemplateLocale($request));
+
         return response()->json([
             'data' => new OnboardingFormSubmissionResource($fresh),
         ]);
@@ -749,9 +763,69 @@ class OnboardingController extends Controller
         $fresh = $submission->fresh();
         $fresh->load(['formTemplate', 'reviewer']);
 
+        $this->prepareLocalizedSubmissionTemplate($fresh, $this->resolveTemplateLocale($request));
+
         return response()->json([
             'data' => new OnboardingFormSubmissionResource($fresh),
         ]);
+    }
+
+    private function prepareLocalizedTemplates(iterable $templates, string $locale): void
+    {
+        foreach ($templates as $template) {
+            if (! $template instanceof OnboardingFormTemplate) {
+                continue;
+            }
+
+            $this->prepareLocalizedTemplate($template, $locale);
+        }
+    }
+
+    private function prepareLocalizedSubmissionTemplates(iterable $submissions, string $locale): void
+    {
+        foreach ($submissions as $submission) {
+            if (! $submission instanceof OnboardingFormSubmission) {
+                continue;
+            }
+
+            $this->prepareLocalizedSubmissionTemplate($submission, $locale);
+        }
+    }
+
+    private function prepareLocalizedSubmissionTemplate(OnboardingFormSubmission $submission, string $locale): void
+    {
+        if (! $submission->relationLoaded('formTemplate')) {
+            return;
+        }
+
+        $template = $submission->formTemplate;
+
+        if (! $template instanceof OnboardingFormTemplate) {
+            return;
+        }
+
+        $this->prepareLocalizedTemplate($template, $locale);
+    }
+
+    private function prepareLocalizedTemplate(OnboardingFormTemplate $template, string $locale): void
+    {
+        $template->setAttribute(
+            OnboardingFormTemplateResource::LOCALIZED_TEMPLATE_ATTRIBUTE,
+            $this->onboardingSchemaLocalizationService->localizeTemplate($template, $locale),
+        );
+    }
+
+    private function resolveTemplateLocale(Request $request): string
+    {
+        $preferredLocale = $request->user()?->preferred_locale;
+
+        if (is_string($preferredLocale) && in_array($preferredLocale, OnboardingSchemaLocalizationService::SUPPORTED_LOCALES, true)) {
+            return $preferredLocale;
+        }
+
+        $requestLocale = $request->getPreferredLanguage(OnboardingSchemaLocalizationService::SUPPORTED_LOCALES);
+
+        return is_string($requestLocale) ? $requestLocale : OnboardingSchemaLocalizationService::DEFAULT_LOCALE;
     }
 
     /**

--- a/app/Http/Resources/OnboardingFormTemplateResource.php
+++ b/app/Http/Resources/OnboardingFormTemplateResource.php
@@ -1,6 +1,6 @@
 <?php
 
-// SPDX-FileCopyrightText: 2025 SecPal Contributors
+// SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 namespace App\Http\Resources;

--- a/app/Http/Resources/OnboardingFormTemplateResource.php
+++ b/app/Http/Resources/OnboardingFormTemplateResource.php
@@ -18,8 +18,6 @@ use Illuminate\Http\Resources\Json\JsonResource;
  */
 class OnboardingFormTemplateResource extends JsonResource
 {
-    public const LOCALIZED_TEMPLATE_ATTRIBUTE = 'localized_template_payload';
-
     /**
      * Disable wrapping for single resources.
      *
@@ -37,7 +35,7 @@ class OnboardingFormTemplateResource extends JsonResource
         /** @var OnboardingFormTemplate $template */
         $template = $this->resource;
 
-        $localizedTemplate = $template->getAttribute(self::LOCALIZED_TEMPLATE_ATTRIBUTE);
+        $localizedTemplate = $template->getAttribute(OnboardingFormTemplate::LOCALIZED_TEMPLATE_ATTRIBUTE);
 
         if (! is_array($localizedTemplate)) {
             $localizedTemplate = [

--- a/app/Http/Resources/OnboardingFormTemplateResource.php
+++ b/app/Http/Resources/OnboardingFormTemplateResource.php
@@ -6,7 +6,6 @@
 namespace App\Http\Resources;
 
 use App\Models\OnboardingFormTemplate;
-use App\Services\OnboardingSchemaLocalizationService;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
@@ -19,6 +18,8 @@ use Illuminate\Http\Resources\Json\JsonResource;
  */
 class OnboardingFormTemplateResource extends JsonResource
 {
+    public const LOCALIZED_TEMPLATE_ATTRIBUTE = 'localized_template_payload';
+
     /**
      * Disable wrapping for single resources.
      *
@@ -36,8 +37,15 @@ class OnboardingFormTemplateResource extends JsonResource
         /** @var OnboardingFormTemplate $template */
         $template = $this->resource;
 
-        $localizedTemplate = app(OnboardingSchemaLocalizationService::class)
-            ->localizeTemplate($template, $this->resolveLocale($request));
+        $localizedTemplate = $template->getAttribute(self::LOCALIZED_TEMPLATE_ATTRIBUTE);
+
+        if (! is_array($localizedTemplate)) {
+            $localizedTemplate = [
+                'name' => $template->name,
+                'description' => $template->description,
+                'form_schema' => is_array($template->form_schema) ? $template->form_schema : [],
+            ];
+        }
 
         return [
             'id' => $this->id,
@@ -53,18 +61,5 @@ class OnboardingFormTemplateResource extends JsonResource
             'created_at' => $this->created_at?->toIso8601String(),
             'updated_at' => $this->updated_at?->toIso8601String(),
         ];
-    }
-
-    private function resolveLocale(Request $request): string
-    {
-        $preferredLocale = $request->user()?->preferred_locale;
-
-        if (is_string($preferredLocale) && in_array($preferredLocale, OnboardingSchemaLocalizationService::SUPPORTED_LOCALES, true)) {
-            return $preferredLocale;
-        }
-
-        $requestLocale = $request->getPreferredLanguage(OnboardingSchemaLocalizationService::SUPPORTED_LOCALES);
-
-        return is_string($requestLocale) ? $requestLocale : OnboardingSchemaLocalizationService::DEFAULT_LOCALE;
     }
 }

--- a/app/Models/OnboardingFormTemplate.php
+++ b/app/Models/OnboardingFormTemplate.php
@@ -1,6 +1,6 @@
 <?php
 
-// SPDX-FileCopyrightText: 2025 SecPal Contributors
+// SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 namespace App\Models;
@@ -27,6 +27,8 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  */
 class OnboardingFormTemplate extends Model
 {
+    public const LOCALIZED_TEMPLATE_ATTRIBUTE = 'localized_template_payload';
+
     /** @use HasFactory<\Database\Factories\OnboardingFormTemplateFactory> */
     use EnforcesTenantRouteBinding, HasFactory, HasUuids, SoftDeletes {
         EnforcesTenantRouteBinding::resolveRouteBindingQuery insteadof HasUuids;

--- a/tests/Feature/Controllers/OnboardingControllerTest.php
+++ b/tests/Feature/Controllers/OnboardingControllerTest.php
@@ -311,6 +311,32 @@ describe('GET /v1/onboarding/submissions', function () {
         expect($response->json('data'))->toHaveCount(1);
         expect($response->json('data')[0]['employee_id'])->toBe($this->employee->id);
     });
+
+    test('localizes nested submission form template metadata using request locale', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.read');
+
+        $this->artisan('db:seed', ['--class' => Database\Seeders\OnboardingFormTemplatesSeeder::class])
+            ->assertSuccessful();
+
+        $template = OnboardingFormTemplate::query()
+            ->whereNull('tenant_id')
+            ->where('name', 'Personal Information Form')
+            ->firstOrFail();
+
+        OnboardingFormSubmission::factory()->create([
+            'employee_id' => $this->employee->id,
+            'form_template_id' => $template->id,
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->withHeader('Accept-Language', 'de-DE,de;q=0.9,en;q=0.8')
+            ->getJson('/v1/onboarding/submissions');
+
+        $response->assertOk()
+            ->assertJsonPath('data.0.form_template.name', 'Persönliche Informationen')
+            ->assertJsonPath('data.0.form_template.description', 'BewachV Paragraf 16 erforderliche Informationen für das Bewacherregister')
+            ->assertJsonPath('data.0.form_template.form_schema.title', 'Persönliche Informationen');
+    });
 });
 
 describe('POST /v1/onboarding/submissions', function () {

--- a/tests/Unit/Policies/OnboardingFormTemplatePolicyTest.php
+++ b/tests/Unit/Policies/OnboardingFormTemplatePolicyTest.php
@@ -145,7 +145,7 @@ describe('OnboardingFormTemplateResource - API Response', function () {
             'form_schema' => ['title' => 'Original title'],
         ]);
 
-        $template->setAttribute('localized_template_payload', [
+        $template->setAttribute(OnboardingFormTemplate::LOCALIZED_TEMPLATE_ATTRIBUTE, [
             'name' => 'Persönliche Informationen',
             'description' => 'Vorlokalisierte Beschreibung',
             'form_schema' => ['title' => 'Vorlokalisierter Titel'],

--- a/tests/Unit/Policies/OnboardingFormTemplatePolicyTest.php
+++ b/tests/Unit/Policies/OnboardingFormTemplatePolicyTest.php
@@ -1,6 +1,6 @@
 <?php
 
-// SPDX-FileCopyrightText: 2025 SecPal Contributors
+// SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use App\Models\OnboardingFormTemplate;

--- a/tests/Unit/Policies/OnboardingFormTemplatePolicyTest.php
+++ b/tests/Unit/Policies/OnboardingFormTemplatePolicyTest.php
@@ -6,6 +6,7 @@
 use App\Models\OnboardingFormTemplate;
 use App\Models\TenantKey;
 use App\Models\User;
+use App\Services\OnboardingSchemaLocalizationService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Spatie\Permission\Models\Permission;
 use Spatie\Permission\PermissionRegistrar;
@@ -137,6 +138,31 @@ describe('OnboardingFormTemplate Model - Accessors', function () {
 });
 
 describe('OnboardingFormTemplateResource - API Response', function () {
+    it('uses prelocalized template payloads without resolving the localization service', function () {
+        $template = OnboardingFormTemplate::factory()->create([
+            'name' => 'Personal Information Form',
+            'description' => 'Original description',
+            'form_schema' => ['title' => 'Original title'],
+        ]);
+
+        $template->setAttribute('localized_template_payload', [
+            'name' => 'Persönliche Informationen',
+            'description' => 'Vorlokalisierte Beschreibung',
+            'form_schema' => ['title' => 'Vorlokalisierter Titel'],
+        ]);
+
+        app()->bind(OnboardingSchemaLocalizationService::class, static function (): never {
+            throw new RuntimeException('The resource must not resolve the localization service.');
+        });
+
+        $resource = app(App\Http\Resources\OnboardingFormTemplateResource::class, ['resource' => $template]);
+        $response = $resource->toArray(request());
+
+        expect($response['name'])->toBe('Persönliche Informationen')
+            ->and($response['description'])->toBe('Vorlokalisierte Beschreibung')
+            ->and($response['form_schema']['title'])->toBe('Vorlokalisierter Titel');
+    });
+
     it('includes can_be_deleted and can_be_edited flags for system templates', function () {
         $systemTemplate = OnboardingFormTemplate::factory()->create([
             'is_system_template' => true,

--- a/tests/Unit/Policies/OnboardingFormTemplatePolicyTest.php
+++ b/tests/Unit/Policies/OnboardingFormTemplatePolicyTest.php
@@ -155,12 +155,17 @@ describe('OnboardingFormTemplateResource - API Response', function () {
             throw new RuntimeException('The resource must not resolve the localization service.');
         });
 
-        $resource = app(App\Http\Resources\OnboardingFormTemplateResource::class, ['resource' => $template]);
-        $response = $resource->toArray(request());
+        try {
+            $resource = app(App\Http\Resources\OnboardingFormTemplateResource::class, ['resource' => $template]);
+            $response = $resource->toArray(request());
 
-        expect($response['name'])->toBe('Persönliche Informationen')
-            ->and($response['description'])->toBe('Vorlokalisierte Beschreibung')
-            ->and($response['form_schema']['title'])->toBe('Vorlokalisierter Titel');
+            expect($response['name'])->toBe('Persönliche Informationen')
+                ->and($response['description'])->toBe('Vorlokalisierte Beschreibung')
+                ->and($response['form_schema']['title'])->toBe('Vorlokalisierter Titel');
+        } finally {
+            app()->forgetInstance(OnboardingSchemaLocalizationService::class);
+            app()->offsetUnset(OnboardingSchemaLocalizationService::class);
+        }
     });
 
     it('includes can_be_deleted and can_be_edited flags for system templates', function () {


### PR DESCRIPTION
## Summary
- move onboarding template localization preparation out of `OnboardingFormTemplateResource`
- prepare localized template payloads in `OnboardingController` for template and submission responses
- add regression coverage for prelocalized resource payloads and localized nested submission templates

## Validation
- `php artisan test tests/Unit/Policies/OnboardingFormTemplatePolicyTest.php --filter="uses prelocalized template payloads without resolving the localization service"`
- `php artisan test tests/Feature/Controllers/OnboardingControllerTest.php --filter="localizes template list metadata using request locale|localizes system template schema using accept language header|prefers user locale over accept language header when localizing templates|localizes nested submission form template metadata using request locale"`
- `php artisan test tests/Feature/Controllers/OnboardingControllerTest.php tests/Unit/Policies/OnboardingFormTemplatePolicyTest.php`
- `vendor/bin/pint --dirty`
- pre-push preflight (`phpstan`, REUSE, domain policy)

Closes #927
