### PR TITLE
test: add issue 958 edge case coverage

### DIFF
--- a/tests/Feature/Auth/PasskeyAuthTest.php
+++ b/tests/Feature/Auth/PasskeyAuthTest.php
@@ -152,6 +152,15 @@ describe('Passkey Authentication', function () {
             ->assertJsonValidationErrors(['device_name']);
     });
 
+    test('token passkey login challenge rejects a whitespace-only device name', function () {
+        $response = $this->postJson('/v1/auth/token/passkeys/challenges', [
+            'device_name' => '   ',
+        ]);
+
+        $response->assertUnprocessable()
+            ->assertJsonValidationErrors(['device_name']);
+    });
+
     test('browser passkey login challenge creation is rate limited with retry headers', function () {
         for ($i = 0; $i < 5; $i++) {
             $response = $this->withHeaders(spaHeaders())

--- a/tests/Feature/Migrations/EmployeeNumberTenantUniquenessTest.php
+++ b/tests/Feature/Migrations/EmployeeNumberTenantUniquenessTest.php
@@ -89,15 +89,22 @@ test('employees table rejects duplicate employee numbers within the same tenant'
         'tenant_id' => $tenant->id,
         'organizational_unit_id' => $unit->id,
         'employee_number' => 'EMP-2026-0001',
-        'email' => 'tenant-one@example.com',
+        'email' => 'employee-one@example.com',
     ]);
 
-    expect(function () use ($tenant, $unit): void {
+    try {
         Employee::factory()->create([
             'tenant_id' => $tenant->id,
             'organizational_unit_id' => $unit->id,
             'employee_number' => 'EMP-2026-0001',
-            'email' => 'tenant-two@example.com',
+            'email' => 'employee-two@example.com',
         ]);
-    })->toThrow(QueryException::class);
+    } catch (QueryException $exception) {
+        expect($exception->getCode())->toBe('23505')
+            ->and($exception->getMessage())->toContain('unique_tenant_employee_number');
+
+        return;
+    }
+
+    expect()->fail('Expected a tenant-scoped employee number unique constraint violation.');
 });

--- a/tests/Feature/Migrations/EmployeeNumberTenantUniquenessTest.php
+++ b/tests/Feature/Migrations/EmployeeNumberTenantUniquenessTest.php
@@ -6,6 +6,7 @@
 use App\Models\Employee;
 use App\Models\OrganizationalUnit;
 use App\Models\TenantKey;
+use Illuminate\Database\QueryException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Schema;
 
@@ -75,4 +76,28 @@ test('employees table allows duplicate employee numbers across tenants', functio
     })->not->toThrow(Exception::class);
 
     expect(Employee::query()->where('employee_number', 'EMP-2026-0001')->count())->toBe(2);
+});
+
+test('employees table rejects duplicate employee numbers within the same tenant', function (): void {
+    $tenant = TenantKey::create(TenantKey::generateEnvelopeKeys());
+
+    $unit = OrganizationalUnit::factory()->create([
+        'tenant_id' => $tenant->id,
+    ]);
+
+    Employee::factory()->create([
+        'tenant_id' => $tenant->id,
+        'organizational_unit_id' => $unit->id,
+        'employee_number' => 'EMP-2026-0001',
+        'email' => 'tenant-one@example.com',
+    ]);
+
+    expect(function () use ($tenant, $unit): void {
+        Employee::factory()->create([
+            'tenant_id' => $tenant->id,
+            'organizational_unit_id' => $unit->id,
+            'employee_number' => 'EMP-2026-0001',
+            'email' => 'tenant-two@example.com',
+        ]);
+    })->toThrow(QueryException::class);
 });


### PR DESCRIPTION
## Summary
- adds the missing 422 regression coverage for whitespace-only token passkey device names
- proves the tenant-scoped employee number unique index still rejects duplicates within the same tenant
- keeps the existing cross-tenant duplicate allowance coverage intact

## Validation
- php artisan test tests/Feature/Auth/PasskeyAuthTest.php tests/Feature/Migrations/EmployeeNumberTenantUniquenessTest.php
- vendor/bin/pint --dirty

Closes #958
