### PR TITLE
Fix employee create/view scope authorization consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- aligned employee create, view, and update authorization on the same descendant-scope and management-level rules, so users can no longer create an employee in a scoped unit and then hit `403 This action is unauthorized.` on the immediate detail fetch; create and update now reject employees whose target unit or management level would fall outside the actor's writable, assignable, and viewable scope
 - creators of newly created child organizational units now receive a direct `admin` scope on that exact unit, so they can delete it and manage its scopes immediately even when their parent access only grants `manage`
 - repaired organizational hierarchy writes when an existing parent unit is missing its mandatory depth-0 self-closure row, and backfill those missing self-closures during migration so child-unit creation no longer silently stores new children as roots with `parent: null`
 - restored `GET /v1/organizational-units/{organizational_unit}` after the single-unit response refactor by threading the request context into the show action as well, so live detail fetches no longer fail with `500 Internal server error` when a user opens an organizational unit directly

--- a/app/Http/Requests/StoreEmployeeRequest.php
+++ b/app/Http/Requests/StoreEmployeeRequest.php
@@ -8,8 +8,12 @@ namespace App\Http\Requests;
 use App\Http\Requests\Concerns\InteractsWithCertificationValidation;
 use App\Http\Requests\Concerns\InteractsWithWorkPermitValidation;
 use App\Models\Employee;
+use App\Models\OrganizationalUnit;
+use App\Models\User;
+use App\Policies\EmployeePolicy;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
+use Illuminate\Validation\Validator;
 
 /**
  * StoreEmployeeRequest validates Employee creation requests.
@@ -27,6 +31,17 @@ class StoreEmployeeRequest extends FormRequest
     public function authorize(): bool
     {
         return $this->user()?->can('create', Employee::class) ?? false;
+    }
+
+    public function withValidator(Validator $validator): void
+    {
+        $validator->after(function (Validator $validator): void {
+            if ($validator->errors()->has('organizational_unit_id') || $validator->errors()->has('management_level')) {
+                return;
+            }
+
+            $this->validateEmployeeScopeConstraints($validator);
+        });
     }
 
     /**
@@ -217,7 +232,7 @@ class StoreEmployeeRequest extends FormRequest
                         return;
                     }
 
-                    /** @var \App\Models\User $user */
+                    /** @var User $user */
                     $user = $this->user();
 
                     // If user has organizational scopes, verify access to the selected unit
@@ -299,5 +314,52 @@ class StoreEmployeeRequest extends FormRequest
             'work_permit_expiry.required' => 'Ablaufdatum der Arbeitserlaubnis ist für befristete Arbeitserlaubnisse verpflichtend.',
             'work_permit_expiry.after' => 'Ablaufdatum der Arbeitserlaubnis muss in der Zukunft liegen.',
         ], $this->certificationValidationMessages());
+    }
+
+    private function validateEmployeeScopeConstraints(Validator $validator): void
+    {
+        /** @var User $user */
+        $user = $this->user();
+
+        if (! $user->organizationalScopes()->exists()) {
+            return;
+        }
+
+        $organizationalUnitId = $this->input('organizational_unit_id');
+        if (! is_string($organizationalUnitId) || $organizationalUnitId === '') {
+            return;
+        }
+
+        $organizationalUnit = OrganizationalUnit::query()->find($organizationalUnitId);
+        if (! $organizationalUnit instanceof OrganizationalUnit) {
+            return;
+        }
+
+        $scopes = $user->getApplicableOrganizationalScopesForUnit($organizationalUnit)
+            ->filter(fn ($scope): bool => $scope->hasMinimumAccessLevel('write'))
+            ->values();
+
+        if ($scopes->isEmpty()) {
+            $validator->errors()->add('organizational_unit_id', __('You do not have write access to the selected organizational unit.'));
+
+            return;
+        }
+
+        $managementLevel = $this->resolvedManagementLevel();
+        $policy = app(EmployeePolicy::class);
+
+        if (! $policy->canCreateInUnit($user, $organizationalUnit, $managementLevel)) {
+            $validator->errors()->add(
+                'management_level',
+                __('You may only create employees whose management level remains assignable and viewable within your organizational scope.'),
+            );
+        }
+    }
+
+    private function resolvedManagementLevel(): int
+    {
+        $managementLevel = $this->input('management_level');
+
+        return is_numeric($managementLevel) ? (int) $managementLevel : 0;
     }
 }

--- a/app/Http/Requests/UpdateEmployeeRequest.php
+++ b/app/Http/Requests/UpdateEmployeeRequest.php
@@ -8,8 +8,12 @@ namespace App\Http\Requests;
 use App\Http\Requests\Concerns\InteractsWithCertificationValidation;
 use App\Http\Requests\Concerns\InteractsWithWorkPermitValidation;
 use App\Models\Employee;
+use App\Models\OrganizationalUnit;
+use App\Models\User;
+use App\Policies\EmployeePolicy;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
+use Illuminate\Validation\Validator;
 
 /**
  * UpdateEmployeeRequest validates Employee update requests.
@@ -31,6 +35,17 @@ class UpdateEmployeeRequest extends FormRequest
         $employee = $this->route('employee');
 
         return $employee !== null && ($this->user()?->can('update', $employee) ?? false);
+    }
+
+    public function withValidator(Validator $validator): void
+    {
+        $validator->after(function (Validator $validator): void {
+            if ($validator->errors()->has('organizational_unit_id') || $validator->errors()->has('management_level')) {
+                return;
+            }
+
+            $this->validateEmployeeScopeConstraints($validator);
+        });
     }
 
     /**
@@ -184,7 +199,7 @@ class UpdateEmployeeRequest extends FormRequest
                         return;
                     }
 
-                    /** @var \App\Models\User $user */
+                    /** @var User $user */
                     $user = $this->user();
 
                     // If user has organizational scopes, verify access to the selected unit
@@ -249,5 +264,69 @@ class UpdateEmployeeRequest extends FormRequest
         }
 
         return false;
+    }
+
+    private function validateEmployeeScopeConstraints(Validator $validator): void
+    {
+        /** @var User $user */
+        $user = $this->user();
+
+        if (! $user->organizationalScopes()->exists()) {
+            return;
+        }
+
+        /** @var Employee|null $employee */
+        $employee = $this->route('employee');
+        if (! $employee instanceof Employee) {
+            return;
+        }
+
+        $organizationalUnit = $this->resolvedOrganizationalUnit($employee);
+        if (! $organizationalUnit instanceof OrganizationalUnit) {
+            return;
+        }
+
+        $scopes = $user->getApplicableOrganizationalScopesForUnit($organizationalUnit)
+            ->filter(fn ($scope): bool => $scope->hasMinimumAccessLevel('write'))
+            ->values();
+
+        if ($scopes->isEmpty()) {
+            $validator->errors()->add('organizational_unit_id', __('You do not have write access to the selected organizational unit.'));
+
+            return;
+        }
+
+        $policy = app(EmployeePolicy::class);
+
+        if (! $policy->canUpdateInUnit($user, $organizationalUnit, $this->resolvedManagementLevel($employee))) {
+            $validator->errors()->add(
+                'management_level',
+                __('You may only update employees whose management level remains assignable and viewable within your organizational scope.'),
+            );
+        }
+    }
+
+    private function resolvedOrganizationalUnit(Employee $employee): ?OrganizationalUnit
+    {
+        $organizationalUnitId = $this->input('organizational_unit_id');
+
+        if (is_string($organizationalUnitId) && $organizationalUnitId !== '') {
+            $organizationalUnit = OrganizationalUnit::query()->find($organizationalUnitId);
+
+            return $organizationalUnit instanceof OrganizationalUnit ? $organizationalUnit : null;
+        }
+
+        return $employee->organizationalUnit;
+    }
+
+    private function resolvedManagementLevel(Employee $employee): int
+    {
+        $managementLevel = $this->input('management_level');
+
+        if (is_numeric($managementLevel)) {
+            return (int) $managementLevel;
+        }
+
+        return $employee->management_level;
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -660,6 +660,63 @@ class User extends Authenticatable implements MustVerifyEmailContract, TwoFactor
     }
 
     /**
+     * Resolve the scopes that apply to a specific organizational unit.
+     *
+     * Direct scopes take precedence over inherited descendant scopes for the
+     * same unit. When no direct scope exists, all ancestor scopes with
+     * include_descendants=true are returned.
+     *
+     * @return SupportCollection<int, UserInternalOrganizationalScope>
+     */
+    public function getApplicableOrganizationalScopesForUnit(OrganizationalUnit $unit): SupportCollection
+    {
+        $scopes = $this->organizationalScopes;
+
+        if ($scopes->isEmpty()) {
+            return collect();
+        }
+
+        /** @var SupportCollection<int, UserInternalOrganizationalScope> $directScopes */
+        $directScopes = $scopes
+            ->where('organizational_unit_id', $unit->id)
+            ->values();
+
+        if ($directScopes->isNotEmpty()) {
+            return $directScopes;
+        }
+
+        /** @var SupportCollection<int, string> $ancestorScopeUnitIds */
+        $ancestorScopeUnitIds = $scopes
+            ->filter(fn (UserInternalOrganizationalScope $scope): bool => $scope->include_descendants)
+            ->pluck('organizational_unit_id')
+            ->unique()
+            ->values();
+
+        if ($ancestorScopeUnitIds->isEmpty()) {
+            return collect();
+        }
+
+        /** @var SupportCollection<int, string> $matchingAncestorIds */
+        $matchingAncestorIds = OrganizationalUnitClosure::query()
+            ->where('descendant_id', $unit->id)
+            ->where('depth', '>', 0)
+            ->whereIn('ancestor_id', $ancestorScopeUnitIds)
+            ->pluck('ancestor_id');
+
+        if ($matchingAncestorIds->isEmpty()) {
+            return collect();
+        }
+
+        /** @var SupportCollection<int, UserInternalOrganizationalScope> $inheritedScopes */
+        $inheritedScopes = $scopes
+            ->filter(fn (UserInternalOrganizationalScope $scope): bool => $scope->include_descendants
+                && $matchingAncestorIds->contains($scope->organizational_unit_id))
+            ->values();
+
+        return $inheritedScopes;
+    }
+
+    /**
      * Determine whether the user may open the customer collection via scoped access.
      *
      * This intentionally checks access entitlements, not whether matching records
@@ -815,48 +872,9 @@ class User extends Authenticatable implements MustVerifyEmailContract, TwoFactor
      */
     public function hasAccessToUnit(OrganizationalUnit $unit, ?string $minimumLevel = null): bool
     {
-        $scopes = $this->organizationalScopes;
+        $scopes = $this->getApplicableOrganizationalScopesForUnit($unit);
 
         if ($scopes->isEmpty()) {
-            return false;
-        }
-
-        // Collect unit IDs for direct scope check and descendant check
-        /** @var SupportCollection<int, string> $directScopeUnitIds */
-        $directScopeUnitIds = collect();
-        /** @var SupportCollection<int, string> $descendantScopeUnitIds */
-        $descendantScopeUnitIds = collect();
-
-        foreach ($scopes as $scope) {
-            $directScopeUnitIds->push($scope->organizational_unit_id);
-            if ($scope->include_descendants) {
-                $descendantScopeUnitIds->push($scope->organizational_unit_id);
-            }
-        }
-
-        // Check if unit is directly scoped
-        $isDirectlyScoped = $directScopeUnitIds->contains($unit->id);
-
-        // Check if unit is a descendant of any scoped unit (single query)
-        $ancestorScopeId = null;
-        if (! $isDirectlyScoped && $descendantScopeUnitIds->isNotEmpty()) {
-            $ancestorScopeId = OrganizationalUnitClosure::whereIn('ancestor_id', $descendantScopeUnitIds->unique())
-                ->where('descendant_id', $unit->id)
-                ->where('depth', '>', 0)
-                ->value('ancestor_id');
-        }
-
-        // Determine which scope applies
-        $applicableScope = null;
-        if ($isDirectlyScoped) {
-            // Find scope with direct match
-            $applicableScope = $scopes->first(fn ($s) => $s->organizational_unit_id === $unit->id);
-        } elseif ($ancestorScopeId !== null) {
-            // Find scope for the ancestor
-            $applicableScope = $scopes->first(fn ($s) => $s->organizational_unit_id === $ancestorScopeId && $s->include_descendants);
-        }
-
-        if ($applicableScope === null) {
             return false;
         }
 
@@ -865,7 +883,8 @@ class User extends Authenticatable implements MustVerifyEmailContract, TwoFactor
             return true;
         }
 
-        // Check if access level is sufficient
-        return $applicableScope->hasMinimumAccessLevel($minimumLevel);
+        return $scopes->contains(
+            fn (UserInternalOrganizationalScope $scope): bool => $scope->hasMinimumAccessLevel($minimumLevel)
+        );
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -673,12 +673,15 @@ class User extends Authenticatable implements MustVerifyEmailContract, TwoFactor
         $scopes = $this->organizationalScopes;
 
         if ($scopes->isEmpty()) {
-            return collect();
+            /** @var SupportCollection<int, UserInternalOrganizationalScope> $emptyScopes */
+            $emptyScopes = collect();
+
+            return $emptyScopes;
         }
 
         /** @var SupportCollection<int, UserInternalOrganizationalScope> $directScopes */
         $directScopes = $scopes
-            ->where('organizational_unit_id', $unit->id)
+            ->filter(fn (UserInternalOrganizationalScope $scope): bool => $scope->organizational_unit_id === $unit->id)
             ->values();
 
         if ($directScopes->isNotEmpty()) {
@@ -693,7 +696,10 @@ class User extends Authenticatable implements MustVerifyEmailContract, TwoFactor
             ->values();
 
         if ($ancestorScopeUnitIds->isEmpty()) {
-            return collect();
+            /** @var SupportCollection<int, UserInternalOrganizationalScope> $emptyScopes */
+            $emptyScopes = collect();
+
+            return $emptyScopes;
         }
 
         /** @var SupportCollection<int, string> $matchingAncestorIds */
@@ -704,7 +710,10 @@ class User extends Authenticatable implements MustVerifyEmailContract, TwoFactor
             ->pluck('ancestor_id');
 
         if ($matchingAncestorIds->isEmpty()) {
-            return collect();
+            /** @var SupportCollection<int, UserInternalOrganizationalScope> $emptyScopes */
+            $emptyScopes = collect();
+
+            return $emptyScopes;
         }
 
         /** @var SupportCollection<int, UserInternalOrganizationalScope> $inheritedScopes */

--- a/app/Models/UserInternalOrganizationalScope.php
+++ b/app/Models/UserInternalOrganizationalScope.php
@@ -159,4 +159,49 @@ class UserInternalOrganizationalScope extends Model
     {
         return self::ACCESS_LEVELS[$this->access_level] ?? 0;
     }
+
+    /**
+     * Determine whether this scope can view the given employee management level.
+     */
+    public function canViewManagementLevel(int $managementLevel): bool
+    {
+        return $this->isWithinManagementLevelRange(
+            $managementLevel,
+            $this->min_viewable_rank,
+            $this->max_viewable_rank,
+        );
+    }
+
+    /**
+     * Determine whether this scope can assign the given employee management level.
+     */
+    public function canAssignManagementLevel(int $managementLevel): bool
+    {
+        return $this->isWithinManagementLevelRange(
+            $managementLevel,
+            $this->min_assignable_rank,
+            $this->max_assignable_rank,
+        );
+    }
+
+    private function isWithinManagementLevelRange(int $managementLevel, ?int $minimumLevel, ?int $maximumLevel): bool
+    {
+        if ($maximumLevel === 0) {
+            return $managementLevel === 0;
+        }
+
+        if ($managementLevel === 0) {
+            return false;
+        }
+
+        if ($minimumLevel !== null && $managementLevel < $minimumLevel) {
+            return false;
+        }
+
+        if ($maximumLevel !== null && $managementLevel > $maximumLevel) {
+            return false;
+        }
+
+        return true;
+    }
 }

--- a/app/Policies/EmployeePolicy.php
+++ b/app/Policies/EmployeePolicy.php
@@ -171,12 +171,18 @@ class EmployeePolicy
     private function applicableScopes(User $user, ?OrganizationalUnit $organizationalUnit, string $minimumAccessLevel): Collection
     {
         if ($organizationalUnit === null) {
-            return collect();
+            /** @var Collection<int, UserInternalOrganizationalScope> $emptyScopes */
+            $emptyScopes = collect();
+
+            return $emptyScopes;
         }
 
-        return $user->getApplicableOrganizationalScopesForUnit($organizationalUnit)
+        /** @var Collection<int, UserInternalOrganizationalScope> $scopes */
+        $scopes = $user->getApplicableOrganizationalScopesForUnit($organizationalUnit)
             ->filter(fn (UserInternalOrganizationalScope $scope): bool => $scope->hasMinimumAccessLevel($minimumAccessLevel))
             ->values();
+
+        return $scopes;
     }
 
     /**

--- a/app/Policies/EmployeePolicy.php
+++ b/app/Policies/EmployeePolicy.php
@@ -6,7 +6,10 @@
 namespace App\Policies;
 
 use App\Models\Employee;
+use App\Models\OrganizationalUnit;
 use App\Models\User;
+use App\Models\UserInternalOrganizationalScope;
+use Illuminate\Support\Collection;
 
 /**
  * Employee Policy
@@ -65,14 +68,8 @@ class EmployeePolicy
                 return false;
             }
 
-            // Check if user has scope with allow_self_access = true for this unit
-            $scope = $user->organizationalScopes()
-                ->where('organizational_unit_id', $employee->organizational_unit_id)
-                ->where('allow_self_access', true)
-                ->first();
-
-            // If no scope with allow_self_access, deny access to own data
-            return $scope !== null;
+            return $this->applicableScopes($user, $employee->organizationalUnit, 'read')
+                ->contains(fn (UserInternalOrganizationalScope $scope): bool => $scope->allow_self_access);
         }
 
         // Users with employee.read permission can view
@@ -80,76 +77,8 @@ class EmployeePolicy
             return false;
         }
 
-        // Check if user has organizational scopes (Manager role)
-        // Optimization: Fetch all user's scopes once, filter in-memory (avoids 2 queries: exists + get)
-        $allScopes = $user->organizationalScopes()->get();
-
-        if ($allScopes->isNotEmpty() && $employee->organizationalUnit !== null) {
-            // Managers: Check organizational scope AND leadership rank filtering
-            // Filter scopes for THIS specific organizational unit
-            $scopes = $allScopes->where('organizational_unit_id', $employee->organizational_unit_id);
-
-            if ($scopes->isEmpty()) {
-                return false; // Manager has scopes, but not for this unit
-            }
-
-            // Get employee's management level (simple integer field)
-            $employeeRank = $employee->management_level;
-
-            foreach ($scopes as $scope) {
-                // Check rank filtering
-                if ($this->isWithinViewableRankRange($employeeRank, $scope->min_viewable_rank, $scope->max_viewable_rank)) {
-                    return true; // Employee visible in at least one scope
-                }
-            }
-
-            return false; // Employee not visible in any scope
-        }
-
-        // No scopes = no access to organizational data
-        // All users accessing employees MUST have organizational scopes
-        return false;
-    }
-
-    /**
-     * Check if employee's management level is within user's viewable range.
-     *
-     * CRITICAL SEMANTICS (ADR-009):
-     * - Non-management employees have management_level = 0
-     * - Management levels: 1-255 (1=CEO/highest, 255=lowest)
-     *
-     * Two separate scope systems (cannot be mixed):
-     * - 0/0: ONLY non-management employees (Guards)
-     * - 1-255: Management levels (e.g., 1/5 = ML1-ML5, 1/255 = all management)
-     * - Invalid: 0/5 (cannot mix non-management with management levels)
-     *
-     * @param  int  $employeeLevel  Employee's management level (0=non-management, 1-255=management)
-     * @param  int|null  $minViewableLevel  Minimum viewable level (0=non-management only, 1-255=management)
-     * @param  int|null  $maxViewableLevel  Maximum viewable level (0=non-management only, 1-255=management)
-     */
-    private function isWithinViewableRankRange(int $employeeLevel, ?int $minViewableLevel, ?int $maxViewableLevel): bool
-    {
-        // Case 1: Scope 0/0 = ONLY non-management employees
-        if ($maxViewableLevel === 0) {
-            return $employeeLevel === 0; // Only non-management visible
-        }
-
-        // Case 2: Employee is non-management (level = 0)
-        if ($employeeLevel === 0) {
-            return false; // Non-management not visible in management scopes (1-255)
-        }
-
-        // Case 3: Management level scopes (1-255)
-        // Check if management level within specified range
-        if ($minViewableLevel !== null && $employeeLevel < $minViewableLevel) {
-            return false; // Below minimum
-        }
-
-        if ($maxViewableLevel !== null && $employeeLevel > $maxViewableLevel) {
-            return false; // Above maximum
-        }
-
-        return true; // Within range
+        return $this->applicableScopes($user, $employee->organizationalUnit, 'read')
+            ->contains(fn (UserInternalOrganizationalScope $scope): bool => $scope->canViewManagementLevel($employee->management_level));
     }
 
     /**
@@ -185,14 +114,8 @@ class EmployeePolicy
                 return false;
             }
 
-            // Check if user has scope with allow_self_access = true for this unit
-            $scope = $user->organizationalScopes()
-                ->where('organizational_unit_id', $employee->organizational_unit_id)
-                ->where('allow_self_access', true)
-                ->first();
-
-            // If no scope with allow_self_access, deny access to own data
-            return $scope !== null;
+            return $this->applicableScopes($user, $employee->organizationalUnit, 'write')
+                ->contains(fn (UserInternalOrganizationalScope $scope): bool => $scope->allow_self_access);
         }
 
         // Users with employee.write or employee.update permission can update
@@ -200,35 +123,60 @@ class EmployeePolicy
             return false;
         }
 
-        // Check if user has organizational scopes (Manager role)
-        // Optimization: Fetch all user's scopes once, filter in-memory (avoids 2 queries: exists + get)
-        $allScopes = $user->organizationalScopes()->get();
+        return $this->applicableScopes($user, $employee->organizationalUnit, 'write')
+            ->contains(fn (UserInternalOrganizationalScope $scope): bool => $scope->canViewManagementLevel($employee->management_level));
+    }
 
-        if ($allScopes->isNotEmpty() && $employee->organizationalUnit !== null) {
-            // Managers: Check organizational scope AND leadership rank filtering
-            // Filter scopes for THIS specific organizational unit
-            $scopes = $allScopes->where('organizational_unit_id', $employee->organizational_unit_id);
-
-            if ($scopes->isEmpty()) {
-                return false; // Manager has scopes, but not for this unit
-            }
-
-            // Get employee's management level (simple integer field)
-            $employeeRank = $employee->management_level;
-
-            foreach ($scopes as $scope) {
-                // Check rank filtering
-                if ($this->isWithinViewableRankRange($employeeRank, $scope->min_viewable_rank, $scope->max_viewable_rank)) {
-                    return true; // Employee editable in at least one scope
-                }
-            }
-
-            return false; // Employee not editable in any scope
+    /**
+     * Determine whether the user may create an employee in the given unit with the given management level.
+     */
+    public function canCreateInUnit(User $user, OrganizationalUnit $organizationalUnit, int $managementLevel): bool
+    {
+        if (! $this->create($user)) {
+            return false;
         }
 
-        // No scopes = no access to organizational data
-        // All users accessing employees MUST have organizational scopes
-        return false;
+        $scopes = $this->applicableScopes($user, $organizationalUnit, 'write');
+
+        if ($scopes->isEmpty()) {
+            return false;
+        }
+
+        return $scopes->contains(fn (UserInternalOrganizationalScope $scope): bool => $scope->canViewManagementLevel($managementLevel)
+            && $scope->canAssignManagementLevel($managementLevel));
+    }
+
+    /**
+     * Determine whether the user may update an employee into the given unit and management level.
+     */
+    public function canUpdateInUnit(User $user, OrganizationalUnit $organizationalUnit, int $managementLevel): bool
+    {
+        if (! $user->can('employee.write') && ! $user->can('employee.update')) {
+            return false;
+        }
+
+        $scopes = $this->applicableScopes($user, $organizationalUnit, 'write');
+
+        if ($scopes->isEmpty()) {
+            return false;
+        }
+
+        return $scopes->contains(fn (UserInternalOrganizationalScope $scope): bool => $scope->canViewManagementLevel($managementLevel)
+            && $scope->canAssignManagementLevel($managementLevel));
+    }
+
+    /**
+     * @return Collection<int, UserInternalOrganizationalScope>
+     */
+    private function applicableScopes(User $user, ?OrganizationalUnit $organizationalUnit, string $minimumAccessLevel): Collection
+    {
+        if ($organizationalUnit === null) {
+            return collect();
+        }
+
+        return $user->getApplicableOrganizationalScopesForUnit($organizationalUnit)
+            ->filter(fn (UserInternalOrganizationalScope $scope): bool => $scope->hasMinimumAccessLevel($minimumAccessLevel))
+            ->values();
     }
 
     /**

--- a/tests/Feature/Controllers/EmployeeControllerTest.php
+++ b/tests/Feature/Controllers/EmployeeControllerTest.php
@@ -80,6 +80,8 @@ function grantDualManagementScopes(User $user, string $organizationalUnitId): vo
         'include_descendants' => true,
         'min_viewable_rank' => 0,
         'max_viewable_rank' => 0,
+        'min_assignable_rank' => 0,
+        'max_assignable_rank' => 0,
         'allow_self_access' => true,
     ]);
     $user->organizationalScopes()->create([
@@ -88,6 +90,8 @@ function grantDualManagementScopes(User $user, string $organizationalUnitId): vo
         'include_descendants' => true,
         'min_viewable_rank' => 1,
         'max_viewable_rank' => 255,
+        'min_assignable_rank' => 1,
+        'max_assignable_rank' => 255,
         'allow_self_access' => true,
     ]);
 }
@@ -2277,6 +2281,10 @@ test('manager cannot create employee in unit outside their scope', function (): 
         'organizational_unit_id' => $unitA->id,
         'access_level' => 'write',
         'include_descendants' => false,
+        'min_viewable_rank' => 0,
+        'max_viewable_rank' => 0,
+        'min_assignable_rank' => 0,
+        'max_assignable_rank' => 0,
     ]);
 
     givePermissionWithTenant($this->user, $this->tenant->id, 'employee.write');
@@ -2309,6 +2317,10 @@ test('manager can create employee in unit within their scope', function (): void
         'organizational_unit_id' => $unitA->id,
         'access_level' => 'write',
         'include_descendants' => false,
+        'min_viewable_rank' => 0,
+        'max_viewable_rank' => 0,
+        'min_assignable_rank' => 0,
+        'max_assignable_rank' => 0,
     ]);
 
     givePermissionWithTenant($this->user, $this->tenant->id, 'employee.write');
@@ -2393,6 +2405,10 @@ test('manager with include_descendants=true can create employee in child unit', 
         'organizational_unit_id' => $parent->id,
         'access_level' => 'write',
         'include_descendants' => true,
+        'min_viewable_rank' => 0,
+        'max_viewable_rank' => 0,
+        'min_assignable_rank' => 0,
+        'max_assignable_rank' => 0,
     ]);
 
     givePermissionWithTenant($this->user, $this->tenant->id, 'employee.write');
@@ -2413,6 +2429,116 @@ test('manager with include_descendants=true can create employee in child unit', 
 
     $response->assertStatus(201);
     expect($response->json('data.organizational_unit_id'))->toBe($child->id);
+});
+
+test('manager can view a newly created employee in a descendant unit immediately after create', function (): void {
+    $parent = OrganizationalUnit::factory()->create(['tenant_id' => $this->tenant->id]);
+    $child = OrganizationalUnit::factory()->create(['tenant_id' => $this->tenant->id]);
+    $child->setParent($parent);
+
+    $this->user->assignRole('Manager');
+    $this->user->organizationalScopes()->create([
+        'organizational_unit_id' => $parent->id,
+        'access_level' => 'write',
+        'include_descendants' => true,
+        'min_viewable_rank' => 0,
+        'max_viewable_rank' => 0,
+        'min_assignable_rank' => 0,
+        'max_assignable_rank' => 0,
+        'allow_self_access' => true,
+    ]);
+
+    givePermissionWithTenant($this->user, $this->tenant->id, 'employee.read');
+    givePermissionWithTenant($this->user, $this->tenant->id, 'employee.write');
+
+    $createResponse = $this->withToken($this->token)->postJson('/v1/employees', [
+        'first_name' => 'Descendant',
+        'last_name' => 'Visible',
+        'email' => 'descendant.visible@example.com',
+        'date_of_birth' => '1990-01-15',
+        'status' => Employee::STATUS_PRE_CONTRACT,
+        'contract_type' => 'full_time',
+        'contract_start_date' => now()->toDateString(),
+        'position' => 'Security Guard',
+        'organizational_unit_id' => $child->id,
+        'management_level' => 0,
+    ]);
+
+    $createResponse->assertCreated();
+
+    $employeeId = $createResponse->json('data.id');
+
+    $this->withToken($this->token)
+        ->getJson("/v1/employees/{$employeeId}")
+        ->assertOk()
+        ->assertJsonPath('data.organizational_unit.id', $child->id);
+});
+
+test('manager cannot create an employee with a management level outside writable and viewable scope', function (): void {
+    $unit = OrganizationalUnit::factory()->create(['tenant_id' => $this->tenant->id]);
+
+    $this->user->assignRole('Manager');
+    $this->user->organizationalScopes()->create([
+        'organizational_unit_id' => $unit->id,
+        'access_level' => 'write',
+        'include_descendants' => false,
+        'min_viewable_rank' => 0,
+        'max_viewable_rank' => 0,
+        'min_assignable_rank' => 0,
+        'max_assignable_rank' => 0,
+        'allow_self_access' => true,
+    ]);
+
+    givePermissionWithTenant($this->user, $this->tenant->id, 'employee.read');
+    givePermissionWithTenant($this->user, $this->tenant->id, 'employee.write');
+
+    $response = $this->withToken($this->token)->postJson('/v1/employees', [
+        'first_name' => 'Rank',
+        'last_name' => 'Mismatch',
+        'email' => 'rank.mismatch@example.com',
+        'date_of_birth' => '1990-01-15',
+        'status' => Employee::STATUS_PRE_CONTRACT,
+        'contract_type' => 'full_time',
+        'contract_start_date' => now()->toDateString(),
+        'position' => 'Area Manager',
+        'organizational_unit_id' => $unit->id,
+        'management_level' => 5,
+    ]);
+
+    $response->assertStatus(422)
+        ->assertJsonValidationErrors(['management_level']);
+});
+
+test('manager cannot update an employee to a management level outside writable and viewable scope', function (): void {
+    $unit = OrganizationalUnit::factory()->create(['tenant_id' => $this->tenant->id]);
+
+    $this->user->assignRole('Manager');
+    $this->user->organizationalScopes()->create([
+        'organizational_unit_id' => $unit->id,
+        'access_level' => 'write',
+        'include_descendants' => false,
+        'min_viewable_rank' => 0,
+        'max_viewable_rank' => 0,
+        'min_assignable_rank' => 0,
+        'max_assignable_rank' => 0,
+        'allow_self_access' => true,
+    ]);
+
+    givePermissionWithTenant($this->user, $this->tenant->id, 'employee.read');
+    givePermissionWithTenant($this->user, $this->tenant->id, 'employee.write');
+
+    $employee = Employee::factory()->create([
+        'tenant_id' => $this->tenant->id,
+        'organizational_unit_id' => $unit->id,
+        'management_level' => 0,
+    ]);
+
+    $response = $this->withToken($this->token)->patchJson("/v1/employees/{$employee->id}", [
+        'management_level' => 5,
+    ]);
+
+    $response->assertStatus(422)
+        ->assertJsonValidationErrors(['management_level']);
 });
 
 test('manager with include_descendants=false cannot create employee in child unit', function (): void {

--- a/tests/Feature/Policies/EmployeePolicyTest.php
+++ b/tests/Feature/Policies/EmployeePolicyTest.php
@@ -83,6 +83,9 @@ test('employee can view own profile', function (): void {
     UserInternalOrganizationalScope::create([
         'user_id' => $user->id,
         'organizational_unit_id' => $orgUnit->id,
+        'access_level' => 'write',
+        'min_viewable_rank' => 0,
+        'max_viewable_rank' => 0,
         'allow_self_access' => true, // Required for self-access
     ]);
 
@@ -206,6 +209,9 @@ test('employee can update own profile', function (): void {
     UserInternalOrganizationalScope::create([
         'user_id' => $user->id,
         'organizational_unit_id' => $orgUnit->id,
+        'access_level' => 'write',
+        'min_viewable_rank' => 0,
+        'max_viewable_rank' => 0,
         'allow_self_access' => true, // Required for self-access
     ]);
 


### PR DESCRIPTION
## Summary
- align employee create, view, and update authorization on the same descendant-scope resolution used for organizational access
- reject create and update payloads when the target unit or management level falls outside the actors writable, assignable, and viewable scope
- add regression coverage for the live create-then-show failure, descendant scopes, and management-level mismatch cases

## Testing
- php artisan test tests/Feature/Policies/EmployeePolicyTest.php tests/Feature/Policies/EmployeePolicyManagementLevelTest.php tests/Feature/Controllers/EmployeeControllerTest.php
- vendor/bin/pint --dirty

## Follow-up
- tracked adjacent list/detail rank-filter drift separately in #987
