### PR TITLE
feat: add stable template_key to OnboardingFormTemplate for localization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- introduced stable `template_key` column on `onboarding_form_templates` so `OnboardingSchemaLocalizationService` uses the immutable key for translation lookup instead of deriving it from the mutable `name` field; system templates are seeded with their keys; tenant templates without a key fall back to the existing `Str::snake($name)` derivation (fixes api#832)
 - added the first `api#472` non-EU work-permit core slice: encrypted `work_permit_number` storage, richer work-permit types, conditional non-EU validation, work-authorization and expiring-document computed fields, factory states for permit-bearing employees, and GDPR-driven work-permit copy deletion when BWR approval or permanent authorization makes the copy unnecessary
 - added the `api#869` employee certification-expiry core slice: encrypted firearms-license storage, first-aid/fire-safety/evacuation tracking fields, structured `additional_certifications`, request validation, factory coverage, and expanded `expiring_documents` aggregation for soon-to-expire or expired compliance records
 - added the first `api#872` operational certification integration slice: `GET /v1/employees/compliance-alerts` for HR/compliance overview filtering and automatic site-assignment blocking when a linked employee has expired or critical compliance documents

--- a/app/Models/OnboardingFormTemplate.php
+++ b/app/Models/OnboardingFormTemplate.php
@@ -19,6 +19,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property string $id
  * @property int|null $tenant_id
  * @property string $name
+ * @property string|null $template_key
  * @property array<string, mixed>|null $form_schema JSON schema for the form
  * @property string|null $description
  * @property bool $is_required
@@ -38,6 +39,7 @@ class OnboardingFormTemplate extends Model
     protected $fillable = [
         'tenant_id',
         'name',
+        'template_key',
         'description',
         'form_schema',
         'is_required',

--- a/app/Services/OnboardingSchemaLocalizationService.php
+++ b/app/Services/OnboardingSchemaLocalizationService.php
@@ -23,7 +23,9 @@ class OnboardingSchemaLocalizationService
     public function localizeTemplate(OnboardingFormTemplate $template, string $locale): array
     {
         $normalizedLocale = $this->normalizeLocale($locale);
-        $templateKey = Str::snake($template->name);
+        $templateKey = ($template->template_key !== null && $template->template_key !== '')
+            ? $template->template_key
+            : Str::snake($template->name);
         $schema = is_array($template->form_schema) ? $template->form_schema : [];
 
         return [

--- a/app/Services/OnboardingSchemaLocalizationService.php
+++ b/app/Services/OnboardingSchemaLocalizationService.php
@@ -23,8 +23,9 @@ class OnboardingSchemaLocalizationService
     public function localizeTemplate(OnboardingFormTemplate $template, string $locale): array
     {
         $normalizedLocale = $this->normalizeLocale($locale);
-        $templateKey = ($template->template_key !== null && $template->template_key !== '')
-            ? $template->template_key
+        $raw = $template->template_key;
+        $templateKey = ($raw !== null && $raw !== '')
+            ? Str::snake($raw)
             : Str::snake($template->name);
         $schema = is_array($template->form_schema) ? $template->form_schema : [];
 

--- a/database/factories/OnboardingFormTemplateFactory.php
+++ b/database/factories/OnboardingFormTemplateFactory.php
@@ -23,6 +23,7 @@ class OnboardingFormTemplateFactory extends Factory
         return [
             'tenant_id' => TenantKey::factory(),
             'name' => fake()->sentence(3),
+            'template_key' => null,
             'description' => fake()->sentence(),
             'form_schema' => [
                 'fields' => [

--- a/database/migrations/2026_04_18_100000_add_template_key_to_onboarding_form_templates_table.php
+++ b/database/migrations/2026_04_18_100000_add_template_key_to_onboarding_form_templates_table.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('onboarding_form_templates', function (Blueprint $table): void {
+            $table->string('template_key')->nullable()->after('name');
+            $table->unique(['template_key', 'tenant_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('onboarding_form_templates', function (Blueprint $table): void {
+            $table->dropUnique(['template_key', 'tenant_id']);
+            $table->dropColumn('template_key');
+        });
+    }
+};

--- a/database/migrations/2026_04_18_100000_add_template_key_to_onboarding_form_templates_table.php
+++ b/database/migrations/2026_04_18_100000_add_template_key_to_onboarding_form_templates_table.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
@@ -14,15 +15,46 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('onboarding_form_templates', function (Blueprint $table): void {
-            $table->string('template_key')->nullable()->after('name');
-            $table->unique(['template_key', 'tenant_id']);
+            $table->string('template_key')->nullable();
         });
+
+        // Backfill stable keys for existing system templates before adding unique constraints.
+        $systemKeys = [
+            'Personal Information Form' => 'personal_information_form',
+            'Bank Account Details' => 'bank_account_details',
+            'Emergency Contact' => 'emergency_contact',
+            'Tax Identification Number' => 'tax_identification_number',
+        ];
+
+        foreach ($systemKeys as $name => $key) {
+            DB::table('onboarding_form_templates')
+                ->where('name', $name)
+                ->whereNull('tenant_id')
+                ->where('is_system_template', true)
+                ->whereNull('template_key')
+                ->update(['template_key' => $key]);
+        }
+
+        // Partial unique index for system templates (tenant_id IS NULL).
+        DB::statement(
+            'CREATE UNIQUE INDEX onboarding_form_templates_template_key_system_unique
+             ON onboarding_form_templates (template_key)
+             WHERE tenant_id IS NULL'
+        );
+        // Partial unique index for tenant-owned templates (tenant_id IS NOT NULL).
+        DB::statement(
+            'CREATE UNIQUE INDEX onboarding_form_templates_template_key_tenant_unique
+             ON onboarding_form_templates (template_key, tenant_id)
+             WHERE tenant_id IS NOT NULL'
+        );
     }
 
     public function down(): void
     {
+        DB::statement('DROP INDEX IF EXISTS onboarding_form_templates_template_key_system_unique');
+        DB::statement('DROP INDEX IF EXISTS onboarding_form_templates_template_key_tenant_unique');
+
         Schema::table('onboarding_form_templates', function (Blueprint $table): void {
-            $table->dropUnique(['template_key', 'tenant_id']);
             $table->dropColumn('template_key');
         });
     }

--- a/database/migrations/2026_04_18_100000_add_template_key_to_onboarding_form_templates_table.php
+++ b/database/migrations/2026_04_18_100000_add_template_key_to_onboarding_form_templates_table.php
@@ -6,6 +6,7 @@ declare(strict_types=1);
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Query\Builder;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
@@ -32,7 +33,7 @@ return new class extends Migration
                 ->whereNull('tenant_id')
                 ->where('is_system_template', true)
                 ->whereNull('template_key')
-                ->where(function ($query) use ($systemTemplate): void {
+                ->where(function (Builder $query) use ($systemTemplate): void {
                     $query->where('sort_order', $systemTemplate['sort_order'])
                         ->orWhereIn('name', $systemTemplate['names']);
                 })

--- a/database/migrations/2026_04_18_100000_add_template_key_to_onboarding_form_templates_table.php
+++ b/database/migrations/2026_04_18_100000_add_template_key_to_onboarding_form_templates_table.php
@@ -20,7 +20,8 @@ return new class extends Migration
         });
 
         // Backfill stable keys for existing system templates before adding unique constraints.
-        // Match by sort_order (stable) with name as fallback for upgrade compatibility.
+        // Resolve each row to a single primary key first to prevent multiple-row assignments
+        // if sort_order or names ever overlap across system templates.
         $systemTemplates = [
             ['template_key' => 'personal_information_form', 'sort_order' => 1, 'names' => ['Personal Information Form']],
             ['template_key' => 'bank_account_details', 'sort_order' => 2, 'names' => ['Bank Account Details']],
@@ -29,7 +30,7 @@ return new class extends Migration
         ];
 
         foreach ($systemTemplates as $systemTemplate) {
-            DB::table('onboarding_form_templates')
+            $id = DB::table('onboarding_form_templates')
                 ->whereNull('tenant_id')
                 ->where('is_system_template', true)
                 ->whereNull('template_key')
@@ -37,7 +38,13 @@ return new class extends Migration
                     $query->where('sort_order', $systemTemplate['sort_order'])
                         ->orWhereIn('name', $systemTemplate['names']);
                 })
-                ->update(['template_key' => $systemTemplate['template_key']]);
+                ->value('id');
+
+            if ($id !== null) {
+                DB::table('onboarding_form_templates')
+                    ->where('id', $id)
+                    ->update(['template_key' => $systemTemplate['template_key']]);
+            }
         }
 
         // Partial unique index for system templates (tenant_id IS NULL).

--- a/database/migrations/2026_04_18_100000_add_template_key_to_onboarding_form_templates_table.php
+++ b/database/migrations/2026_04_18_100000_add_template_key_to_onboarding_form_templates_table.php
@@ -19,20 +19,24 @@ return new class extends Migration
         });
 
         // Backfill stable keys for existing system templates before adding unique constraints.
-        $systemKeys = [
-            'Personal Information Form' => 'personal_information_form',
-            'Bank Account Details' => 'bank_account_details',
-            'Emergency Contact' => 'emergency_contact',
-            'Tax Identification Number' => 'tax_identification_number',
+        // Match by sort_order (stable) with name as fallback for upgrade compatibility.
+        $systemTemplates = [
+            ['template_key' => 'personal_information_form', 'sort_order' => 1, 'names' => ['Personal Information Form']],
+            ['template_key' => 'bank_account_details', 'sort_order' => 2, 'names' => ['Bank Account Details']],
+            ['template_key' => 'emergency_contact', 'sort_order' => 3, 'names' => ['Emergency Contact']],
+            ['template_key' => 'tax_identification_number', 'sort_order' => 4, 'names' => ['Tax Identification Number']],
         ];
 
-        foreach ($systemKeys as $name => $key) {
+        foreach ($systemTemplates as $systemTemplate) {
             DB::table('onboarding_form_templates')
-                ->where('name', $name)
                 ->whereNull('tenant_id')
                 ->where('is_system_template', true)
                 ->whereNull('template_key')
-                ->update(['template_key' => $key]);
+                ->where(function ($query) use ($systemTemplate): void {
+                    $query->where('sort_order', $systemTemplate['sort_order'])
+                        ->orWhereIn('name', $systemTemplate['names']);
+                })
+                ->update(['template_key' => $systemTemplate['template_key']]);
         }
 
         // Partial unique index for system templates (tenant_id IS NULL).

--- a/database/seeders/OnboardingFormTemplatesSeeder.php
+++ b/database/seeders/OnboardingFormTemplatesSeeder.php
@@ -1,6 +1,6 @@
 <?php
 
-// SPDX-FileCopyrightText: 2025 SecPal Contributors
+// SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 namespace Database\Seeders;
@@ -18,15 +18,17 @@ class OnboardingFormTemplatesSeeder extends Seeder
         $templates = [
             [
                 'name' => 'Personal Information Form',
+                'template_key' => 'personal_information_form',
                 'description' => 'BewachV § 16 required information for Bewacherregister',
                 'form_schema' => $this->getPersonalInformationSchema(),
                 'is_required' => true,
                 'is_system_template' => true,
                 'sort_order' => 1,
-                'tenant_id' => null, // System-wide template
+                'tenant_id' => null,
             ],
             [
                 'name' => 'Bank Account Details',
+                'template_key' => 'bank_account_details',
                 'description' => 'Account information for salary payment',
                 'form_schema' => $this->getBankAccountSchema(),
                 'is_required' => false,
@@ -36,6 +38,7 @@ class OnboardingFormTemplatesSeeder extends Seeder
             ],
             [
                 'name' => 'Emergency Contact',
+                'template_key' => 'emergency_contact',
                 'description' => 'Emergency contact persons',
                 'form_schema' => $this->getEmergencyContactSchema(),
                 'is_required' => false,
@@ -45,6 +48,7 @@ class OnboardingFormTemplatesSeeder extends Seeder
             ],
             [
                 'name' => 'Tax Identification Number',
+                'template_key' => 'tax_identification_number',
                 'description' => 'Tax ID and tax class information (§ 39e EStG)',
                 'form_schema' => $this->getTaxIdentificationSchema(),
                 'is_required' => false,
@@ -57,7 +61,7 @@ class OnboardingFormTemplatesSeeder extends Seeder
         foreach ($templates as $template) {
             OnboardingFormTemplate::updateOrCreate(
                 [
-                    'name' => $template['name'],
+                    'template_key' => $template['template_key'],
                     'tenant_id' => null,
                 ],
                 $template

--- a/tests/Unit/Services/OnboardingSchemaLocalizationServiceTest.php
+++ b/tests/Unit/Services/OnboardingSchemaLocalizationServiceTest.php
@@ -68,3 +68,51 @@ test('it falls back to stored values when no translation exists', function (): v
         ->and($localized['form_schema']['title'])->toBe('Tenant Custom Form')
         ->and($localized['form_schema']['properties']['custom_field']['title'])->toBe('Custom Field');
 });
+
+test('it uses template_key for translation lookup when name has changed', function (): void {
+    $template = OnboardingFormTemplate::factory()->make([
+        'tenant_id' => null,
+        'is_system_template' => true,
+        'name' => 'Renamed Emergency Contact Form',
+        'template_key' => 'emergency_contact',
+        'description' => 'Emergency contact persons',
+        'form_schema' => [
+            'title' => 'Emergency Contact',
+            'description' => 'Emergency contact persons',
+            'type' => 'object',
+            'properties' => [
+                'contact_1_relationship' => [
+                    'type' => 'string',
+                    'title' => 'Contact 1: Relationship',
+                    'enum' => ['spouse', 'partner', 'parent', 'sibling'],
+                ],
+            ],
+        ],
+    ]);
+
+    $localized = app(OnboardingSchemaLocalizationService::class)->localizeTemplate($template, 'de');
+
+    expect($localized['name'])->toBe('Notfallkontakt')
+        ->and($localized['description'])->toBe('Ansprechpartner für Notfälle')
+        ->and($localized['form_schema']['title'])->toBe('Notfallkontakt');
+});
+
+test('it falls back to snake-case name when template_key is null', function (): void {
+    $template = OnboardingFormTemplate::factory()->make([
+        'tenant_id' => null,
+        'is_system_template' => true,
+        'name' => 'Emergency Contact',
+        'template_key' => null,
+        'description' => 'Emergency contact persons',
+        'form_schema' => [
+            'title' => 'Emergency Contact',
+            'type' => 'object',
+            'properties' => [],
+        ],
+    ]);
+
+    $localized = app(OnboardingSchemaLocalizationService::class)->localizeTemplate($template, 'de');
+
+    expect($localized['name'])->toBe('Notfallkontakt')
+        ->and($localized['description'])->toBe('Ansprechpartner für Notfälle');
+});


### PR DESCRIPTION
## Summary

Introduces a stable `template_key` column on `onboarding_form_templates` so `OnboardingSchemaLocalizationService` uses an immutable identifier for translation lookup instead of deriving one from the mutable `name` field.

Closes #832

## Changes

- **migration** (`2026_04_18_100000_add_template_key_to_onboarding_form_templates_table.php`): nullable `template_key` string column with unique index scoped to `(template_key, tenant_id)`
- **model** (`OnboardingFormTemplate`): `template_key` added to `$fillable` and `@property` docblock
- **factory** (`OnboardingFormTemplateFactory`): `template_key` defaults to `null`
- **seeder** (`OnboardingFormTemplatesSeeder`): all 4 system templates seeded with stable keys; `updateOrCreate` now matches on `template_key` instead of `name` for system rows
- **service** (`OnboardingSchemaLocalizationService`): uses `template_key` when set, falls back to `Str::snake($name)` for tenant-owned templates without a key
- **tests** (`OnboardingSchemaLocalizationServiceTest`): two new tests — one validating key-based lookup despite a renamed `name`, one confirming the `null`-key fallback still resolves correctly

## Test Evidence

TDD red → green confirmed:
- `it uses template_key for translation lookup when name has changed` — failed before service fix, passes after
- `it falls back to snake-case name when template_key is null` — always passes (null fallback unbroken)
- All 233 onboarding-scoped tests pass
- Preflight: REUSE, domain policy, PHPStan, Pint all clean
