### PR TITLE
fix: scope organizational unit parent validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- scoped `POST /v1/organizational-units/{organizational_unit}/parent` parent validation to the authenticated tenant and excluded soft-deleted organizational units, so cross-tenant and deleted `parent_id` probes now fail validation instead of leaking existence through later `403` or `404` responses (fixes `api#966`)
 - restored pre-contract onboarding self-service access for the authenticated employee flow so `GET /v1/onboarding/steps`, `/v1/onboarding/templates*`, and `/v1/onboarding/submissions` plus `POST`/`PATCH /v1/onboarding/submissions*` no longer require extra `onboarding.read` or `onboarding.write` runtime permissions beyond the pre-contract ownership checks already enforced by the onboarding policies and controller guards (fixes `api#954`)
 - upgraded `phpunit/phpunit` to `12.5.23` together with `pestphp/pest` `4.6.3` so the test runner is no longer pinned to a vulnerable PHPUnit child-process INI forwarding release range (`GHSA-qrr6-mg7r-m243`)
 - blocked direct `POST /v1/employees` and `PATCH /v1/employees/{employee}` writes to `employment_end_date` and `retention_period_end` so BewachV / GDPR retention dates remain lifecycle-managed by termination handling and observer-driven calculation instead of client-controlled payloads (continues `api#470`)

--- a/app/Http/Controllers/Api/V1/OrganizationalUnitController.php
+++ b/app/Http/Controllers/Api/V1/OrganizationalUnitController.php
@@ -16,6 +16,7 @@ use App\Models\UserInternalOrganizationalScope;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Validation\Rule;
 
 /**
  * OrganizationalUnitController handles CRUD operations for organizational units.
@@ -290,9 +291,19 @@ class OrganizationalUnitController extends Controller
     {
         $this->authorize('update', $organizational_unit);
 
+        /** @var \App\Models\User $user */
+        $user = $request->user();
+
         /** @var array{parent_id: string} $validated */
         $validated = $request->validate([
-            'parent_id' => ['required', 'uuid', 'exists:organizational_units,id'],
+            'parent_id' => [
+                'required',
+                'uuid',
+                Rule::exists('organizational_units', 'id')->where(function (\Illuminate\Database\Query\Builder $query) use ($user): void {
+                    $query->where('tenant_id', $user->tenant_id)
+                        ->whereNull('deleted_at');
+                }),
+            ],
         ]);
 
         /** @var OrganizationalUnit $parent */

--- a/tests/Feature/Controllers/Api/V1/OrganizationalUnitControllerTest.php
+++ b/tests/Feature/Controllers/Api/V1/OrganizationalUnitControllerTest.php
@@ -1056,6 +1056,64 @@ describe('OrganizationalUnitController - Hierarchy', function () {
             ->assertJsonValidationErrors(['parent_id']);
     });
 
+    test('attach parent rejects cross-tenant parent ids during validation', function () {
+        $orphan = OrganizationalUnit::factory()->create([
+            'tenant_id' => $this->tenant->id,
+            'name' => 'Orphan Unit',
+            'type' => 'department',
+        ]);
+
+        UserInternalOrganizationalScope::create([
+            'tenant_id' => $this->tenant->id,
+            'user_id' => $this->user->id,
+            'organizational_unit_id' => $orphan->id,
+            'access_level' => 'admin',
+        ]);
+
+        $otherTenant = TenantKey::create(TenantKey::generateEnvelopeKeys());
+        $foreignParent = OrganizationalUnit::factory()->create([
+            'tenant_id' => $otherTenant->id,
+            'name' => 'Foreign Parent',
+            'type' => 'company',
+        ]);
+
+        $response = postJson("/v1/organizational-units/{$orphan->id}/parent", [
+            'parent_id' => $foreignParent->id,
+        ]);
+
+        $response->assertUnprocessable()
+            ->assertJsonValidationErrors(['parent_id']);
+    });
+
+    test('attach parent rejects soft deleted parent ids during validation', function () {
+        $orphan = OrganizationalUnit::factory()->create([
+            'tenant_id' => $this->tenant->id,
+            'name' => 'Orphan Unit',
+            'type' => 'department',
+        ]);
+
+        UserInternalOrganizationalScope::create([
+            'tenant_id' => $this->tenant->id,
+            'user_id' => $this->user->id,
+            'organizational_unit_id' => $orphan->id,
+            'access_level' => 'admin',
+        ]);
+
+        $deletedParent = OrganizationalUnit::factory()->create([
+            'tenant_id' => $this->tenant->id,
+            'name' => 'Deleted Parent',
+            'type' => 'company',
+        ]);
+        $deletedParent->delete();
+
+        $response = postJson("/v1/organizational-units/{$orphan->id}/parent", [
+            'parent_id' => $deletedParent->id,
+        ]);
+
+        $response->assertUnprocessable()
+            ->assertJsonValidationErrors(['parent_id']);
+    });
+
     test('user can detach parent from unit when they have direct scope', function () {
         // Arrange: Create child with parent
         $child = OrganizationalUnit::factory()->create([


### PR DESCRIPTION
## Summary
- Scope attachParent parent validation to the authenticated tenant.
- Reject soft-deleted organizational units during parent_id validation.
- Add regression coverage for cross-tenant and soft-deleted parent probes.

## Validation
- Focused attachParent Pest tests
- vendor/bin/pint --dirty
- Full OrganizationalUnitController Pest file

Closes #966
