### PR TITLE
refactor: extract shared scope-access resolution into a single reusable method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- centralized organizational-scope access resolution in `User::hasAccessToUnit()` so persisted checks and in-memory self-lockout simulations now share the same direct-scope-first descendant semantics instead of duplicating that logic in `OrganizationalScopeController` (refs `api#982`)
 - removed the predefined `Admin` role and the `admin` organizational scope access level from the API runtime, seeded fixtures, and RBAC/auth test bootstraps; privileged access is now modeled through explicit permissions plus `manage` organizational scopes, and existing `admin` scope rows are normalized to `manage` during migration
 - clarified the repo-local under-`1.x` policy in Copilot governance so API work explicitly prefers removing insecure or obsolete compatibility shims over preserving them without a proven live caller
 - converted all findings from the 2026-03-31 security audit to GitHub Issues (#834–#847) tracked under Epic #848

--- a/app/Http/Controllers/Api/V1/OrganizationalScopeController.php
+++ b/app/Http/Controllers/Api/V1/OrganizationalScopeController.php
@@ -240,6 +240,15 @@ class OrganizationalScopeController extends Controller
     /**
      * Prevent a user from removing their own last scope-management path on the unit.
      *
+     * The access check uses {@see User::hasAccessToUnit()} with a caller-supplied in-memory
+     * scope collection so the post-change state can be simulated without mutating data.
+     * This differs from the removed controller-local helper which used `value('ancestor_id')`
+     * to pick a single DB-ordered ancestor scope.  Evaluating all applicable scopes is the
+     * correct behaviour: if the user retains manage access through any applicable scope
+     * (direct or inherited), they are not locked out.  Resolves the non-determinism in the
+     * previous helper and aligns with the shared direct-scope-first semantics of
+     * {@see User::resolveApplicableOrganizationalScopesForUnit()} (refs api#982).
+     *
      * @param  array<string, mixed>  $pendingAttributes
      */
     private function preventSelfScopeManagementLockout(

--- a/app/Http/Controllers/Api/V1/OrganizationalScopeController.php
+++ b/app/Http/Controllers/Api/V1/OrganizationalScopeController.php
@@ -10,7 +10,6 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\StoreOrganizationalScopeRequest;
 use App\Http\Requests\UpdateOrganizationalScopeRequest;
 use App\Models\OrganizationalUnit;
-use App\Models\OrganizationalUnitClosure;
 use App\Models\User;
 use App\Models\UserInternalOrganizationalScope;
 use Illuminate\Http\JsonResponse;
@@ -271,76 +270,13 @@ class OrganizationalScopeController extends Controller
             $simulatedScopes->push($simulatedScope);
         }
 
-        if ($this->scopesHaveMinimumAccessToUnit($simulatedScopes, $organizationalUnit, 'manage')) {
+        if ($actor->hasAccessToUnit($organizationalUnit, 'manage', $simulatedScopes)) {
             return null;
         }
 
         return response()->json([
             'message' => __(self::SELF_SCOPE_LOCKOUT_MESSAGE),
         ], Response::HTTP_FORBIDDEN);
-    }
-
-    /**
-     * Evaluate minimum access for a unit using an in-memory scope collection.
-     *
-     * This intentionally mirrors the direct-scope-first access semantics of
-     * User::hasAccessToUnit() but operates on a caller-supplied collection instead
-     * of querying the database. This allows the lockout check to simulate
-     * post-modification state (e.g. after a scope is removed or downgraded)
-     * without mutating data or making additional DB calls.
-     *
-     * See api#982 for a tracked refactoring to unify this with User::hasAccessToUnit().
-     *
-     * @param  Collection<int, UserInternalOrganizationalScope>  $scopes
-     */
-    private function scopesHaveMinimumAccessToUnit(
-        Collection $scopes,
-        OrganizationalUnit $organizationalUnit,
-        string $minimumLevel,
-    ): bool {
-        if ($scopes->isEmpty()) {
-            return false;
-        }
-
-        /** @var Collection<int, string> $directScopeUnitIds */
-        $directScopeUnitIds = collect();
-        /** @var Collection<int, string> $descendantScopeUnitIds */
-        $descendantScopeUnitIds = collect();
-
-        foreach ($scopes as $scope) {
-            $directScopeUnitIds->push($scope->organizational_unit_id);
-
-            if ($scope->include_descendants) {
-                $descendantScopeUnitIds->push($scope->organizational_unit_id);
-            }
-        }
-
-        $isDirectlyScoped = $directScopeUnitIds->contains($organizationalUnit->id);
-
-        $ancestorScopeId = null;
-        if (! $isDirectlyScoped && $descendantScopeUnitIds->isNotEmpty()) {
-            $ancestorScopeId = OrganizationalUnitClosure::whereIn('ancestor_id', $descendantScopeUnitIds->unique())
-                ->where('descendant_id', $organizationalUnit->id)
-                ->where('depth', '>', 0)
-                ->value('ancestor_id');
-        }
-
-        $applicableScope = null;
-        if ($isDirectlyScoped) {
-            $applicableScope = $scopes->first(
-                fn (UserInternalOrganizationalScope $scope) => $scope->organizational_unit_id === $organizationalUnit->id,
-            );
-        } elseif ($ancestorScopeId !== null) {
-            $applicableScope = $scopes->first(
-                fn (UserInternalOrganizationalScope $scope) => $scope->organizational_unit_id === $ancestorScopeId && $scope->include_descendants,
-            );
-        }
-
-        if (! $applicableScope instanceof UserInternalOrganizationalScope) {
-            return false;
-        }
-
-        return $applicableScope->hasMinimumAccessLevel($minimumLevel);
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -17,7 +17,6 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Database\Query\Builder as QueryBuilder;
-// Models used in organizational scope methods
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Collection as SupportCollection;
@@ -670,8 +669,21 @@ class User extends Authenticatable implements MustVerifyEmailContract, TwoFactor
      */
     public function getApplicableOrganizationalScopesForUnit(OrganizationalUnit $unit): SupportCollection
     {
-        $scopes = $this->organizationalScopes;
+        return $this->resolveApplicableOrganizationalScopesForUnit($unit, $this->organizationalScopes);
+    }
 
+    /**
+     * Resolve the scopes that apply to a specific organizational unit.
+     *
+     * Direct scopes take precedence over inherited descendant scopes for the
+     * same unit. When no direct scope exists, all ancestor scopes with
+     * include_descendants=true are returned.
+     *
+     * @param  SupportCollection<int, UserInternalOrganizationalScope>  $scopes
+     * @return SupportCollection<int, UserInternalOrganizationalScope>
+     */
+    private function resolveApplicableOrganizationalScopesForUnit(OrganizationalUnit $unit, SupportCollection $scopes): SupportCollection
+    {
         if ($scopes->isEmpty()) {
             /** @var SupportCollection<int, UserInternalOrganizationalScope> $emptyScopes */
             $emptyScopes = collect();
@@ -878,12 +890,15 @@ class User extends Authenticatable implements MustVerifyEmailContract, TwoFactor
      * - Single query to check if target unit is a descendant of any scoped unit
      *
      * @param  string|null  $minimumLevel  Optional minimum access level required
+     * @param  SupportCollection<int, UserInternalOrganizationalScope>|null  $scopes
      */
-    public function hasAccessToUnit(OrganizationalUnit $unit, ?string $minimumLevel = null): bool
+    public function hasAccessToUnit(OrganizationalUnit $unit, ?string $minimumLevel = null, ?SupportCollection $scopes = null): bool
     {
-        $scopes = $this->getApplicableOrganizationalScopesForUnit($unit);
+        $resolvedScopes = $scopes === null
+            ? $this->getApplicableOrganizationalScopesForUnit($unit)
+            : $this->resolveApplicableOrganizationalScopesForUnit($unit, $scopes);
 
-        if ($scopes->isEmpty()) {
+        if ($resolvedScopes->isEmpty()) {
             return false;
         }
 
@@ -892,7 +907,7 @@ class User extends Authenticatable implements MustVerifyEmailContract, TwoFactor
             return true;
         }
 
-        return $scopes->contains(
+        return $resolvedScopes->contains(
             fn (UserInternalOrganizationalScope $scope): bool => $scope->hasMinimumAccessLevel($minimumLevel)
         );
     }

--- a/tests/Feature/Models/UserInternalOrganizationalScopeTest.php
+++ b/tests/Feature/Models/UserInternalOrganizationalScopeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-// SPDX-FileCopyrightText: 2025 SecPal Contributors
+// SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use App\Models\OrganizationalUnit;
@@ -381,6 +381,58 @@ describe('UserInternalOrganizationalScope Model', function () {
             expect($this->user->hasAccessToUnit($this->region, 'write'))->toBeFalse();
             expect($this->user->hasAccessToUnit($this->branch, 'read'))->toBeTrue();
             expect($this->user->hasAccessToUnit($this->branch, 'manage'))->toBeFalse();
+        });
+
+        it('user hasAccessToUnit() matches database and in-memory scope resolution for the same scope set', function (): void {
+            UserInternalOrganizationalScope::create([
+                'user_id' => $this->user->id,
+                'organizational_unit_id' => $this->company->id,
+                'access_level' => 'manage',
+                'include_descendants' => true,
+            ]);
+
+            UserInternalOrganizationalScope::create([
+                'user_id' => $this->user->id,
+                'organizational_unit_id' => $this->branch->id,
+                'access_level' => 'read',
+                'include_descendants' => false,
+            ]);
+
+            $scopes = $this->user->organizationalScopes()->get()->values();
+
+            expect($this->user->hasAccessToUnit($this->region, 'manage', $scopes))->toBe(
+                $this->user->hasAccessToUnit($this->region, 'manage')
+            )->and($this->user->hasAccessToUnit($this->branch, 'manage', $scopes))->toBe(
+                $this->user->hasAccessToUnit($this->branch, 'manage')
+            )->and($this->user->hasAccessToUnit($this->branch, 'read', $scopes))->toBe(
+                $this->user->hasAccessToUnit($this->branch, 'read')
+            )->and($this->user->hasAccessToUnit($this->region, 'manage', $scopes))->toBeTrue()
+                ->and($this->user->hasAccessToUnit($this->branch, 'manage', $scopes))->toBeFalse()
+                ->and($this->user->hasAccessToUnit($this->branch, 'read', $scopes))->toBeTrue();
+        });
+
+        it('user hasAccessToUnit() can evaluate a simulated in-memory scope collection', function (): void {
+            UserInternalOrganizationalScope::create([
+                'user_id' => $this->user->id,
+                'organizational_unit_id' => $this->company->id,
+                'access_level' => 'manage',
+                'include_descendants' => true,
+            ]);
+
+            $persistedDirectScope = UserInternalOrganizationalScope::create([
+                'user_id' => $this->user->id,
+                'organizational_unit_id' => $this->branch->id,
+                'access_level' => 'read',
+                'include_descendants' => false,
+            ]);
+
+            $simulatedScopes = $this->user->organizationalScopes()
+                ->whereKeyNot($persistedDirectScope->id)
+                ->get()
+                ->values();
+
+            expect($this->user->hasAccessToUnit($this->branch, 'manage'))->toBeFalse()
+                ->and($this->user->hasAccessToUnit($this->branch, 'manage', $simulatedScopes))->toBeTrue();
         });
     });
 });


### PR DESCRIPTION
## Summary
- centralize organizational scope resolution in `User::hasAccessToUnit()` so callers can reuse the same direct-scope-first logic with either persisted or simulated scope collections
- replace the controller-local self-lockout helper with the shared `User` model path
- add regression coverage proving in-memory scope simulation matches persisted behavior and can model post-change access correctly

## Testing
- php artisan test tests/Feature/Models/UserInternalOrganizationalScopeTest.php tests/Feature/Controllers/OrganizationalScopeControllerTest.php
- vendor/bin/phpstan analyse app/Models/User.php app/Http/Controllers/Api/V1/OrganizationalScopeController.php tests/Feature/Models/UserInternalOrganizationalScopeTest.php --memory-limit=1G
- vendor/bin/pint --dirty --test

Closes #982
