### PR TITLE
docs: add activity logging guides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- added user, admin, and legal guides for the shipped activity logging system, covering scoped log visibility, verification semantics, retention execution, and the GDPR-oriented archive model (api#892)
 - introduced stable `template_key` column on `onboarding_form_templates` so `OnboardingSchemaLocalizationService` uses the immutable key for translation lookup instead of deriving it from the mutable `name` field; system templates are seeded with their keys; tenant templates without a key fall back to the existing `Str::snake($name)` derivation (fixes api#832)
 - added the first `api#472` non-EU work-permit core slice: encrypted `work_permit_number` storage, richer work-permit types, conditional non-EU validation, work-authorization and expiring-document computed fields, factory states for permit-bearing employees, and GDPR-driven work-permit copy deletion when BWR approval or permanent authorization makes the copy unnecessary
 - added the `api#869` employee certification-expiry core slice: encrypted firearms-license storage, first-aid/fire-safety/evacuation tracking fields, structured `additional_certifications`, request validation, factory coverage, and expanded `expiring_documents` aggregation for soon-to-expire or expired compliance records

--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ GET /v1/users/{id}/permissions
 - [Permission System](docs/guides/permission-system.md)
 - [Temporal Roles](docs/guides/temporal-roles.md)
 - [Direct Permissions](docs/guides/direct-permissions.md)
+- [Activity Logging User Guide](docs/ACTIVITY_LOGGING_USER_GUIDE.md)
+- [Activity Logging Admin Guide](docs/ACTIVITY_LOGGING_ADMIN_GUIDE.md)
+- [Activity Logging Legal Guide](docs/ACTIVITY_LOGGING_LEGAL_GUIDE.md)
 - [API Reference](docs/api/rbac-endpoints.md)
 
 ### 👥 Employee Status And Invitation Rules

--- a/docs/ACTIVITY_LOGGING_ADMIN_GUIDE.md
+++ b/docs/ACTIVITY_LOGGING_ADMIN_GUIDE.md
@@ -1,0 +1,155 @@
+<!--
+SPDX-FileCopyrightText: 2026 SecPal
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+# Activity Logging Admin Guide
+
+This guide explains the shipped SecPal activity logging implementation for administrators and operators.
+
+## Operational Scope
+
+The activity logging system already ships with:
+
+- API list, detail, and verification endpoints
+- scoped authorization via tenant, organizational-unit, and leadership filtering
+- hash-chain linking per tenant
+- Merkle batching for grouped verification
+- OpenTimestamp submission and later Bitcoin anchoring
+- retention processing with archive-plus-hard-delete behavior
+
+## Access Model
+
+Viewing activity logs requires `activity_log.read`.
+
+Additional rules still apply:
+
+- tenant isolation is mandatory
+- scoped users see only activities inside their accessible organizational units
+- direct activity access uses leadership-based filtering for employee-caused entries
+- activities from system or non-employee causers are handled separately from employee-caused activities
+
+For operators this means that "has the permission" is not the same as "can see every row in the tenant".
+
+## API Endpoints
+
+- `GET /v1/activity-logs`
+- `GET /v1/activity-logs/{activity}`
+- `GET /v1/activity-logs/{activity}/verify`
+
+List responses are paginated, newest first, with `50` items per page by default and `100` as the maximum.
+
+## Verification Data In Responses
+
+Every activity resource can include:
+
+- `previous_hash`
+- `event_hash`
+- `merkle_root`
+- `merkle_batch_id`
+- `merkle_proof`
+- `ots_submitted_at`
+- `ots_confirmed_at`
+- `has_ots_proof`
+- orphaned-genesis markers and timestamps
+
+`include_verification=1` adds four computed checks per row:
+
+- `chain_valid`
+- `chain_link_valid`
+- `merkle_valid`
+- `ots_valid`
+
+Use that flag sparingly on list views. It is intended for focused investigation, not for bulk browsing.
+
+## How Integrity Processing Works
+
+### Hash Chain
+
+- the activity row is inserted first
+- hash processing is dispatched from the `created` hook
+- the processing path uses synchronized execution plus database locking to keep predecessor selection consistent per tenant
+- `event_hash` is therefore not guaranteed to be present before the row has completed post-insert processing
+
+### Merkle Batching
+
+- activities can be grouped into Merkle batches
+- the stored `merkle_proof` demonstrates inclusion in the batch root
+- single-entry batches are valid and can have an empty proof because the leaf is already the root
+
+### OpenTimestamp
+
+- SecPal submits Merkle roots, not raw personal data, to OpenTimestamps
+- `ots_submitted_at` means the proof has been sent or recorded for further upgrade
+- `ots_confirmed_at` means Bitcoin confirmation is available
+- OpenTimestamp proof handling is documented in more detail in [OpenTimestamp Integration](OPENTIMESTAMP_INTEGRATION.md)
+
+## Retention Operations
+
+Use the retention command:
+
+```bash
+php artisan activity:apply-retention
+php artisan activity:apply-retention --dry-run
+php artisan activity:apply-retention --tenant=123
+```
+
+### Retention Model
+
+Retention is based on legal duration per `log_name`, not on different security levels.
+
+- 3 years: operational, security, authentication, RBAC, scope, customer, site, employee, HR, works-council, sensitive-access, and guard-book categories
+- 8 years: invoice and payment related categories plus `contract_change`
+- 10 years: `annual_closing`
+
+The cutoff uses calendar-year retention. Example:
+
+- activity created on `2022-03-15`
+- 3-year retention applies through the end of `2025`
+- deletion becomes eligible from `2026-01-01 00:00:00`
+
+### What The Command Does
+
+For each eligible activity it:
+
+1. stores only minimal forensic data in `activity_log_archive`
+2. marks the successor as orphaned genesis when a predecessor link is removed
+3. hard deletes the original activity row
+
+This is intentional. There is no soft-delete grace period for retained activity rows.
+
+## Archive Model
+
+`activity_log_archive` keeps only the minimal verification set:
+
+- original activity ID
+- tenant ID
+- log category
+- original timestamp
+- `event_hash`
+- `previous_hash`
+- `merkle_root`
+- `merkle_batch_id`
+
+It does not retain descriptions, change properties, subject identifiers, causer identifiers, or other personal context.
+
+## Operational Caveats
+
+- A `null` verification field does not automatically mean tampering. It can mean the relevant forensic step has not completed or no proof is available yet.
+- Orphaned genesis is an expected post-retention state, not necessarily corruption.
+- Documentation and operational examples should use `getRetentionYearsForLogType()` or `getAllRetentionYears()` terminology; the older `getRetentionYears()` helper is deprecated.
+- The source of truth for log-category retention is the `Activity` model, not outdated draft notes or old queue/command comments.
+
+## Recommended Admin Checks
+
+- verify queue processing for activity hashing, Merkle batching, and OpenTimestamp jobs when forensic fields stop appearing
+- use `--dry-run` before large retention runs
+- investigate unexpected `false` verification results before assuming client or UI issues
+- treat cross-tenant or cross-scope visibility complaints as authorization questions first, not as missing-data questions
+
+## Related Documents
+
+- [Activity Logging User Guide](ACTIVITY_LOGGING_USER_GUIDE.md)
+- [Activity Logging Legal Guide](ACTIVITY_LOGGING_LEGAL_GUIDE.md)
+- [OpenTimestamp Integration](OPENTIMESTAMP_INTEGRATION.md)
+- [Queue Workers](QUEUE_WORKERS.md)

--- a/docs/ACTIVITY_LOGGING_ADMIN_GUIDE.md
+++ b/docs/ACTIVITY_LOGGING_ADMIN_GUIDE.md
@@ -142,7 +142,7 @@ It does not retain descriptions, change properties, subject identifiers, causer 
 
 ## Recommended Admin Checks
 
-- verify queue processing for activity hashing, Merkle batching, and OpenTimestamp jobs when forensic fields stop appearing
+- verify synchronous hash-chain generation in the request path for missing `event_hash`/`previous_hash`, and verify queue processing for Merkle batching and OpenTimestamp jobs when queued forensic fields stop appearing
 - use `--dry-run` before large retention runs
 - investigate unexpected `false` verification results before assuming client or UI issues
 - treat cross-tenant or cross-scope visibility complaints as authorization questions first, not as missing-data questions

--- a/docs/ACTIVITY_LOGGING_LEGAL_GUIDE.md
+++ b/docs/ACTIVITY_LOGGING_LEGAL_GUIDE.md
@@ -1,0 +1,164 @@
+<!--
+SPDX-FileCopyrightText: 2026 SecPal
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+# Activity Logging Legal Guide
+
+This guide summarizes the shipped SecPal activity logging behavior for legal, audit, and compliance review.
+
+## Purpose Of The System
+
+SecPal activity logging is designed to provide:
+
+- tenant-scoped auditability for operational and security events
+- tamper-evident integrity signals through hash chaining and Merkle proofs
+- optional external timestamp anchoring through OpenTimestamps and Bitcoin
+- legally bounded retention with data minimization after the retention period ends
+
+It is not a blanket promise that every log remains readable forever. The design explicitly balances forensic verification with GDPR storage limitation.
+
+## What Is Retained In Active Logs
+
+While an activity remains inside `activity_log`, the API can expose:
+
+- description text
+- subject and causer identifiers
+- change properties
+- IP address and user agent
+- hash-chain, Merkle, and OpenTimestamp fields
+
+This allows internal audit and operations teams to investigate the event in context during the lawful retention period.
+
+## Integrity Layers
+
+### 1. Hash Chain
+
+Each activity can store:
+
+- `previous_hash`
+- `event_hash`
+
+This allows later proof that a record still matches the expected sequence for its tenant. Activities without a predecessor are genesis entries.
+
+### 2. Merkle Proofs
+
+Activities may also carry:
+
+- `merkle_root`
+- `merkle_batch_id`
+- `merkle_proof`
+
+This provides batch-level inclusion evidence even when many activities are processed together.
+
+### 3. OpenTimestamp / Bitcoin Anchoring
+
+SecPal can submit Merkle roots to OpenTimestamps. The relevant activity fields are:
+
+- `ots_submitted_at`
+- `ots_confirmed_at`
+- `ots_proof`
+
+OpenTimestamp submission anchors digests, not the underlying personal data, to public timestamp infrastructure.
+
+## Retention Model
+
+Retention is driven by legal duration per activity category.
+
+### 3-Year Categories
+
+Operational and security categories, including authentication, RBAC, organizational scope changes, employee changes, HR access, works-council access, sensitive access, and guard-book-related entries, default to 3 years.
+
+### 8-Year Categories
+
+`invoice_generated`, `payment_processed`, and `contract_change` use 8-year retention.
+
+### 10-Year Categories
+
+`annual_closing` uses 10-year retention.
+
+### Calendar-Year Cutoff
+
+SecPal uses calendar-year retention boundaries. A log is retained through the end of the relevant retention year and becomes eligible for deletion on the following day.
+
+Example:
+
+- creation date: `2022-03-15`
+- retention: 3 years
+- retained through: `2025-12-31`
+- eligible for deletion from: `2026-01-01`
+
+## GDPR-Oriented Archive And Deletion Design
+
+When retention expires, SecPal does not keep the full personal-data-bearing activity row.
+
+Instead it:
+
+1. copies minimal forensic fields into `activity_log_archive`
+2. removes the original activity with a hard delete
+3. marks any successor whose predecessor was removed as orphaned genesis
+
+The archive intentionally retains only:
+
+- activity ID
+- tenant ID
+- log category
+- original timestamp
+- event hash
+- previous hash
+- Merkle root
+- Merkle batch ID
+
+The archive intentionally excludes:
+
+- description text
+- `properties`
+- subject references
+- causer references
+- request metadata such as IP address and user agent
+
+This supports the GDPR storage-limitation principle while still preserving limited integrity evidence.
+
+## Orphaned Genesis Meaning
+
+An orphaned genesis marker indicates that a predecessor link disappeared because retention removed an older record, not because the chain was silently corrupted.
+
+That is why:
+
+- `is_orphaned_genesis = true` can still be a valid state
+- chain-link verification can legitimately succeed after the predecessor was archived and deleted
+
+For legal review, orphaned genesis should be interpreted as a documented retention-boundary artifact.
+
+## Verification Semantics
+
+The API verification endpoint returns four checks:
+
+- `chain_valid`
+- `chain_link_valid`
+- `merkle_valid`
+- `ots_valid`
+
+Interpretation guidance:
+
+- `true`: the currently available verification path checks out
+- `false`: a verification failure was detected and should be investigated
+- `null`: the relevant verification data is not available yet or is not applicable in that state
+
+`null` is not evidence of tampering by itself.
+
+## What This Guide Intentionally Does Not Claim
+
+- It does not claim qualified eIDAS timestamps.
+- It does not claim indefinite retention of full audit content.
+- It does not claim tenant-wide visibility for every privileged reader; scope and leadership controls still constrain access.
+
+## Related Legal And Technical References
+
+- BewachV §21 Abs. 4
+- HGB §257
+- AO §147
+- GDPR Art. 5(1)(e)
+- GDPR Art. 17
+- [OpenTimestamp Integration](OPENTIMESTAMP_INTEGRATION.md)
+- [Activity Logging Admin Guide](ACTIVITY_LOGGING_ADMIN_GUIDE.md)

--- a/docs/ACTIVITY_LOGGING_USER_GUIDE.md
+++ b/docs/ACTIVITY_LOGGING_USER_GUIDE.md
@@ -1,0 +1,94 @@
+<!--
+SPDX-FileCopyrightText: 2026 SecPal
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+# Activity Logging User Guide
+
+This guide explains how SecPal users can view and verify the shipped activity log from the API and frontend audit UI.
+
+## Who Can Use It
+
+- You need the `activity_log.read` permission.
+- Tenant isolation always applies. You can only see activities from your own tenant.
+- If your account uses organizational scopes, the list view only includes activities from your accessible organizational units.
+- Leadership filtering applies to activities caused by employees. In scoped views, you only see activities from users whose management level falls into your allowed view range.
+
+## What The Activity Log Shows
+
+Each entry can include:
+
+- when the event happened
+- the log category (`log_name`)
+- a human-readable description
+- the affected subject and the causer, when available
+- request metadata such as IP address and user agent
+- forensic metadata such as hash-chain, Merkle, and OpenTimestamp fields
+
+The frontend activity-log screen is backed by these API endpoints:
+
+- `GET /v1/activity-logs`
+- `GET /v1/activity-logs/{activity}`
+- `GET /v1/activity-logs/{activity}/verify`
+
+## Available Filters
+
+`GET /v1/activity-logs` supports these user-facing filters:
+
+- `from_date` and `to_date` for date ranges
+- `log_name` for exact log-category matching
+- `search` for description search
+- `organizational_unit_id`
+- `causer_type` and `causer_id`
+- `subject_type` and `subject_id`
+- `per_page` from `1` to `100`
+- `include_verification` to attach verification results to each listed row
+
+Notes:
+
+- date filters accept calendar dates; `to_date` must not be earlier than `from_date`
+- description search is SQL-escaped, so literal backslashes, `%`, and `_` are treated consistently instead of widening the search unexpectedly
+- `include_verification=1` is more expensive than the default list view because it triggers cryptographic verification work per returned activity
+
+## Typical Review Flow
+
+1. Open the activity log list.
+2. Narrow the time range and log category first.
+3. Add causer or subject filters if you are investigating a specific person or record.
+4. Open the individual activity when you need the full subject, causer, and forensic fields.
+5. Use the verification endpoint or UI action when you need integrity evidence for a single entry.
+
+## Understanding Verification Results
+
+Verification can report four signals:
+
+- `chain_valid`: the activity still fits into the tenant hash chain
+- `chain_link_valid`: the direct predecessor link is valid for this record
+- `merkle_valid`: the activity still matches its stored Merkle proof and root
+- `ots_valid`: the OpenTimestamp proof verifies successfully
+
+Important behavior:
+
+- verification values can be `null` when required forensic data is not present yet
+- newly created entries may not have a stable `event_hash` immediately at first render because hash processing happens after insert
+- an entry marked as orphaned genesis can still verify as valid when its predecessor was legitimately removed by retention processing
+
+## What Users Should Not Expect
+
+- The activity log is read-only. The API does not provide edit or delete operations for individual entries.
+- Scoped users do not get tenant-wide visibility just because they can open the activity log.
+- The list endpoint is not intended to replace legal exports or full forensic reviews.
+
+## When To Escalate
+
+Escalate to an administrator or compliance reviewer when:
+
+- an expected activity is missing from your scoped view
+- verification returns `false` for chain, Merkle, or OpenTimestamp checks
+- you need evidence beyond normal UI review, such as retention or blockchain-anchoring details
+
+## Related Documents
+
+- [Activity Logging Admin Guide](ACTIVITY_LOGGING_ADMIN_GUIDE.md)
+- [Activity Logging Legal Guide](ACTIVITY_LOGGING_LEGAL_GUIDE.md)
+- [OpenTimestamp Integration](OPENTIMESTAMP_INTEGRATION.md)


### PR DESCRIPTION
## Summary

- add end-user, admin, and legal guides for the shipped activity logging implementation
- link the new guides from the API README and record the documentation addition in `CHANGELOG.md`
- keep the guide content aligned with the current scoped-access, verification, retention, and archive behavior already implemented in the API

## Validation

- `npx markdownlint-cli2 README.md docs/ACTIVITY_LOGGING_USER_GUIDE.md docs/ACTIVITY_LOGGING_ADMIN_GUIDE.md docs/ACTIVITY_LOGGING_LEGAL_GUIDE.md`

## Related

- Closes #892

## Checklist

- [x] Single topic
- [x] CHANGELOG updated
- [x] Relevant validation passed
