### PR TITLE
Clarify under-1.x compatibility removal guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -76,6 +76,7 @@ At minimum verify:
 - Reject AI-generated test or helper mutations that move executable code across Pest scope boundaries or bypass framework wiring.
 - Reject AI-generated refactors that resolve services inside API resources or serializers, move business logic into presentation code, or repeat request-scoped work that should run once per request.
 - Reject AI-generated key or constraint changes that derive identifiers from mutable display names or ignore tenant-scoped uniqueness and database constraints.
+- Reject AI-generated compatibility keep-alives that preserve obsolete request fields, deprecated payload aliases, or legacy API-side storage/input shims without a proven live caller. Because the SecPal project is still under `1.x`, prefer removing unnecessary compatibility paths over carrying them forward when they weaken security, correctness, or contract clarity.
 
 ## Repository Conventions
 
@@ -88,3 +89,4 @@ At minimum verify:
 ## Scope Notes
 
 - Do not add dependencies or create documentation files unless the task requires them.
+- Because the SecPal project is still under `1.x`, breaking changes are acceptable when they remove insecure or obsolete compatibility layers. When taking that route, update tests and `CHANGELOG.md` in the same change set instead of keeping a legacy path alive by default.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- clarified the repo-local under-`1.x` policy in Copilot governance so API work explicitly prefers removing insecure or obsolete compatibility shims over preserving them without a proven live caller
 - converted all findings from the 2026-03-31 security audit to GitHub Issues (#834–#847) tracked under Epic #848
 - strengthened repo-local Copilot governance for AI findings: API work now requires proof of defect before merging AI-generated fix PRs, treats green CI alone as insufficient evidence for semantic test changes, and explicitly rejects Pest file-scope mutations that bypass framework wiring
 - wired the central Copilot-instructions validator into `quality.yml` so API pull requests now fail automatically when known Laravel AI-risk guardrails or generic AI-triage guidance are missing from the runtime baseline


### PR DESCRIPTION
## Summary
- clarify the repo-local Copilot guidance for the project-wide under-1.x compatibility-removal policy
- document the governance change in the API changelog

## Validation
- git diff --check
- repository pre-push validation during git push

Closes #942
