### PR TITLE
refactor: use validated payloads in remaining controllers

### DIFF
--- a/app/Http/Controllers/Api/V1/OnboardingController.php
+++ b/app/Http/Controllers/Api/V1/OnboardingController.php
@@ -843,14 +843,12 @@ class OnboardingController extends Controller
     {
         $this->authorize('confirmOnboarding', $employee);
 
-        $request->validate([
+        /** @var array{notes?: string|null} $validated */
+        $validated = $request->validate([
             'notes' => ['nullable', 'string', 'max:1000'],
         ]);
-        $notes = $request->input('notes');
 
-        if (! is_string($notes)) {
-            $notes = null;
-        }
+        $notes = $validated['notes'] ?? null;
 
         /** @var \App\Models\User $user */
         $user = $request->user();

--- a/app/Http/Controllers/Api/V1/OrganizationalUnitController.php
+++ b/app/Http/Controllers/Api/V1/OrganizationalUnitController.php
@@ -290,14 +290,13 @@ class OrganizationalUnitController extends Controller
     {
         $this->authorize('update', $organizational_unit);
 
-        $request->validate([
+        /** @var array{parent_id: string} $validated */
+        $validated = $request->validate([
             'parent_id' => ['required', 'uuid', 'exists:organizational_units,id'],
         ]);
 
-        /** @var string $parentId */
-        $parentId = $request->input('parent_id');
         /** @var OrganizationalUnit $parent */
-        $parent = OrganizationalUnit::findOrFail($parentId);
+        $parent = OrganizationalUnit::findOrFail($validated['parent_id']);
 
         // Also need permission on the parent to add children
         $this->authorize('create', $parent);

--- a/tests/Feature/Controllers/Api/V1/OrganizationalUnitControllerTest.php
+++ b/tests/Feature/Controllers/Api/V1/OrganizationalUnitControllerTest.php
@@ -1034,6 +1034,28 @@ describe('OrganizationalUnitController - Hierarchy', function () {
         ]);
     });
 
+    test('attach parent validates parent_id as a UUID', function () {
+        $orphan = OrganizationalUnit::factory()->create([
+            'tenant_id' => $this->tenant->id,
+            'name' => 'Orphan Unit',
+            'type' => 'department',
+        ]);
+
+        UserInternalOrganizationalScope::create([
+            'tenant_id' => $this->tenant->id,
+            'user_id' => $this->user->id,
+            'organizational_unit_id' => $orphan->id,
+            'access_level' => 'admin',
+        ]);
+
+        $response = postJson("/v1/organizational-units/{$orphan->id}/parent", [
+            'parent_id' => 'not-a-uuid',
+        ]);
+
+        $response->assertUnprocessable()
+            ->assertJsonValidationErrors(['parent_id']);
+    });
+
     test('user can detach parent from unit when they have direct scope', function () {
         // Arrange: Create child with parent
         $child = OrganizationalUnit::factory()->create([

--- a/tests/Feature/Controllers/OnboardingControllerTest.php
+++ b/tests/Feature/Controllers/OnboardingControllerTest.php
@@ -1001,6 +1001,24 @@ describe('POST /v1/admin/onboarding/employees/{employee}/confirm', function () {
         $response->assertStatus(422);
     });
 
+    test('returns 422 when confirmation notes exceed the maximum length', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.confirm');
+
+        $this->employee->update([
+            'onboarding_workflow_status' => Employee::WORKFLOW_STATUS_SUBMITTED_FOR_REVIEW,
+            'onboarding_completed' => true,
+            'contract_start_date' => now()->addWeek()->toDateString(),
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->postJson("/v1/admin/onboarding/employees/{$this->employee->id}/confirm", [
+                'notes' => str_repeat('A', 1001),
+            ]);
+
+        $response->assertUnprocessable()
+            ->assertJsonValidationErrors(['notes']);
+    });
+
     test('confirms onboarding dossier and keeps contract confirmed when contract start is in the future', function (): void {
         givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.confirm');
 


### PR DESCRIPTION
## Summary
- replaces the remaining inline validate plus input controller pattern with direct use of the validated payload
- covers attach-parent parent_id validation with a focused controller regression
- covers onboarding confirmation notes validation with a focused controller regression

## Validation
- php artisan test tests/Feature/Controllers/Api/V1/OrganizationalUnitControllerTest.php tests/Feature/Controllers/OnboardingControllerTest.php
- vendor/bin/pint --dirty

Closes #866
