### PR TITLE
fix: block unsafe customer assignments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- fixed `POST /v1/customers/{customer}/assignments` to apply the same employee-compliance expiry gate as site assignments, so customer assignments now reject employees with critical or expired compliance documents while still allowing warning-only alerts (fixes `api#999`)
 - fixed onboarding self-service backend blockers so authenticated pre-contract employees can upload files to their own editable onboarding submissions without an extra `onboarding.write` grant, while onboarding completion now counts required tenant templates together with required system templates for the employee's tenant-specific completion state (fixes `api#986`)
 - fixed `GET /v1/employees` to apply the same scoped management-level visibility rules as `GET /v1/employees/{employee}`, so collection responses no longer include employees whose detail endpoint would still return `403 This action is unauthorized.` for the same user (fixes `api#987`)
 - aligned employee create, view, and update authorization on the same descendant-scope and management-level rules, so users can no longer create an employee in a scoped unit and then hit `403 This action is unauthorized.` on the immediate detail fetch; create and update now reject employees whose target unit or management level would fall outside the actor's writable, assignable, and viewable scope

--- a/app/Http/Controllers/Api/V1/CustomerAssignmentController.php
+++ b/app/Http/Controllers/Api/V1/CustomerAssignmentController.php
@@ -1,6 +1,6 @@
 <?php
 
-// SPDX-FileCopyrightText: 2025 SecPal Contributors
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 declare(strict_types=1);
@@ -14,6 +14,9 @@ use App\Http\Requests\Api\V1\Assignment\UpdateAssignmentRequest;
 use App\Http\Resources\Api\V1\CustomerAssignmentResource;
 use App\Models\Customer;
 use App\Models\CustomerAssignment;
+use App\Models\Employee;
+use App\Models\User;
+use App\Services\EmployeeComplianceService;
 use Illuminate\Http\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -70,13 +73,26 @@ class CustomerAssignmentController extends Controller
      *
      * @return JsonResponse CustomerAssignmentResource (201 Created) or error (409 Conflict)
      */
-    public function store(StoreCustomerAssignmentRequest $request, Customer $customer): JsonResponse
+    public function store(StoreCustomerAssignmentRequest $request, Customer $customer, EmployeeComplianceService $complianceService): JsonResponse
     {
         $this->authorize('create', [CustomerAssignment::class, $customer]);
 
         $validated = $request->validated();
         $validated['tenant_id'] = $request->input('tenant_id');
         $validated['customer_id'] = $customer->id;
+
+        /** @var User $targetUser */
+        $targetUser = User::query()->with('employee')->findOrFail($validated['user_id']);
+        $blockingDocuments = $targetUser->employee instanceof Employee
+            ? $complianceService->blockingDocuments($targetUser->employee)
+            : collect();
+
+        if ($blockingDocuments->isNotEmpty()) {
+            return response()->json([
+                'message' => 'Employee cannot be assigned while critical compliance documents are expired or due within 7 days.',
+                'blocking_documents' => $blockingDocuments->all(),
+            ], Response::HTTP_UNPROCESSABLE_ENTITY);
+        }
 
         // Check for existing assignment with same user+role
         $existing = CustomerAssignment::where('customer_id', $customer->id)

--- a/tests/Feature/Controllers/Api/V1/CustomerAssignmentControllerTest.php
+++ b/tests/Feature/Controllers/Api/V1/CustomerAssignmentControllerTest.php
@@ -1,13 +1,15 @@
 <?php
 
 /*
- * SPDX-FileCopyrightText: 2025 SecPal Contributors
+ * SPDX-FileCopyrightText: 2026 SecPal Contributors
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 use App\Models\Customer;
 use App\Models\CustomerAssignment;
+use App\Models\Employee;
+use App\Models\OrganizationalUnit;
 use App\Models\TenantKey;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -249,6 +251,78 @@ describe('POST /v1/customers/{customer}/assignments', function () {
         $response->assertStatus(201);
         expect($response->json('data.valid_from'))->not()->toBeNull();
         expect($response->json('data.valid_until'))->not()->toBeNull();
+    });
+
+    test('blocks assignments when the target user employee has critical compliance expiries', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'assignments.create');
+        givePermissionWithTenant($this->user, $this->tenant->id, 'customers.update');
+
+        $targetUser = User::factory()->create([
+            'tenant_id' => $this->tenant->id,
+        ]);
+
+        $organizationalUnit = OrganizationalUnit::factory()->create([
+            'tenant_id' => $this->tenant->id,
+        ]);
+
+        Employee::factory()->withExpiringComplianceCertifications()->create([
+            'tenant_id' => $this->tenant->id,
+            'organizational_unit_id' => $organizationalUnit->id,
+            'user_id' => $targetUser->id,
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->postJson("/v1/customers/{$this->customer->id}/assignments", [
+                'user_id' => $targetUser->id,
+                'role' => 'Key Account Manager',
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonPath('message', 'Employee cannot be assigned while critical compliance documents are expired or due within 7 days.')
+            ->assertJsonStructure([
+                'blocking_documents' => [
+                    '*' => ['type', 'status', 'expiry'],
+                ],
+            ]);
+    });
+
+    test('allows assignments when the target user employee has warning level compliance alerts only', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'assignments.create');
+        givePermissionWithTenant($this->user, $this->tenant->id, 'customers.update');
+
+        $targetUser = User::factory()->create([
+            'tenant_id' => $this->tenant->id,
+        ]);
+
+        $organizationalUnit = OrganizationalUnit::factory()->create([
+            'tenant_id' => $this->tenant->id,
+        ]);
+
+        Employee::factory()->withComplianceCertifications()->create([
+            'tenant_id' => $this->tenant->id,
+            'organizational_unit_id' => $organizationalUnit->id,
+            'user_id' => $targetUser->id,
+            'firearms_license_expiry' => now()->addDays(20)->toDateString(),
+            'first_aid_cert_expiry' => now()->addDays(45)->toDateString(),
+            'evacuation_cert_expiry' => now()->addDays(60)->toDateString(),
+            'additional_certifications' => [
+                [
+                    'name' => 'Badge',
+                    'issued_date' => now()->subMonth()->toDateString(),
+                    'expiry_date' => now()->addDays(21)->toDateString(),
+                    'issuer' => 'Customer Security',
+                ],
+            ],
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->postJson("/v1/customers/{$this->customer->id}/assignments", [
+                'user_id' => $targetUser->id,
+                'role' => 'Key Account Manager',
+            ]);
+
+        $response->assertCreated()
+            ->assertJsonPath('data.user.id', $targetUser->id);
     });
 
     test('returns 409 when duplicate assignment exists', function (): void {


### PR DESCRIPTION
## Summary
- block customer assignment creation when the target employee has critical or expired compliance documents
- cover the customer assignment path with focused feature tests for blocking and warning-only compliance states
- document the API behavior change in the changelog

## Testing
- php artisan test tests/Feature/Controllers/Api/V1/CustomerAssignmentControllerTest.php
- vendor/bin/pint --dirty

Fixes #999
