### PR TITLE
fix(onboarding): restore pre-contract self-service access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- restored pre-contract onboarding self-service access for the authenticated employee flow so `GET /v1/onboarding/steps`, `/v1/onboarding/templates*`, and `/v1/onboarding/submissions` plus `POST`/`PATCH /v1/onboarding/submissions*` no longer require extra `onboarding.read` or `onboarding.write` runtime permissions beyond the pre-contract ownership checks already enforced by the onboarding policies and controller guards (fixes `api#954`)
 - upgraded `phpunit/phpunit` to `12.5.23` together with `pestphp/pest` `4.6.3` so the test runner is no longer pinned to a vulnerable PHPUnit child-process INI forwarding release range (`GHSA-qrr6-mg7r-m243`)
 - blocked direct `POST /v1/employees` and `PATCH /v1/employees/{employee}` writes to `employment_end_date` and `retention_period_end` so BewachV / GDPR retention dates remain lifecycle-managed by termination handling and observer-driven calculation instead of client-controlled payloads (continues `api#470`)
 - fixed `GET /v1/employees/compliance-alerts` to filter the full alert set before paginating, so warning/critical/expired work-permit and certification entries are no longer hidden behind non-alert employees and the pagination metadata now reports the real alert count (continues `api#472`)

--- a/app/Policies/OnboardingFormSubmissionPolicy.php
+++ b/app/Policies/OnboardingFormSubmissionPolicy.php
@@ -33,6 +33,10 @@ class OnboardingFormSubmissionPolicy
      */
     public function viewAny(User $user): bool
     {
+        if ($this->isPreContractEmployee($user)) {
+            return true;
+        }
+
         return $user->can('onboarding.read');
     }
 
@@ -78,21 +82,11 @@ class OnboardingFormSubmissionPolicy
      */
     public function create(User $user): bool
     {
-        // Must have permission
-        if (! $user->can('onboarding.write')) {
-            return false;
+        if ($this->isPreContractEmployee($user)) {
+            return true;
         }
 
-        /** @var Employee|null $employee */
-        $employee = $user->employee()->first();
-
-        // User must have an employee record
-        if ($employee === null) {
-            return false;
-        }
-
-        // Only pre-contract employees can create submissions
-        return $employee->status === 'pre_contract';
+        return $user->can('onboarding.write');
     }
 
     /**
@@ -109,8 +103,7 @@ class OnboardingFormSubmissionPolicy
             return false;
         }
 
-        return $user->can('onboarding.write')
-            && $user->id === $employee->user_id;
+        return $user->id === $employee->user_id;
     }
 
     /**
@@ -160,5 +153,10 @@ class OnboardingFormSubmissionPolicy
     public function delete(User $user, OnboardingFormSubmission $submission): bool
     {
         return $user->can('onboarding.delete');
+    }
+
+    private function isPreContractEmployee(User $user): bool
+    {
+        return $user->employee?->status === Employee::STATUS_PRE_CONTRACT;
     }
 }

--- a/app/Policies/OnboardingFormSubmissionPolicy.php
+++ b/app/Policies/OnboardingFormSubmissionPolicy.php
@@ -15,10 +15,10 @@ use App\Models\User;
  * Authorization rules for onboarding form submissions with pre-contract status checks.
  *
  * Rules:
- * - viewAny: Employee (own submissions) OR HR
+ * - viewAny: pre-contract employees (own submissions) OR users with onboarding.read
  * - view: Employee (own) OR HR
- * - create: Employee (pre-contract status)
- * - update: Employee (own, with onboarding.write permission; controller enforces editable states)
+ * - create: pre-contract employees only (self-service)
+ * - update: Employee (own; controller enforces editable states)
  * - uploadFile: Employee (own, with onboarding.write permission)
  * - approve: HR only
  * - reject: HR only
@@ -78,23 +78,19 @@ class OnboardingFormSubmissionPolicy
     /**
      * Determine if user can create submissions.
      *
-     * Users must have onboarding.write permission AND be pre-contract employees.
+     * Only pre-contract employees can create their own onboarding submissions
+     * (self-service path). No additional onboarding.write permission is required.
      */
     public function create(User $user): bool
     {
-        if ($this->isPreContractEmployee($user)) {
-            return true;
-        }
-
-        return $user->can('onboarding.write');
+        return $this->isPreContractEmployee($user);
     }
 
     /**
      * Determine if user can update a submission.
      *
-     * Only the authenticated employee can update their own submissions, and
-     * they still need onboarding.write permission. The controller decides
-     * whether the current submission state is still editable.
+     * Only the authenticated employee who owns the submission can update it.
+     * The controller decides whether the current submission state is still editable.
      */
     public function update(User $user, OnboardingFormSubmission $submission): bool
     {
@@ -157,6 +153,9 @@ class OnboardingFormSubmissionPolicy
 
     private function isPreContractEmployee(User $user): bool
     {
-        return $user->employee?->status === Employee::STATUS_PRE_CONTRACT;
+        return Employee::query()
+            ->where('user_id', $user->getKey())
+            ->where('tenant_id', $user->tenant_id)
+            ->value('status') === Employee::STATUS_PRE_CONTRACT;
     }
 }

--- a/app/Policies/OnboardingFormTemplatePolicy.php
+++ b/app/Policies/OnboardingFormTemplatePolicy.php
@@ -15,8 +15,8 @@ use App\Models\User;
  * Authorization rules for onboarding form template management.
  *
  * Rules:
- * - viewAny: HR only
- * - view: HR only
+ * - viewAny: pre-contract employees (self-service) OR users with onboarding.read
+ * - view: pre-contract employees (self-service) OR users with onboarding.read
  * - create: HR only (for custom templates)
  * - update: HR only (cannot modify system templates)
  * - delete: HR only (cannot delete system templates)
@@ -26,7 +26,8 @@ class OnboardingFormTemplatePolicy
     /**
      * Determine if user can view any onboarding form templates.
      *
-     * Users with onboarding.read permission can view templates.
+     * Pre-contract employees can view templates for self-service onboarding.
+     * Users with onboarding.read permission can also view templates.
      */
     public function viewAny(User $user): bool
     {
@@ -40,7 +41,8 @@ class OnboardingFormTemplatePolicy
     /**
      * Determine if user can view a specific template.
      *
-     * Users with onboarding.read permission can view templates.
+     * Pre-contract employees can view templates for self-service onboarding.
+     * Users with onboarding.read permission can also view templates.
      */
     public function view(User $user, OnboardingFormTemplate $template): bool
     {
@@ -95,6 +97,9 @@ class OnboardingFormTemplatePolicy
 
     private function isPreContractEmployee(User $user): bool
     {
-        return $user->employee?->status === Employee::STATUS_PRE_CONTRACT;
+        return Employee::query()
+            ->where('user_id', $user->getKey())
+            ->where('tenant_id', $user->tenant_id)
+            ->value('status') === Employee::STATUS_PRE_CONTRACT;
     }
 }

--- a/app/Policies/OnboardingFormTemplatePolicy.php
+++ b/app/Policies/OnboardingFormTemplatePolicy.php
@@ -5,6 +5,7 @@
 
 namespace App\Policies;
 
+use App\Models\Employee;
 use App\Models\OnboardingFormTemplate;
 use App\Models\User;
 
@@ -29,6 +30,10 @@ class OnboardingFormTemplatePolicy
      */
     public function viewAny(User $user): bool
     {
+        if ($this->isPreContractEmployee($user)) {
+            return true;
+        }
+
         return $user->can('onboarding.read');
     }
 
@@ -39,6 +44,10 @@ class OnboardingFormTemplatePolicy
      */
     public function view(User $user, OnboardingFormTemplate $template): bool
     {
+        if ($this->isPreContractEmployee($user)) {
+            return true;
+        }
+
         return $user->can('onboarding.read');
     }
 
@@ -82,5 +91,10 @@ class OnboardingFormTemplatePolicy
         }
 
         return $user->can('onboarding_template.write') || $user->can('onboarding_template.delete');
+    }
+
+    private function isPreContractEmployee(User $user): bool
+    {
+        return $user->employee?->status === Employee::STATUS_PRE_CONTRACT;
     }
 }

--- a/tests/Feature/Controllers/OnboardingControllerTest.php
+++ b/tests/Feature/Controllers/OnboardingControllerTest.php
@@ -75,11 +75,11 @@ describe('GET /v1/onboarding/steps', function () {
         $response->assertStatus(401);
     });
 
-    test('returns 403 when user lacks onboarding.read permission', function (): void {
+    test('allows pre-contract employees to fetch onboarding steps without onboarding.read permission', function (): void {
         $response = $this->withToken($this->token)
             ->getJson('/v1/onboarding/steps');
 
-        $response->assertStatus(403);
+        $response->assertOk();
     });
 
     test('returns onboarding steps for pre-contract employee', function (): void {
@@ -132,11 +132,11 @@ describe('GET /v1/onboarding/templates', function () {
         $response->assertStatus(401);
     });
 
-    test('returns 403 when user lacks onboarding.read permission', function (): void {
+    test('allows pre-contract employees to list templates without onboarding.read permission', function (): void {
         $response = $this->withToken($this->token)
             ->getJson('/v1/onboarding/templates');
 
-        $response->assertStatus(403);
+        $response->assertOk();
     });
 
     test('returns system and tenant templates', function (): void {
@@ -193,11 +193,11 @@ describe('GET /v1/onboarding/templates/{template}', function () {
         $response->assertStatus(401);
     });
 
-    test('returns 403 when user lacks onboarding.read permission', function (): void {
+    test('allows pre-contract employees to view a template without onboarding.read permission', function (): void {
         $response = $this->withToken($this->token)
             ->getJson("/v1/onboarding/templates/{$this->template->id}");
 
-        $response->assertStatus(403);
+        $response->assertOk();
     });
 
     test('returns template details with form_schema', function (): void {
@@ -272,11 +272,11 @@ describe('GET /v1/onboarding/submissions', function () {
         $response->assertStatus(401);
     });
 
-    test('returns 403 when user lacks onboarding.read permission', function (): void {
+    test('allows pre-contract employees to list submissions without onboarding.read permission', function (): void {
         $response = $this->withToken($this->token)
             ->getJson('/v1/onboarding/submissions');
 
-        $response->assertStatus(403);
+        $response->assertOk();
     });
 
     test('returns employee own submissions', function (): void {
@@ -349,7 +349,7 @@ describe('POST /v1/onboarding/submissions', function () {
         $response->assertStatus(401);
     });
 
-    test('returns 403 when user lacks onboarding.write permission', function (): void {
+    test('allows pre-contract employees to create submissions without onboarding.write permission', function (): void {
         $response = $this->withToken($this->token)
             ->postJson('/v1/onboarding/submissions', [
                 'form_template_id' => $this->template->id,
@@ -357,12 +357,11 @@ describe('POST /v1/onboarding/submissions', function () {
                 'status' => 'draft',
             ]);
 
-        $response->assertStatus(403);
+        $response->assertCreated()
+            ->assertJsonPath('data.status', 'draft');
     });
 
     test('returns 422 when required fields are missing', function (): void {
-        givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.write');
-
         $response = $this->withToken($this->token)
             ->postJson('/v1/onboarding/submissions', []);
 
@@ -499,7 +498,7 @@ describe('PATCH /v1/onboarding/submissions/{submission}', function () {
         $response->assertStatus(401);
     });
 
-    test('returns 403 when user lacks onboarding.write permission', function (): void {
+    test('allows pre-contract employees to update submissions without onboarding.write permission', function (): void {
         $submission = OnboardingFormSubmission::factory()->create([
             'employee_id' => $this->employee->id,
             'form_template_id' => $this->template->id,
@@ -511,12 +510,11 @@ describe('PATCH /v1/onboarding/submissions/{submission}', function () {
                 'form_data' => ['name' => 'Updated'],
             ]);
 
-        $response->assertStatus(403);
+        $response->assertOk()
+            ->assertJsonPath('data.form_data.name', 'Updated');
     });
 
     test('returns 422 when neither form data nor status is provided', function (): void {
-        givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.write');
-
         $submission = OnboardingFormSubmission::factory()->create([
             'employee_id' => $this->employee->id,
             'form_template_id' => $this->template->id,

--- a/tests/Feature/Policies/OnboardingFormSubmissionPolicyTest.php
+++ b/tests/Feature/Policies/OnboardingFormSubmissionPolicyTest.php
@@ -159,6 +159,35 @@ test('only pre contract employees can create submissions without onboarding.writ
     expect($this->policy->create($userWithNoEmployee))->toBeFalse();
 });
 
+test('user with onboarding.write but non-pre-contract employee status cannot create submissions', function (): void {
+    $userWithWriteOnly = User::factory()->create();
+    givePermissionWithTenant($userWithWriteOnly, $this->tenant->id, 'onboarding.write');
+    Employee::factory()->for($this->tenant, 'tenant')->create([
+        'user_id' => $userWithWriteOnly->id,
+        'status' => Employee::STATUS_ACTIVE,
+    ]);
+
+    expect($this->policy->create($userWithWriteOnly))->toBeFalse();
+});
+
+test('pre-contract employee from a different tenant cannot create submissions in current tenant', function (): void {
+    // Create a second tenant
+    $otherKeys = TenantKey::generateEnvelopeKeys();
+    $otherTenant = TenantKey::create($otherKeys);
+
+    // User has a pre_contract employee record in the OTHER tenant only
+    $userFromOtherTenant = User::factory()->create();
+    Employee::factory()->for($otherTenant, 'tenant')->create([
+        'user_id' => $userFromOtherTenant->id,
+        'status' => Employee::STATUS_PRE_CONTRACT,
+    ]);
+
+    // The user's own tenant_id is current tenant, but no employee record there
+    $userFromOtherTenant->update(['tenant_id' => $this->tenant->id]);
+
+    expect($this->policy->create($userFromOtherTenant))->toBeFalse();
+});
+
 test('employee can update own submissions without onboarding.write', function (): void {
     $user = User::factory()->create();
     $employee = Employee::factory()->for($this->tenant, 'tenant')->create([

--- a/tests/Feature/Policies/OnboardingFormSubmissionPolicyTest.php
+++ b/tests/Feature/Policies/OnboardingFormSubmissionPolicyTest.php
@@ -42,12 +42,19 @@ afterEach(function (): void {
     TenantKey::setKekPath(null);
 });
 
-test('users with onboarding.read can view any submissions', function (): void {
+test('pre-contract employees can view any submissions without onboarding.read', function (): void {
+    $preContractUser = User::factory()->create();
+    Employee::factory()->for($this->tenant, 'tenant')->create([
+        'user_id' => $preContractUser->id,
+        'status' => Employee::STATUS_PRE_CONTRACT,
+    ]);
+
     $userWithPermission = User::factory()->create();
     givePermissionWithTenant($userWithPermission, $this->tenant->id, 'onboarding.read');
 
     $userWithoutPermission = User::factory()->create();
 
+    expect($this->policy->viewAny($preContractUser))->toBeTrue();
     expect($this->policy->viewAny($userWithPermission))->toBeTrue();
     expect($this->policy->viewAny($userWithoutPermission))->toBeFalse();
 });
@@ -124,42 +131,39 @@ test('users with onboarding.read and org scope can view submissions in scope', f
     expect($this->policy->view($userWithScope, $submission))->toBeTrue();
 });
 
-test('only pre contract employees with onboarding.write can create submissions', function (): void {
+test('only pre contract employees can create submissions without onboarding.write', function (): void {
     $userWithPreContract = User::factory()->create();
-    givePermissionWithTenant($userWithPreContract, $this->tenant->id, 'onboarding.write');
-    $preContractEmployee = Employee::factory()->for($this->tenant, 'tenant')->create([
+    Employee::factory()->for($this->tenant, 'tenant')->create([
         'user_id' => $userWithPreContract->id,
-        'status' => 'pre_contract',
+        'status' => Employee::STATUS_PRE_CONTRACT,
     ]);
 
     $userWithActiveEmployee = User::factory()->create();
-    givePermissionWithTenant($userWithActiveEmployee, $this->tenant->id, 'onboarding.write');
-    $activeEmployee = Employee::factory()->for($this->tenant, 'tenant')->create([
+    Employee::factory()->for($this->tenant, 'tenant')->create([
         'user_id' => $userWithActiveEmployee->id,
-        'status' => 'active',
+        'status' => Employee::STATUS_ACTIVE,
     ]);
 
     $userWithNoEmployee = User::factory()->create();
-    givePermissionWithTenant($userWithNoEmployee, $this->tenant->id, 'onboarding.write');
 
-    $userWithoutPermission = User::factory()->create();
-    $employeeNoPermission = Employee::factory()->for($this->tenant, 'tenant')->create([
-        'user_id' => $userWithoutPermission->id,
-        'status' => 'pre_contract',
+    $userWithPermission = User::factory()->create();
+    givePermissionWithTenant($userWithPermission, $this->tenant->id, 'onboarding.write');
+    Employee::factory()->for($this->tenant, 'tenant')->create([
+        'user_id' => $userWithPermission->id,
+        'status' => Employee::STATUS_PRE_CONTRACT,
     ]);
 
     expect($this->policy->create($userWithPreContract))->toBeTrue();
+    expect($this->policy->create($userWithPermission))->toBeTrue();
     expect($this->policy->create($userWithActiveEmployee))->toBeFalse();
     expect($this->policy->create($userWithNoEmployee))->toBeFalse();
-    expect($this->policy->create($userWithoutPermission))->toBeFalse();
 });
 
-test('employee can update own submissions', function (): void {
+test('employee can update own submissions without onboarding.write', function (): void {
     $user = User::factory()->create();
-    givePermissionWithTenant($user, $this->tenant->id, 'onboarding.write');
     $employee = Employee::factory()->for($this->tenant, 'tenant')->create([
         'user_id' => $user->id,
-        'status' => 'pre_contract',
+        'status' => Employee::STATUS_PRE_CONTRACT,
     ]);
     $template = OnboardingFormTemplate::factory()->create();
     $submission = OnboardingFormSubmission::factory()->create([

--- a/tests/Feature/Policies/OnboardingFormTemplatePolicyTest.php
+++ b/tests/Feature/Policies/OnboardingFormTemplatePolicyTest.php
@@ -3,6 +3,7 @@
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+use App\Models\Employee;
 use App\Models\OnboardingFormTemplate;
 use App\Models\TenantKey;
 use App\Models\User;
@@ -39,23 +40,37 @@ afterEach(function (): void {
     TenantKey::setKekPath(null);
 });
 
-test('users with onboarding.read can view any templates', function (): void {
+test('pre-contract employees can view any templates without onboarding.read', function (): void {
+    $preContractUser = User::factory()->create();
+    Employee::factory()->for($this->tenant, 'tenant')->create([
+        'user_id' => $preContractUser->id,
+        'status' => Employee::STATUS_PRE_CONTRACT,
+    ]);
+
     $userWithPermission = User::factory()->create();
     givePermissionWithTenant($userWithPermission, $this->tenant->id, 'onboarding.read');
 
     $userWithoutPermission = User::factory()->create();
 
+    expect($this->policy->viewAny($preContractUser))->toBeTrue();
     expect($this->policy->viewAny($userWithPermission))->toBeTrue();
     expect($this->policy->viewAny($userWithoutPermission))->toBeFalse();
 });
 
-test('users with onboarding.read can view individual templates', function (): void {
+test('pre-contract employees can view individual templates without onboarding.read', function (): void {
+    $preContractUser = User::factory()->create();
+    Employee::factory()->for($this->tenant, 'tenant')->create([
+        'user_id' => $preContractUser->id,
+        'status' => Employee::STATUS_PRE_CONTRACT,
+    ]);
+
     $userWithPermission = User::factory()->create();
     givePermissionWithTenant($userWithPermission, $this->tenant->id, 'onboarding.read');
 
     $userWithoutPermission = User::factory()->create();
     $template = OnboardingFormTemplate::factory()->create(['is_system_template' => false]);
 
+    expect($this->policy->view($preContractUser, $template))->toBeTrue();
     expect($this->policy->view($userWithPermission, $template))->toBeTrue();
     expect($this->policy->view($userWithoutPermission, $template))->toBeFalse();
 });

--- a/tests/Feature/Policies/OnboardingFormTemplatePolicyTest.php
+++ b/tests/Feature/Policies/OnboardingFormTemplatePolicyTest.php
@@ -75,6 +75,27 @@ test('pre-contract employees can view individual templates without onboarding.re
     expect($this->policy->view($userWithoutPermission, $template))->toBeFalse();
 });
 
+test('pre-contract employee from a different tenant cannot view templates in current tenant', function (): void {
+    // Create a second tenant
+    $otherKeys = TenantKey::generateEnvelopeKeys();
+    $otherTenant = TenantKey::create($otherKeys);
+
+    // User has pre_contract employee in OTHER tenant only
+    $userFromOtherTenant = User::factory()->create();
+    Employee::factory()->for($otherTenant, 'tenant')->create([
+        'user_id' => $userFromOtherTenant->id,
+        'status' => Employee::STATUS_PRE_CONTRACT,
+    ]);
+
+    // User's own tenant_id is current tenant, but has no employee record there
+    $userFromOtherTenant->update(['tenant_id' => $this->tenant->id]);
+
+    $template = OnboardingFormTemplate::factory()->create(['is_system_template' => false]);
+
+    expect($this->policy->viewAny($userFromOtherTenant))->toBeFalse();
+    expect($this->policy->view($userFromOtherTenant, $template))->toBeFalse();
+});
+
 test('users with onboarding_template.write can create templates', function (): void {
     $userWithWrite = User::factory()->create();
     givePermissionWithTenant($userWithWrite, $this->tenant->id, 'onboarding_template.write');


### PR DESCRIPTION
## Summary

- restore pre-contract onboarding self-service access for steps, templates, submissions, and submission create/update without extra `onboarding.read` or `onboarding.write` runtime permissions
- keep the existing privileged onboarding read and approval paths intact for HR and other permissioned users
- update onboarding policy/controller coverage and changelog documentation for the current `main` behavior

Closes #954.
Supersedes the remaining relevant scope from #503.

## Testing

- `vendor/bin/pest tests/Feature/Policies/OnboardingFormTemplatePolicyTest.php tests/Feature/Policies/OnboardingFormSubmissionPolicyTest.php tests/Feature/Controllers/OnboardingControllerTest.php --colors=never`
- `vendor/bin/pint --dirty`
- `vendor/bin/phpstan analyse app/Policies/OnboardingFormTemplatePolicy.php app/Policies/OnboardingFormSubmissionPolicy.php tests/Feature/Policies/OnboardingFormTemplatePolicyTest.php tests/Feature/Policies/OnboardingFormSubmissionPolicyTest.php tests/Feature/Controllers/OnboardingControllerTest.php --no-progress --memory-limit=512M`
