### PR TITLE
fix: unblock onboarding self-service uploads and tenant completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- fixed onboarding self-service backend blockers so authenticated pre-contract employees can upload files to their own editable onboarding submissions without an extra `onboarding.write` grant, while onboarding completion now counts required tenant templates together with required system templates for the employee's tenant-specific completion state (fixes `api#986`)
 - aligned employee create, view, and update authorization on the same descendant-scope and management-level rules, so users can no longer create an employee in a scoped unit and then hit `403 This action is unauthorized.` on the immediate detail fetch; create and update now reject employees whose target unit or management level would fall outside the actor's writable, assignable, and viewable scope
 - creators of newly created child organizational units now receive a direct `manage` scope on that exact unit, so they can delete it and manage its scopes immediately even when their parent access only grants `manage`
 - repaired organizational hierarchy writes when an existing parent unit is missing its mandatory depth-0 self-closure row, and backfill those missing self-closures during migration so child-unit creation no longer silently stores new children as roots with `parent: null`

--- a/app/Policies/OnboardingFormSubmissionPolicy.php
+++ b/app/Policies/OnboardingFormSubmissionPolicy.php
@@ -1,6 +1,6 @@
 <?php
 
-// SPDX-FileCopyrightText: 2025 SecPal Contributors
+// SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 namespace App\Policies;
@@ -105,15 +105,11 @@ class OnboardingFormSubmissionPolicy
     /**
      * Determine if user can upload an attachment for a submission.
      *
-     * Uploads are restricted to the authenticated pre-contract employee's own
-     * submission and still require the onboarding.write capability.
+     * Uploads follow the self-service path for the authenticated employee's own
+     * submission. Editable-state enforcement stays at the controller layer.
      */
     public function uploadFile(User $user, OnboardingFormSubmission $submission): bool
     {
-        if (! $user->can('onboarding.write')) {
-            return false;
-        }
-
         $employee = $submission->employee;
 
         return $employee !== null && $user->id === $employee->user_id;

--- a/app/Services/OnboardingCompletionService.php
+++ b/app/Services/OnboardingCompletionService.php
@@ -8,6 +8,7 @@ namespace App\Services;
 use App\Models\Employee;
 use App\Models\OnboardingFormSubmission;
 use App\Models\OnboardingFormTemplate;
+use Illuminate\Database\Eloquent\Builder;
 use UnexpectedValueException;
 
 /**
@@ -208,7 +209,10 @@ class OnboardingCompletionService
         throw new UnexpectedValueException('Expected onboarding template id to be a non-empty string or integer value.');
     }
 
-    private function requiredTemplatesQuery(Employee $employee)
+    /**
+     * @return Builder<OnboardingFormTemplate>
+     */
+    private function requiredTemplatesQuery(Employee $employee): Builder
     {
         return OnboardingFormTemplate::query()
             ->where('is_required', true)

--- a/app/Services/OnboardingCompletionService.php
+++ b/app/Services/OnboardingCompletionService.php
@@ -1,6 +1,6 @@
 <?php
 
-// SPDX-FileCopyrightText: 2025 SecPal Contributors
+// SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 namespace App\Services;
@@ -36,9 +36,7 @@ class OnboardingCompletionService
      */
     public function checkCompletion(Employee $employee): bool
     {
-        // Get all required template IDs (system templates only, tenant-agnostic)
-        $requiredTemplateIds = OnboardingFormTemplate::where('is_required', true)
-            ->whereNull('tenant_id') // System templates only
+        $requiredTemplateIds = $this->requiredTemplatesQuery($employee)
             ->pluck('id')
             ->all();
 
@@ -95,9 +93,7 @@ class OnboardingCompletionService
      */
     public function getCompletionStatus(Employee $employee): array
     {
-        // Get all required templates (system templates only)
-        $requiredTemplates = OnboardingFormTemplate::where('is_required', true)
-            ->whereNull('tenant_id')
+        $requiredTemplates = $this->requiredTemplatesQuery($employee)
             ->orderBy('sort_order')
             ->get(['id', 'name', 'description']);
 
@@ -210,5 +206,15 @@ class OnboardingCompletionService
         }
 
         throw new UnexpectedValueException('Expected onboarding template id to be a non-empty string or integer value.');
+    }
+
+    private function requiredTemplatesQuery(Employee $employee)
+    {
+        return OnboardingFormTemplate::query()
+            ->where('is_required', true)
+            ->where(static function ($query) use ($employee): void {
+                $query->whereNull('tenant_id')
+                    ->orWhere('tenant_id', $employee->tenant_id);
+            });
     }
 }

--- a/tests/Feature/Controllers/OnboardingControllerTest.php
+++ b/tests/Feature/Controllers/OnboardingControllerTest.php
@@ -699,7 +699,9 @@ describe('POST /v1/onboarding/submissions/{submission}/files', function () {
         $response->assertStatus(401);
     });
 
-    test('returns 403 when user lacks onboarding.write permission', function (): void {
+    test('allows self-service upload for an own draft submission without onboarding.write permission', function (): void {
+        Storage::fake('local');
+
         $submission = OnboardingFormSubmission::factory()->create([
             'employee_id' => $this->employee->id,
             'form_template_id' => $this->template->id,
@@ -707,12 +709,24 @@ describe('POST /v1/onboarding/submissions/{submission}/files', function () {
         ]);
 
         $response = $this->withToken($this->token)
+            ->withHeaders(['Accept' => 'application/json'])
             ->post("/v1/onboarding/submissions/{$submission->id}/files", [
                 'file' => UploadedFile::fake()->create('contract.pdf', 100, 'application/pdf'),
                 'document_type' => 'contract',
             ]);
 
-        $response->assertStatus(403);
+        $response->assertStatus(201)
+            ->assertJsonStructure([
+                'data' => ['id', 'filename'],
+            ]);
+
+        expect($response->json('data.filename'))->toBe('contract.pdf');
+
+        $this->assertDatabaseHas('onboarding_submission_files', [
+            'onboarding_form_submission_id' => $submission->id,
+            'document_type' => 'contract',
+            'file_name' => 'contract.pdf',
+        ]);
     });
 
     test('uploads a file for an employee draft submission', function (): void {

--- a/tests/Unit/Services/OnboardingCompletionServiceTest.php
+++ b/tests/Unit/Services/OnboardingCompletionServiceTest.php
@@ -1,11 +1,12 @@
 <?php
 
-// SPDX-FileCopyrightText: 2025 SecPal Contributors
+// SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use App\Models\Employee;
 use App\Models\OnboardingFormSubmission;
 use App\Models\OnboardingFormTemplate;
+use App\Models\TenantKey;
 use App\Services\OnboardingCompletionService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
@@ -174,6 +175,53 @@ describe('OnboardingCompletionService::checkCompletion', function () {
 
         // Should be complete despite optional template missing
         expect($result)->toBeTrue();
+        expect($employee->fresh()->onboarding_completed)->toBeTrue();
+    });
+
+    it('requires tenant-scoped required templates for the employee tenant before marking onboarding complete', function () {
+        $employee = Employee::factory()->preContract()->create([
+            'status' => Employee::STATUS_PRE_CONTRACT,
+            'onboarding_completed' => false,
+        ]);
+
+        $otherTenant = TenantKey::factory()->create();
+
+        $systemTemplate = OnboardingFormTemplate::factory()->create([
+            'tenant_id' => null,
+            'is_required' => true,
+            'is_system_template' => true,
+        ]);
+
+        $tenantTemplate = OnboardingFormTemplate::factory()->create([
+            'tenant_id' => $employee->tenant_id,
+            'is_required' => true,
+            'is_system_template' => false,
+        ]);
+
+        OnboardingFormTemplate::factory()->create([
+            'tenant_id' => $otherTenant->id,
+            'is_required' => true,
+            'is_system_template' => false,
+        ]);
+
+        OnboardingFormSubmission::factory()->create([
+            'employee_id' => $employee->id,
+            'form_template_id' => $systemTemplate->id,
+            'status' => 'approved',
+        ]);
+
+        $result = $this->service->checkCompletion($employee);
+
+        expect($result)->toBeFalse();
+        expect($employee->fresh()->onboarding_completed)->toBeFalse();
+
+        OnboardingFormSubmission::factory()->create([
+            'employee_id' => $employee->id,
+            'form_template_id' => $tenantTemplate->id,
+            'status' => 'approved',
+        ]);
+
+        expect($this->service->checkCompletion($employee))->toBeTrue();
         expect($employee->fresh()->onboarding_completed)->toBeTrue();
     });
 
@@ -474,6 +522,55 @@ describe('OnboardingCompletionService::getCompletionStatus', function () {
             'completed_required' => 1,
             'missing_templates' => [],
         ]);
+    });
+
+    it('includes tenant-scoped required templates for the employee tenant in completion status', function () {
+        $employee = Employee::factory()->preContract()->create([
+            'status' => Employee::STATUS_PRE_CONTRACT,
+        ]);
+
+        $otherTenant = TenantKey::factory()->create();
+
+        OnboardingFormTemplate::factory()->create([
+            'tenant_id' => null,
+            'is_required' => true,
+            'is_system_template' => true,
+            'name' => 'Personal Information',
+            'sort_order' => 1,
+        ]);
+
+        $tenantTemplate = OnboardingFormTemplate::factory()->create([
+            'tenant_id' => $employee->tenant_id,
+            'is_required' => true,
+            'is_system_template' => false,
+            'name' => 'Tenant NDA',
+            'sort_order' => 2,
+        ]);
+
+        OnboardingFormTemplate::factory()->create([
+            'tenant_id' => $otherTenant->id,
+            'is_required' => true,
+            'is_system_template' => false,
+            'name' => 'Other Tenant Only',
+            'sort_order' => 3,
+        ]);
+
+        OnboardingFormSubmission::factory()->create([
+            'employee_id' => $employee->id,
+            'form_template_id' => $tenantTemplate->id,
+            'status' => 'approved',
+        ]);
+
+        $status = $this->service->getCompletionStatus($employee);
+
+        expect($status)->toMatchArray([
+            'is_completed' => false,
+            'total_required' => 2,
+            'completed_required' => 1,
+        ]);
+
+        expect($status['missing_templates'])->toHaveCount(1);
+        expect($status['missing_templates'][0]['name'])->toBe('Personal Information');
     });
 
     it('handles no required templates (instant completion)', function () {


### PR DESCRIPTION
## Summary
- allow authenticated pre-contract employees to upload files to their own editable onboarding submissions without an extra onboarding.write grant
- count required tenant onboarding templates together with required system templates for the employee tenant completion state
- add focused regression coverage for the upload path and tenant-aware completion logic

## Validation
- php artisan test tests/Feature/Controllers/OnboardingControllerTest.php tests/Unit/Services/OnboardingCompletionServiceTest.php
- php artisan test tests/Feature/Api/OnboardingCompletionTest.php tests/Feature/Policies/OnboardingFormSubmissionPolicyTest.php
- vendor/bin/phpstan analyse app/Services/OnboardingCompletionService.php --no-progress
- vendor/bin/pint --dirty

Fixes #986
