### PR TITLE
fix: upgrade phpunit child-process security patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- upgraded `phpunit/phpunit` to `12.5.23` together with `pestphp/pest` `4.6.3` so the test runner no longer remains pinned to a vulnerable PHPUnit child-process INI forwarding release range (`GHSA-qrr6-mg7r-m243`)
 - blocked direct `POST /v1/employees` and `PATCH /v1/employees/{employee}` writes to `employment_end_date` and `retention_period_end` so BewachV / GDPR retention dates remain lifecycle-managed by termination handling and observer-driven calculation instead of client-controlled payloads (continues `api#470`)
 - fixed `GET /v1/employees/compliance-alerts` to filter the full alert set before paginating, so warning/critical/expired work-permit and certification entries are no longer hidden behind non-alert employees and the pagination metadata now reports the real alert count (continues `api#472`)
 - made `POST /v1/employees` accept omitted `management_level` values for non-management hires again, defaulting persisted records to `0` so invite-enabled onboarding preparation no longer fails with `422 The management level field is required.` when clients do not send a leadership rank

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- upgraded `phpunit/phpunit` to `12.5.23` together with `pestphp/pest` `4.6.3` so the test runner no longer remains pinned to a vulnerable PHPUnit child-process INI forwarding release range (`GHSA-qrr6-mg7r-m243`)
+- upgraded `phpunit/phpunit` to `12.5.23` together with `pestphp/pest` `4.6.3` so the test runner is no longer pinned to a vulnerable PHPUnit child-process INI forwarding release range (`GHSA-qrr6-mg7r-m243`)
 - blocked direct `POST /v1/employees` and `PATCH /v1/employees/{employee}` writes to `employment_end_date` and `retention_period_end` so BewachV / GDPR retention dates remain lifecycle-managed by termination handling and observer-driven calculation instead of client-controlled payloads (continues `api#470`)
 - fixed `GET /v1/employees/compliance-alerts` to filter the full alert set before paginating, so warning/critical/expired work-permit and certification entries are no longer hidden behind non-alert employees and the pagination metadata now reports the real alert count (continues `api#472`)
 - made `POST /v1/employees` accept omitted `management_level` values for non-management hires again, defaulting persisted records to `0` so invite-enabled onboarding preparation no longer fails with `422 The management level field is required.` when clients do not send a leadership rank

--- a/composer.lock
+++ b/composer.lock
@@ -9278,16 +9278,16 @@
         },
         {
             "name": "pestphp/pest",
-            "version": "v4.6.1",
+            "version": "v4.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pestphp/pest.git",
-                "reference": "87db0b484788cfde4778b715bb1fed34133685fa"
+                "reference": "bff44562a99d30aa37573995566051b0344f9f8e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pestphp/pest/zipball/87db0b484788cfde4778b715bb1fed34133685fa",
-                "reference": "87db0b484788cfde4778b715bb1fed34133685fa",
+                "url": "https://api.github.com/repos/pestphp/pest/zipball/bff44562a99d30aa37573995566051b0344f9f8e",
+                "reference": "bff44562a99d30aa37573995566051b0344f9f8e",
                 "shasum": ""
             },
             "require": {
@@ -9299,12 +9299,12 @@
                 "pestphp/pest-plugin-mutate": "^4.0.1",
                 "pestphp/pest-plugin-profanity": "^4.2.1",
                 "php": "^8.3.0",
-                "phpunit/phpunit": "^12.5.20",
+                "phpunit/phpunit": "^12.5.23",
                 "symfony/process": "^7.4.8|^8.0.8"
             },
             "conflict": {
                 "filp/whoops": "<2.18.3",
-                "phpunit/phpunit": ">12.5.20",
+                "phpunit/phpunit": ">12.5.23",
                 "sebastian/exporter": "<7.0.0",
                 "webmozart/assert": "<1.11.0"
             },
@@ -9379,7 +9379,7 @@
             ],
             "support": {
                 "issues": "https://github.com/pestphp/pest/issues",
-                "source": "https://github.com/pestphp/pest/tree/v4.6.1"
+                "source": "https://github.com/pestphp/pest/tree/v4.6.3"
             },
             "funding": [
                 {
@@ -9391,7 +9391,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-04-15T16:03:09+00:00"
+            "time": "2026-04-18T13:51:25+00:00"
         },
         {
             "name": "pestphp/pest-plugin",
@@ -10257,16 +10257,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "12.5.20",
+            "version": "12.5.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "c2364520611caa03567a8a020f2d59f3f90b115a"
+                "reference": "c54fcf3d6bcb6e96ac2f7e40097dc37b5f139969"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c2364520611caa03567a8a020f2d59f3f90b115a",
-                "reference": "c2364520611caa03567a8a020f2d59f3f90b115a",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c54fcf3d6bcb6e96ac2f7e40097dc37b5f139969",
+                "reference": "c54fcf3d6bcb6e96ac2f7e40097dc37b5f139969",
                 "shasum": ""
             },
             "require": {
@@ -10280,7 +10280,7 @@
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=8.3",
-                "phpunit/php-code-coverage": "^12.5.5",
+                "phpunit/php-code-coverage": "^12.5.6",
                 "phpunit/php-file-iterator": "^6.0.1",
                 "phpunit/php-invoker": "^6.0.0",
                 "phpunit/php-text-template": "^5.0.0",
@@ -10288,7 +10288,7 @@
                 "sebastian/cli-parser": "^4.2.0",
                 "sebastian/comparator": "^7.1.6",
                 "sebastian/diff": "^7.0.0",
-                "sebastian/environment": "^8.0.4",
+                "sebastian/environment": "^8.1.0",
                 "sebastian/exporter": "^7.0.2",
                 "sebastian/global-state": "^8.0.2",
                 "sebastian/object-enumerator": "^7.0.0",
@@ -10335,7 +10335,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.20"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.23"
             },
             "funding": [
                 {
@@ -10343,7 +10343,7 @@
                     "type": "other"
                 }
             ],
-            "time": "2026-04-15T05:05:59+00:00"
+            "time": "2026-04-18T06:12:49+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -11488,5 +11488,5 @@
         "php": "^8.4"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
## Summary

- upgrade `phpunit/phpunit` from `12.5.20` to `12.5.23` to move off the vulnerable child-process INI forwarding range behind `GHSA-qrr6-mg7r-m243`
- upgrade `pestphp/pest` from `v4.6.1` to `v4.6.3` so the test stack remains compatible with the patched PHPUnit release
- add an API changelog entry for the dependency security update

## Testing

- composer audit
- composer validate --strict
- php artisan test tests/Feature/Controllers/Api/V1/ActivityLogControllerTest.php
- php artisan test tests/Unit/Support/LikePatternTest.php

## Notes

- full `php artisan test` is currently blocked by unrelated `RoleManagementApiTest` duplicate-permission failures tracked in #938
- pre-push preflight passed; hook skipped full tests by default

## Related

- Dependabot alert: `GHSA-qrr6-mg7r-m243`
- Refs #938

## Checklist

- [x] Single topic
- [x] CHANGELOG updated
- [x] Composer audit clean after update
