### PR TITLE
refactor(api): complete remaining issue 935 cleanups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- applied the remaining `api#935` test and copy cleanups by extracting reused employee-controller and concurrency helpers, making BewachV retention assertions date-relative, strengthening tenant-isolation role-validation fixtures, and aligning the BWR ID-document auto-deletion email wording with its mail coverage
 - made the employee lifecycle, qualification-controller, employee-observer, and serial concurrency test fixtures self-cleaning and idempotent, while `TenantSetupCommandTest` now explicitly resets leaked tenant-key state and the role-management plus temporal-role API fixtures tolerate pre-seeded `sanctum` RBAC state, so leaked permissions, roles, tenant keys, or concurrency-test rows no longer poison later full-suite runs (fixes `api#972`)
 - scoped `POST /v1/organizational-units/{organizational_unit}/parent` parent validation to the authenticated tenant and excluded soft-deleted organizational units, so cross-tenant and deleted `parent_id` probes now fail validation instead of leaking existence through later `403` or `404` responses (fixes `api#966`)
 - made the RBAC test bootstraps in `RoleManagementApiTest` and `UserPermissionAssignmentApiTest` seed permissions and tenant-scoped roles idempotently, so repeated or pre-seeded `sanctum` contexts no longer fail with duplicate-role or duplicate-permission exceptions during targeted validation and the full-suite rerun for `api#938`

--- a/resources/views/emails/hr/bwr-id-document-auto-deleted.blade.php
+++ b/resources/views/emails/hr/bwr-id-document-auto-deleted.blade.php
@@ -4,7 +4,7 @@
 <x-mail::message>
 # {{ __('ID Document Copy Deleted After BWR Approval') }}
 
-{{ __('The stored ID document copy for the following employee was deleted automatically because BWR approval made continued storage unnecessary.') }}
+{{ __('The stored ID document copy for the following employee was deleted automatically because BWR approval made continued storage no longer necessary.') }}
 
 ## {{ __('Employee Information') }}
 

--- a/tests/Feature/Controllers/EmployeeControllerTest.php
+++ b/tests/Feature/Controllers/EmployeeControllerTest.php
@@ -72,6 +72,26 @@ afterEach(function (): void {
     TenantKey::setKekPath(null);
 });
 
+function grantDualManagementScopes(User $user, string $organizationalUnitId): void
+{
+    $user->organizationalScopes()->create([
+        'organizational_unit_id' => $organizationalUnitId,
+        'access_level' => 'manage',
+        'include_descendants' => true,
+        'min_viewable_rank' => 0,
+        'max_viewable_rank' => 0,
+        'allow_self_access' => true,
+    ]);
+    $user->organizationalScopes()->create([
+        'organizational_unit_id' => $organizationalUnitId,
+        'access_level' => 'manage',
+        'include_descendants' => true,
+        'min_viewable_rank' => 1,
+        'max_viewable_rank' => 255,
+        'allow_self_access' => true,
+    ]);
+}
+
 describe('GET /v1/employees', function () {
     test('returns 401 when not authenticated', function (): void {
         $response = $this->getJson('/v1/employees');
@@ -905,22 +925,7 @@ describe('GET /v1/employees/{employee}', function () {
         // We intentionally create two non-overlapping rank scopes (ADR-009):
         // one for Guards (0-0) and one for Leadership (1-255). A single scope
         // cannot model both cohorts without either excluding one group or broadening access.
-        $this->user->organizationalScopes()->create([
-            'organizational_unit_id' => $this->organizationalUnit->id,
-            'access_level' => 'manage',
-            'include_descendants' => true,
-            'min_viewable_rank' => 0,
-            'max_viewable_rank' => 0, // Guards only
-            'allow_self_access' => true,
-        ]);
-        $this->user->organizationalScopes()->create([
-            'organizational_unit_id' => $this->organizationalUnit->id,
-            'access_level' => 'manage',
-            'include_descendants' => true,
-            'min_viewable_rank' => 1,
-            'max_viewable_rank' => 255, // Leadership only
-            'allow_self_access' => true,
-        ]);
+        grantDualManagementScopes($this->user, $this->organizationalUnit->id);
 
         $employee = Employee::factory()->create([
             'tenant_id' => $this->tenant->id,
@@ -1096,22 +1101,7 @@ describe('PATCH /v1/employees/{employee}', function () {
         givePermissionWithTenant($this->user, $this->tenant->id, 'employee.write');
 
         // Need TWO scopes: 0-0 for Guards + 1-255 for Leadership (ADR-009)
-        $this->user->organizationalScopes()->create([
-            'organizational_unit_id' => $this->organizationalUnit->id,
-            'access_level' => 'manage',
-            'include_descendants' => true,
-            'min_viewable_rank' => 0,
-            'max_viewable_rank' => 0, // Guards only
-            'allow_self_access' => true,
-        ]);
-        $this->user->organizationalScopes()->create([
-            'organizational_unit_id' => $this->organizationalUnit->id,
-            'access_level' => 'manage',
-            'include_descendants' => true,
-            'min_viewable_rank' => 1,
-            'max_viewable_rank' => 255, // Leadership only
-            'allow_self_access' => true,
-        ]);
+        grantDualManagementScopes($this->user, $this->organizationalUnit->id);
 
         $employee = Employee::factory()->create([
             'tenant_id' => $this->tenant->id,
@@ -1131,22 +1121,7 @@ describe('PATCH /v1/employees/{employee}', function () {
     test('rejects direct status changes via patch', function (): void {
         givePermissionWithTenant($this->user, $this->tenant->id, 'employee.write');
 
-        $this->user->organizationalScopes()->create([
-            'organizational_unit_id' => $this->organizationalUnit->id,
-            'access_level' => 'manage',
-            'include_descendants' => true,
-            'min_viewable_rank' => 0,
-            'max_viewable_rank' => 0,
-            'allow_self_access' => true,
-        ]);
-        $this->user->organizationalScopes()->create([
-            'organizational_unit_id' => $this->organizationalUnit->id,
-            'access_level' => 'manage',
-            'include_descendants' => true,
-            'min_viewable_rank' => 1,
-            'max_viewable_rank' => 255,
-            'allow_self_access' => true,
-        ]);
+        grantDualManagementScopes($this->user, $this->organizationalUnit->id);
 
         $employee = Employee::factory()->create([
             'tenant_id' => $this->tenant->id,
@@ -1168,22 +1143,7 @@ describe('PATCH /v1/employees/{employee}', function () {
     test('rejects null status via patch', function (): void {
         givePermissionWithTenant($this->user, $this->tenant->id, 'employee.write');
 
-        $this->user->organizationalScopes()->create([
-            'organizational_unit_id' => $this->organizationalUnit->id,
-            'access_level' => 'manage',
-            'include_descendants' => true,
-            'min_viewable_rank' => 0,
-            'max_viewable_rank' => 0,
-            'allow_self_access' => true,
-        ]);
-        $this->user->organizationalScopes()->create([
-            'organizational_unit_id' => $this->organizationalUnit->id,
-            'access_level' => 'manage',
-            'include_descendants' => true,
-            'min_viewable_rank' => 1,
-            'max_viewable_rank' => 255,
-            'allow_self_access' => true,
-        ]);
+        grantDualManagementScopes($this->user, $this->organizationalUnit->id);
 
         $employee = Employee::factory()->create([
             'tenant_id' => $this->tenant->id,
@@ -1205,22 +1165,7 @@ describe('PATCH /v1/employees/{employee}', function () {
     test('rejects direct bwr field changes via patch and preserves audit trail invariants', function (): void {
         givePermissionWithTenant($this->user, $this->tenant->id, 'employee.write');
 
-        $this->user->organizationalScopes()->create([
-            'organizational_unit_id' => $this->organizationalUnit->id,
-            'access_level' => 'manage',
-            'include_descendants' => true,
-            'min_viewable_rank' => 0,
-            'max_viewable_rank' => 0,
-            'allow_self_access' => true,
-        ]);
-        $this->user->organizationalScopes()->create([
-            'organizational_unit_id' => $this->organizationalUnit->id,
-            'access_level' => 'manage',
-            'include_descendants' => true,
-            'min_viewable_rank' => 1,
-            'max_viewable_rank' => 255,
-            'allow_self_access' => true,
-        ]);
+        grantDualManagementScopes($this->user, $this->organizationalUnit->id);
 
         $employee = Employee::factory()->create([
             'tenant_id' => $this->tenant->id,
@@ -1264,22 +1209,7 @@ describe('PATCH /v1/employees/{employee}', function () {
     test('rejects direct retention field changes via patch', function (): void {
         givePermissionWithTenant($this->user, $this->tenant->id, 'employee.write');
 
-        $this->user->organizationalScopes()->create([
-            'organizational_unit_id' => $this->organizationalUnit->id,
-            'access_level' => 'manage',
-            'include_descendants' => true,
-            'min_viewable_rank' => 0,
-            'max_viewable_rank' => 0,
-            'allow_self_access' => true,
-        ]);
-        $this->user->organizationalScopes()->create([
-            'organizational_unit_id' => $this->organizationalUnit->id,
-            'access_level' => 'manage',
-            'include_descendants' => true,
-            'min_viewable_rank' => 1,
-            'max_viewable_rank' => 255,
-            'allow_self_access' => true,
-        ]);
+        grantDualManagementScopes($this->user, $this->organizationalUnit->id);
 
         $employee = Employee::factory()->create([
             'tenant_id' => $this->tenant->id,

--- a/tests/Feature/Controllers/EmployeeNumberConcurrencyTest.php
+++ b/tests/Feature/Controllers/EmployeeNumberConcurrencyTest.php
@@ -22,6 +22,14 @@ function refreshEmployeeNumberConcurrencyDatabase(): void
     app(PermissionRegistrar::class)->forgetCachedPermissions();
 }
 
+function assertChildProcessSucceeded(int $childPid): void
+{
+    expect(pcntl_waitpid($childPid, $status))->toBe($childPid);
+    expect(pcntl_wifexited($status))->toBeTrue();
+    expect(pcntl_wifsignaled($status))->toBeFalse();
+    expect(pcntl_wexitstatus($status))->toBe(0);
+}
+
 /**
  * @property TenantKey $tenant
  * @property User $user
@@ -85,11 +93,12 @@ test('concurrent employee creation requests produce distinct employee numbers', 
             }
 
             if ($pid === 0) {
-                DB::disconnect();
+                DB::purge();
+                DB::reconnect();
                 app(PermissionRegistrar::class)->forgetCachedPermissions();
 
                 while (trim((string) file_get_contents($startSignalPath)) !== 'go') {
-                    usleep(10_000);
+                    usleep(100_000);
                 }
 
                 $response = $this->withToken($this->token)
@@ -110,10 +119,7 @@ test('concurrent employee creation requests produce distinct employee numbers', 
         file_put_contents($startSignalPath, 'go');
 
         foreach ($childPids as $childPid) {
-            expect(pcntl_waitpid($childPid, $status))->toBe($childPid);
-            expect(pcntl_wifexited($status))->toBeTrue();
-            expect(pcntl_wifsignaled($status))->toBeFalse();
-            expect(pcntl_wexitstatus($status))->toBe(0);
+            assertChildProcessSucceeded($childPid);
         }
 
         $results = collect(range(1, $requestCount))
@@ -136,11 +142,8 @@ test('concurrent employee creation requests produce distinct employee numbers', 
             unlink($startSignalPath);
         }
 
-        foreach (range(1, $requestCount) as $index) {
-            $path = $synchronizationDirectory."/result-{$index}.json";
-            if (file_exists($path)) {
-                unlink($path);
-            }
+        foreach (glob($synchronizationDirectory.'/result-*.json') ?: [] as $path) {
+            unlink($path);
         }
 
         if (is_dir($synchronizationDirectory)) {

--- a/tests/Feature/Mail/EmployeeLifecycleMailTest.php
+++ b/tests/Feature/Mail/EmployeeLifecycleMailTest.php
@@ -1,6 +1,6 @@
 <?php
 
-// SPDX-FileCopyrightText: 2025 SecPal Contributors
+// SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -279,7 +279,7 @@ test('qualification expiring mail contains qualification data', function () {
     $empQual = EmployeeQualification::create([
         'employee_id' => $employee->id,
         'qualification_id' => $qualification->id,
-        'obtained_date' => now()->subYear(),
+        'obtained_date' => now()->subYears(1),
         'expiry_date' => $expiryDate,
         'status' => EmployeeQualification::STATUS_EXPIRING,
         'certificate_number' => 'CERT-12345',
@@ -376,5 +376,5 @@ test('bwr id document auto deleted mail includes employee details and deletion r
         ->and($mail->envelope()->subject)->toContain('BWR')
         ->and($mail->render())->toContain('Casey Secure')
         ->and($mail->render())->toContain('EMP-912')
-        ->and($mail->render())->toContain('deleted automatically because BWR approval made continued storage unnecessary');
+        ->and($mail->render())->toContain('deleted automatically because BWR approval made continued storage no longer necessary');
 });

--- a/tests/Feature/RoleManagementApiTest.php
+++ b/tests/Feature/RoleManagementApiTest.php
@@ -229,8 +229,29 @@ describe('POST /v1/roles - Create Role', function () {
     });
 
     test('ignores spoofed tenant input when validating role creation uniqueness', function (): void {
-        createRoleManagementRole('Manager');
+        $manager = createRoleManagementRole('Manager');
         $otherTenant = TenantKey::create(TenantKey::generateEnvelopeKeys());
+
+        $this->registrar->setPermissionsTeamId($otherTenant->id);
+        $otherTenantManager = createRoleManagementRole('Manager');
+        $this->registrar->setPermissionsTeamId($this->tenant->id);
+        $this->registrar->forgetCachedPermissions();
+
+        expect(Role::query()
+            ->where('name', 'Manager')
+            ->where('guard_name', 'sanctum')
+            ->where('tenant_id', $manager->tenant_id)
+            ->exists())->toBeTrue();
+        expect(Role::query()
+            ->where('name', 'Manager')
+            ->where('guard_name', 'sanctum')
+            ->where('tenant_id', $otherTenantManager->tenant_id)
+            ->exists())->toBeTrue();
+        expect(Role::query()
+            ->where('name', 'Manager')
+            ->where('guard_name', 'sanctum')
+            ->whereIn('tenant_id', [$manager->tenant_id, $otherTenantManager->tenant_id])
+            ->count())->toBe(2);
 
         $request = CreateRoleRequest::create('/v1/roles', 'POST', [
             'name' => 'Manager',
@@ -447,11 +468,32 @@ describe('PATCH /v1/roles/{id} - Update Role', function () {
     });
 
     test('ignores spoofed tenant input when validating role updates', function (): void {
-        createRoleManagementRole('Manager');
+        $manager = createRoleManagementRole('Manager');
         createRoleManagementRole('Guard');
         $otherTenant = TenantKey::create(TenantKey::generateEnvelopeKeys());
 
-        $request = UpdateRoleRequest::create('/v1/roles/1', 'PATCH', [
+        $this->registrar->setPermissionsTeamId($otherTenant->id);
+        $otherTenantManager = createRoleManagementRole('Manager');
+        $this->registrar->setPermissionsTeamId($this->tenant->id);
+        $this->registrar->forgetCachedPermissions();
+
+        expect(Role::query()
+            ->where('name', 'Manager')
+            ->where('guard_name', 'sanctum')
+            ->where('tenant_id', $manager->tenant_id)
+            ->exists())->toBeTrue();
+        expect(Role::query()
+            ->where('name', 'Manager')
+            ->where('guard_name', 'sanctum')
+            ->where('tenant_id', $otherTenantManager->tenant_id)
+            ->exists())->toBeTrue();
+        expect(Role::query()
+            ->where('name', 'Manager')
+            ->where('guard_name', 'sanctum')
+            ->whereIn('tenant_id', [$manager->tenant_id, $otherTenantManager->tenant_id])
+            ->count())->toBe(2);
+
+        $request = UpdateRoleRequest::create("/v1/roles/{$manager->id}", 'PATCH', [
             'name' => 'Manager',
             'tenant_id' => $otherTenant->id,
         ]);

--- a/tests/Unit/Observers/EmployeeObserverBewachvTest.php
+++ b/tests/Unit/Observers/EmployeeObserverBewachvTest.php
@@ -6,11 +6,12 @@
 use App\Models\Employee;
 use App\Models\TenantKey;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Storage;
 use Spatie\Activitylog\Models\Activity;
 
-uses(RefreshDatabase::class)->group('unit', 'observer', 'bewachv');
+uses(RefreshDatabase::class)->group('unit', 'observer', 'BewachV');
 
 beforeEach(function () {
     if (! file_exists(TenantKey::getKekPath())) {
@@ -149,32 +150,41 @@ test('it deletes work permit copy when permit becomes permanent', function () {
 });
 
 test('it calculates retention period when employee is terminated', function () {
+    $terminationDate = Carbon::parse(now()->subMonths(6)->toDateString());
+    $retentionPeriodEnd = $terminationDate->copy()->endOfYear()->addYears(3);
+
     $employee = Employee::factory()->create(['status' => Employee::STATUS_ACTIVE]);
 
     $employee->status = Employee::STATUS_TERMINATED;
-    $employee->termination_date = '2024-06-15';
+    $employee->termination_date = $terminationDate->toDateString();
     $employee->save();
 
     $employee->refresh();
-    expect($employee->employment_end_date->toDateString())->toEqual('2024-06-15')
-        ->and($employee->retention_period_end->toDateString())->toEqual('2027-12-31');
+    expect($employee->employment_end_date->toDateString())->toEqual($terminationDate->toDateString())
+        ->and($employee->retention_period_end->toDateString())->toEqual($retentionPeriodEnd->toDateString());
 });
 
 test('it calculates retention period for year end termination', function () {
+    $terminationDate = Carbon::parse(now()->subYear()->endOfYear()->toDateString());
+    $retentionPeriodEnd = $terminationDate->copy()->endOfYear()->addYears(3);
+
     $employee = Employee::factory()->create(['status' => Employee::STATUS_ACTIVE]);
 
     $employee->status = Employee::STATUS_TERMINATED;
-    $employee->termination_date = '2024-12-31';
+    $employee->termination_date = $terminationDate->toDateString();
     $employee->save();
 
-    expect($employee->fresh()->retention_period_end->toDateString())->toEqual('2027-12-31');
+    expect($employee->fresh()->retention_period_end->toDateString())->toEqual($retentionPeriodEnd->toDateString());
 });
 
 test('it logs retention period calculation with legal basis', function () {
+    $terminationDate = Carbon::parse(now()->subMonths(6)->toDateString());
+    $retentionPeriodEnd = $terminationDate->copy()->endOfYear()->addYears(3);
+
     $employee = Employee::factory()->create(['status' => Employee::STATUS_ACTIVE]);
 
     $employee->status = Employee::STATUS_TERMINATED;
-    $employee->termination_date = '2024-06-15';
+    $employee->termination_date = $terminationDate->toDateString();
     $employee->save();
 
     $activity = Activity::where('subject_id', $employee->id)
@@ -184,8 +194,8 @@ test('it logs retention period calculation with legal basis', function () {
 
     expect($activity)->not->toBeNull()
         ->and($activity->properties->get('action'))->toEqual('retention_period_calculated')
-        ->and($activity->properties->get('employment_end_date'))->toEqual('2024-06-15')
-        ->and($activity->properties->get('retention_period_end'))->toEqual('2027-12-31')
+        ->and($activity->properties->get('employment_end_date'))->toEqual($terminationDate->toDateString())
+        ->and($activity->properties->get('retention_period_end'))->toEqual($retentionPeriodEnd->toDateString())
         ->and($activity->properties->get('legal_basis'))->toContain('BewachV');
 });
 
@@ -203,6 +213,9 @@ test('it does not calculate retention when termination date is null', function (
 });
 
 test('it handles both bwr activation and termination in same update', function () {
+    $terminationDate = Carbon::parse(now()->subMonths(6)->toDateString());
+    $retentionPeriodEnd = $terminationDate->copy()->endOfYear()->addYears(3);
+
     Storage::put('id_documents/doc.pdf', 'test');
     $employee = Employee::factory()->create(['status' => Employee::STATUS_ACTIVE, 'bwr_status' => 'pending', 'id_document_copy_path' => 'id_documents/doc.pdf']);
 
@@ -211,7 +224,7 @@ test('it handles both bwr activation and termination in same update', function (
     $employee->save();
 
     $employee->status = Employee::STATUS_TERMINATED;
-    $employee->termination_date = '2024-06-15';
+    $employee->termination_date = $terminationDate->toDateString();
     $employee->save();
 
     // Refresh from DB
@@ -219,7 +232,7 @@ test('it handles both bwr activation and termination in same update', function (
 
     expect($employee->id_document_copy_deleted_at)->not->toBeNull()
         ->and($employee->retention_period_end)->not->toBeNull()
-        ->and($employee->retention_period_end->toDateString())->toEqual('2027-12-31')
+        ->and($employee->retention_period_end->toDateString())->toEqual($retentionPeriodEnd->toDateString())
         ->and($employee->employment_end_date)->not->toBeNull()
-        ->and($employee->employment_end_date->toDateString())->toEqual('2024-06-15');
+        ->and($employee->employment_end_date->toDateString())->toEqual($terminationDate->toDateString());
 });

--- a/tests/Unit/Observers/EmployeeObserverBewachvTest.php
+++ b/tests/Unit/Observers/EmployeeObserverBewachvTest.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Storage;
 use Spatie\Activitylog\Models\Activity;
 
-uses(RefreshDatabase::class)->group('unit', 'observer', 'BewachV');
+uses(RefreshDatabase::class)->group('unit', 'observer', 'bewachv');
 
 beforeEach(function () {
     if (! file_exists(TenantKey::getKekPath())) {


### PR DESCRIPTION
## Summary
- extract the remaining duplicated test helpers in the employee controller and concurrency coverage
- make the BewachV observer retention assertions date-relative and tighten tenant-isolation role-validation fixtures
- align the BWR ID-document auto-deletion email copy with its mail regression coverage

## Validation
- `vendor/bin/pint --dirty`
- `php artisan test tests/Feature/Controllers/EmployeeControllerTest.php --filter='returns employee with relationships|updates employee with valid data|rejects direct status changes via patch|rejects null status via patch|rejects direct bwr field changes via patch and preserves audit trail invariants|rejects direct retention field changes via patch'`
- `php artisan test tests/Feature/Mail/EmployeeLifecycleMailTest.php tests/Unit/Observers/EmployeeObserverBewachvTest.php tests/Feature/RoleManagementApiTest.php tests/Feature/Controllers/EmployeeNumberConcurrencyTest.php`

Closes #935