### PR TITLE
Remove remaining admin-model API drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- removed the remaining Admin-role and `admin`-scope documentation drift from the API guides, auth examples, ADR-linked RBAC references, and supporting test fixtures so the documented bootstrap, authorization, and audit examples now consistently use explicit permissions plus explicit `manage` scopes instead of the deleted legacy model
 - centralized organizational-scope access resolution in `User::hasAccessToUnit()` so persisted checks and in-memory self-lockout simulations now share the same direct-scope-first descendant semantics instead of duplicating that logic in `OrganizationalScopeController` (refs `api#982`)
 - removed the predefined `Admin` role and the `admin` organizational scope access level from the API runtime, seeded fixtures, and RBAC/auth test bootstraps; privileged access is now modeled through explicit permissions plus `manage` organizational scopes, and existing `admin` scope rows are normalized to `manage` during migration
 - clarified the repo-local under-`1.x` policy in Copilot governance so API work explicitly prefers removing insecure or obsolete compatibility shims over preserving them without a proven live caller

--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -111,8 +111,8 @@ Set-Cookie: laravel_session=<session>; path=/; HttpOnly; Secure; SameSite=lax
     "id": 1,
     "name": "John Doe",
     "email": "user@example.com",
-    "roles": ["Admin"],
-    "permissions": ["*"],
+    "roles": ["Manager"],
+    "permissions": ["employees.read", "shifts.read", "work_instructions.read"],
     "hasOrganizationalScopes": true
   }
 }
@@ -141,8 +141,8 @@ Content-Type: application/json
   "id": 1,
   "name": "John Doe",
   "email": "user@example.com",
-  "roles": ["Admin"],
-  "permissions": ["*"],
+  "roles": ["Manager"],
+  "permissions": ["employees.read", "shifts.read", "work_instructions.read"],
   "hasOrganizationalScopes": true
 }
 ```

--- a/docs/api/rbac-endpoints.md
+++ b/docs/api/rbac-endpoints.md
@@ -249,7 +249,7 @@ Extend the expiration date of a temporal role assignment.
 
 **Endpoint:** `PATCH /v1/users/{user}/roles/{role}/extend`
 
-**Authorization:** Requires `roles.extend_expiration` permission
+**Authorization:** Requires `role.assign` permission
 
 **URL Parameters:**
 
@@ -260,7 +260,8 @@ Extend the expiration date of a temporal role assignment.
 
 ```json
 {
-  "valid_until": "2025-12-31T23:59:59Z"
+  "valid_until": "2025-12-31T23:59:59Z",
+  "reason": "Vacation coverage extended"
 }
 ```
 
@@ -268,14 +269,11 @@ Extend the expiration date of a temporal role assignment.
 
 ```json
 {
-  "data": {
-    "user_id": 123,
-    "role": "manager",
-    "old_valid_until": "2025-12-14T23:59:59Z",
-    "new_valid_until": "2025-12-31T23:59:59Z",
-    "extended_by": 1,
-    "extended_at": "2025-11-15T10:00:00Z"
-  }
+  "user_id": 123,
+  "role": "manager",
+  "valid_from": "2025-12-01T00:00:00Z",
+  "valid_until": "2025-12-31T23:59:59Z",
+  "reason": "Vacation coverage extended"
 }
 ```
 
@@ -300,7 +298,7 @@ Get a list of all roles in the system (predefined + custom).
 
 **Endpoint:** `GET /v1/roles`
 
-**Authorization:** Requires `role.read` permission
+**Authorization:** Requires `roles.read` permission
 
 **Query Parameters:**
 
@@ -451,7 +449,7 @@ Get detailed information about a specific role, including assigned permissions.
 
 **Endpoint:** `GET /v1/roles/{id}`
 
-**Authorization:** Requires `role.read` permission
+**Authorization:** Requires `roles.read` permission
 
 **URL Parameters:**
 

--- a/docs/api/rbac-endpoints.md
+++ b/docs/api/rbac-endpoints.md
@@ -34,7 +34,7 @@ Assign a role to a user. Supports both permanent and temporal assignments.
 
 **Endpoint:** `POST /v1/users/{user}/roles`
 
-**Authorization:** Requires `role.assign` permission (Manager or Admin)
+**Authorization:** Requires `role.assign` permission
 
 **URL Parameters:**
 
@@ -55,7 +55,7 @@ Assign a role to a user. Supports both permanent and temporal assignments.
 
 | Field         | Type   | Required | Description                                                    |
 | ------------- | ------ | -------- | -------------------------------------------------------------- |
-| `role`        | string | Yes      | Role name (e.g., "manager", "guard", "admin")                  |
+| `role`        | string | Yes      | Role name (e.g., `Manager`, `HR`, `regional_manager`)          |
 | `valid_from`  | string | No       | ISO 8601 timestamp when role becomes active (null = immediate) |
 | `valid_until` | string | No       | ISO 8601 timestamp when role expires (null = permanent)        |
 | `reason`      | string | No       | Justification for role assignment (max 500 chars)              |
@@ -150,7 +150,7 @@ Get all roles assigned to a user, including temporal information.
 
 **Endpoint:** `GET /v1/users/{user}/roles`
 
-**Authorization:** Requires `role.read` permission (User can view own, Manager/Admin can view all)
+**Authorization:** Users may view their own roles; viewing another user's roles requires `role.read`
 
 **URL Parameters:**
 
@@ -203,7 +203,7 @@ Remove a role assignment from a user.
 
 **Endpoint:** `DELETE /v1/users/{user}/roles/{role}`
 
-**Authorization:** Requires `role.revoke` permission (Manager or Admin)
+**Authorization:** Requires `role.revoke` permission
 
 **URL Parameters:**
 
@@ -249,7 +249,7 @@ Extend the expiration date of a temporal role assignment.
 
 **Endpoint:** `PATCH /v1/users/{user}/roles/{role}/extend`
 
-**Authorization:** Requires `role.extend_expiration` permission (Manager or Admin)
+**Authorization:** Requires `roles.extend_expiration` permission
 
 **URL Parameters:**
 
@@ -319,18 +319,18 @@ Get a list of all roles in the system (predefined + custom).
   "data": [
     {
       "id": 1,
-      "name": "admin",
-      "description": "Full system access",
-      "permissions_count": 42,
+      "name": "Manager",
+      "description": "Operational management within assigned scopes",
+      "permissions_count": 18,
       "users_count": 2,
       "created_at": "2025-11-01T10:00:00Z",
       "updated_at": "2025-11-01T10:00:00Z"
     },
     {
       "id": 2,
-      "name": "manager",
-      "description": "Branch management",
-      "permissions_count": 15,
+      "name": "HR",
+      "description": "HR lifecycle and onboarding operations",
+      "permissions_count": 16,
       "users_count": 8,
       "created_at": "2025-11-01T10:00:00Z",
       "updated_at": "2025-11-05T14:30:00Z"
@@ -368,7 +368,7 @@ Create a new custom role with assigned permissions.
 
 **Endpoint:** `POST /v1/roles`
 
-**Authorization:** Authorized via Laravel Policy (Admin role required). Note: Route-level middleware will be added in future release (see Issue #161).
+**Authorization:** Requires `roles.create` permission. Authorization is currently enforced via Laravel Policy; route-level middleware is planned as a follow-up (see Issue #161).
 
 **Request Body:**
 
@@ -505,7 +505,7 @@ Update a role's name, description, and/or permissions.
 
 **Endpoint:** `PATCH /v1/roles/{id}`
 
-**Authorization:** Authorized via Laravel Policy (Admin role required). Note: Route-level middleware will be added in future release (see Issue #161).
+**Authorization:** Requires `roles.update` permission. Authorization is currently enforced via Laravel Policy; route-level middleware is planned as a follow-up (see Issue #161).
 
 **URL Parameters:**
 
@@ -556,7 +556,7 @@ Delete a custom role. **Cannot delete roles that are assigned to users.**
 
 **Endpoint:** `DELETE /v1/roles/{id}`
 
-**Authorization:** Authorized via Laravel Policy (Admin role required). Note: Route-level middleware will be added in future release (see Issue #161).
+**Authorization:** Requires `roles.delete` permission. Authorization is currently enforced via Laravel Policy; route-level middleware is planned as a follow-up (see Issue #161).
 
 **URL Parameters:**
 
@@ -663,7 +663,7 @@ Create a new custom permission.
 
 **Endpoint:** `POST /v1/permissions`
 
-**Authorization:** Authorized via Laravel Policy (Admin role required). Note: Route-level middleware will be added in future release (see Issue #161).
+**Authorization:** Requires `permissions.create` permission. Authorization is currently enforced via Laravel Policy; route-level middleware is planned as a follow-up (see Issue #161).
 
 **Request Body:**
 
@@ -745,11 +745,11 @@ Get detailed information about a specific permission.
     "roles": [
       {
         "id": 1,
-        "name": "admin"
+        "name": "Manager"
       },
       {
         "id": 2,
-        "name": "manager"
+        "name": "HR"
       }
     ],
     "roles_count": 4,
@@ -774,7 +774,7 @@ Update a permission's description. **Note:** Permission names are immutable for 
 
 **Endpoint:** `PATCH /v1/permissions/{id}`
 
-**Authorization:** Authorized via Laravel Policy (Admin role required). Note: Route-level middleware will be added in future release (see Issue #161).
+**Authorization:** Requires `permissions.update` permission. Authorization is currently enforced via Laravel Policy; route-level middleware is planned as a follow-up (see Issue #161).
 
 **URL Parameters:**
 
@@ -820,7 +820,7 @@ Delete a custom permission. **Cannot delete if assigned to any role or user.**
 
 **Endpoint:** `DELETE /v1/permissions/{id}`
 
-**Authorization:** Authorized via Laravel Policy (Admin role required). Note: Route-level middleware will be added in future release (see Issue #161).
+**Authorization:** Requires `permissions.delete` permission. Authorization is currently enforced via Laravel Policy; route-level middleware is planned as a follow-up (see Issue #161).
 
 **URL Parameters:**
 
@@ -866,7 +866,7 @@ Get all permissions for a user, showing role-based, direct, and combined permiss
 
 **Endpoint:** `GET /v1/users/{user}/permissions`
 
-**Authorization:** User can view own permissions; Admin can view any user's permissions
+**Authorization:** Users may view their own permissions; viewing another user's permissions requires `permissions.read`
 
 **URL Parameters:**
 
@@ -934,7 +934,7 @@ Assign one or more permissions directly to a user, bypassing roles.
 
 **Endpoint:** `POST /v1/users/{user}/permissions`
 
-**Authorization:** Authorized via Laravel Policy (Admin role required). Note: Route-level middleware will be added in future release (see Issue #161).
+**Authorization:** Requires `permissions.assign_direct` permission. Authorization is currently enforced via Laravel Policy; route-level middleware is planned as a follow-up (see Issue #161).
 
 **URL Parameters:**
 
@@ -1008,7 +1008,7 @@ Remove a direct permission from a user. **Does not affect role-based permissions
 
 **Endpoint:** `DELETE /v1/users/{user}/permissions/{permission}`
 
-**Authorization:** Authorized via Laravel Policy (Admin role required). Note: Route-level middleware will be added in future release (see Issue #161).
+**Authorization:** Requires `permissions.revoke_direct` permission. Authorization is currently enforced via Laravel Policy; route-level middleware is planned as a follow-up (see Issue #161).
 
 **URL Parameters:**
 
@@ -1045,7 +1045,7 @@ Get only the permissions assigned directly to a user (excludes role-based permis
 
 **Endpoint:** `GET /v1/users/{user}/permissions/direct`
 
-**Authorization:** User can view own; Admin can view any
+**Authorization:** Users may view their own direct permissions; viewing another user's direct permissions requires `permissions.read`
 
 **URL Parameters:**
 

--- a/docs/api/rbac-endpoints.md
+++ b/docs/api/rbac-endpoints.md
@@ -53,12 +53,12 @@ Assign a role to a user. Supports both permanent and temporal assignments.
 
 **Parameters:**
 
-| Field         | Type   | Required | Description                                                    |
-| ------------- | ------ | -------- | -------------------------------------------------------------- |
-| `role`        | string | Yes      | Role name (e.g., `Manager`, `HR`, `regional_manager`)          |
-| `valid_from`  | string | No       | ISO 8601 timestamp when role becomes active (null = immediate) |
-| `valid_until` | string | No       | ISO 8601 timestamp when role expires (null = permanent)        |
-| `reason`      | string | No       | Justification for role assignment (max 500 chars)              |
+| Field         | Type   | Required | Description                                                                                                                                              |
+| ------------- | ------ | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `role`        | string | Yes      | Role name; case-sensitive, must match the exact value stored in `roles.name` (e.g., `Manager`, `HR`, or a custom lowercase name like `regional_manager`) |
+| `valid_from`  | string | No       | ISO 8601 timestamp when role becomes active (null = immediate)                                                                                           |
+| `valid_until` | string | No       | ISO 8601 timestamp when role expires (null = permanent)                                                                                                  |
+| `reason`      | string | No       | Justification for role assignment (max 500 chars)                                                                                                        |
 
 **Success Response (201 Created):**
 
@@ -269,8 +269,8 @@ Extend the expiration date of a temporal role assignment.
 
 ```json
 {
-  "user_id": 123,
-  "role": "manager",
+  "user_id": "550e8400-e29b-41d4-a716-446655440000",
+  "role": "Manager",
   "valid_from": "2025-12-01T00:00:00Z",
   "valid_until": "2025-12-31T23:59:59Z",
   "reason": "Vacation coverage extended"
@@ -366,7 +366,7 @@ Create a new custom role with assigned permissions.
 
 **Endpoint:** `POST /v1/roles`
 
-**Authorization:** Requires `roles.create` permission. Authorization is currently enforced via Laravel Policy; route-level middleware is planned as a follow-up (see Issue #161).
+**Authorization:** Requires `roles.create` permission. Authorization is enforced at the route level via `permission:roles.create`, with policy/Gate checks retained as an additional defense-in-depth layer.
 
 **Request Body:**
 
@@ -503,7 +503,7 @@ Update a role's name, description, and/or permissions.
 
 **Endpoint:** `PATCH /v1/roles/{id}`
 
-**Authorization:** Requires `roles.update` permission. Authorization is currently enforced via Laravel Policy; route-level middleware is planned as a follow-up (see Issue #161).
+**Authorization:** Requires `roles.update` permission. Authorization is enforced at the route level via middleware and additionally via Laravel Policy/Gate checks.
 
 **URL Parameters:**
 
@@ -554,7 +554,7 @@ Delete a custom role. **Cannot delete roles that are assigned to users.**
 
 **Endpoint:** `DELETE /v1/roles/{id}`
 
-**Authorization:** Requires `roles.delete` permission. Authorization is currently enforced via Laravel Policy; route-level middleware is planned as a follow-up (see Issue #161).
+**Authorization:** Requires `roles.delete` permission. Authorization is enforced at the route level via `permission:roles.delete` middleware, with Laravel Policy/Gate checks providing additional protection.
 
 **URL Parameters:**
 
@@ -661,7 +661,7 @@ Create a new custom permission.
 
 **Endpoint:** `POST /v1/permissions`
 
-**Authorization:** Requires `permissions.create` permission. Authorization is currently enforced via Laravel Policy; route-level middleware is planned as a follow-up (see Issue #161).
+**Authorization:** Requires `permissions.create` permission. Authorization is enforced at the route level via `permission:permissions.create` middleware, with additional policy/Gate checks applied in the request flow.
 
 **Request Body:**
 
@@ -772,7 +772,7 @@ Update a permission's description. **Note:** Permission names are immutable for 
 
 **Endpoint:** `PATCH /v1/permissions/{id}`
 
-**Authorization:** Requires `permissions.update` permission. Authorization is currently enforced via Laravel Policy; route-level middleware is planned as a follow-up (see Issue #161).
+**Authorization:** Requires `permissions.update` permission. Authorization is enforced at the route level via `permission:permissions.update` middleware and additionally checked via Laravel Policy/Gate.
 
 **URL Parameters:**
 
@@ -818,7 +818,7 @@ Delete a custom permission. **Cannot delete if assigned to any role or user.**
 
 **Endpoint:** `DELETE /v1/permissions/{id}`
 
-**Authorization:** Requires `permissions.delete` permission. Authorization is currently enforced via Laravel Policy; route-level middleware is planned as a follow-up (see Issue #161).
+**Authorization:** Requires `permissions.delete` permission. Authorization is enforced by route-level `permission:permissions.delete` middleware and Laravel Policy/Gate checks.
 
 **URL Parameters:**
 
@@ -932,7 +932,7 @@ Assign one or more permissions directly to a user, bypassing roles.
 
 **Endpoint:** `POST /v1/users/{user}/permissions`
 
-**Authorization:** Requires `permissions.assign_direct` permission. Authorization is currently enforced via Laravel Policy; route-level middleware is planned as a follow-up (see Issue #161).
+**Authorization:** Requires `permissions.assign_direct` permission. Authorization is enforced by both the route-level `permission:permissions.assign_direct` middleware and the Laravel Policy for this endpoint.
 
 **URL Parameters:**
 
@@ -1006,7 +1006,7 @@ Remove a direct permission from a user. **Does not affect role-based permissions
 
 **Endpoint:** `DELETE /v1/users/{user}/permissions/{permission}`
 
-**Authorization:** Requires `permissions.revoke_direct` permission. Authorization is currently enforced via Laravel Policy; route-level middleware is planned as a follow-up (see Issue #161).
+**Authorization:** Requires `permissions.revoke_direct` permission. Authorization is enforced by both route-level `permission:permissions.revoke_direct` middleware and the Laravel Policy for this action.
 
 **URL Parameters:**
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -225,7 +225,7 @@ Migration name ......................................... Batch / Status
 ### 3. Seed Predefined Roles (RBAC)
 
 ```bash
-# Seed 5 predefined roles (Admin, Manager, Guard, Client, Works Council)
+# Seed 7 predefined roles (Employee, Employee Read Only, HR, Manager, Guard, Client, Works Council)
 php artisan db:seed --class=RolesAndPermissionsSeeder
 ```
 

--- a/docs/guides/multi-tenant-deployment.md
+++ b/docs/guides/multi-tenant-deployment.md
@@ -231,9 +231,9 @@ Users can register themselves:
 curl -X POST https://api.secpal.dev/v1/auth/register \
   -H "Content-Type: application/json" \
   -d '{
-    "email": "admin@customercorp.com",
+        "email": "ops@customercorp.com",
     "password": "SecurePassword123!",
-    "name": "Admin User",
+        "name": "Initial Operator",
     "tenant_id": 1
   }'
 ```
@@ -244,15 +244,15 @@ curl -X POST https://api.secpal.dev/v1/auth/register \
 {
   "user": {
     "id": "9d8e7f6a-5b4c-3d2e-1f0e-9d8c7b6a5f4e",
-    "email": "admin@customercorp.com",
-    "name": "Admin User",
+    "email": "ops@customercorp.com",
+    "name": "Initial Operator",
     "tenant_id": 1
   },
   "token": "1|XYZ..."
 }
 ```
 
-#### Option B: Admin User Creation (Tinker)
+#### Option B: Bootstrap User Creation (Tinker)
 
 ```bash
 php artisan tinker
@@ -260,18 +260,45 @@ php artisan tinker
 
 ```php
 use App\Models\User;
+use App\Models\Permission;
+use App\Models\UserInternalOrganizationalScope;
 use Illuminate\Support\Facades\Hash;
 
 // Create user for tenant 1
 $user = User::create([
-    'email' => 'admin@tenant1.com',
+    'email' => 'ops@tenant1.com',
     'password' => Hash::make('SecurePassword123!'),
-    'name' => 'Admin User',
+    'name' => 'Initial Operator',
     'tenant_id' => 1, // Assign to tenant 1
 ]);
 
-// Assign admin role (tenant-scoped)
-$user->assignRole('Admin');
+app(\Spatie\Permission\PermissionRegistrar::class)->setPermissionsTeamId($user->tenant_id);
+$user->syncPermissions(
+    Permission::query()->where('guard_name', 'sanctum')->pluck('name')->all()
+);
+
+$rootUnit = \App\Models\OrganizationalUnit::firstOrCreate([
+    'tenant_id' => $user->tenant_id,
+    'name' => 'Headquarters',
+], [
+    'type' => 'branch',
+]);
+
+UserInternalOrganizationalScope::updateOrCreate(
+    [
+        'user_id' => $user->id,
+        'organizational_unit_id' => $rootUnit->id,
+        'min_viewable_rank' => null,
+        'max_viewable_rank' => null,
+        'min_assignable_rank' => null,
+        'max_assignable_rank' => null,
+    ],
+    [
+        'access_level' => 'manage',
+        'include_descendants' => true,
+        'allow_self_access' => true,
+    ]
+);
 
 echo "User created: {$user->email} (Tenant {$user->tenant_id})\n";
 ```
@@ -282,12 +309,12 @@ Roles and permissions are **tenant-scoped** using Spatie Permission's team featu
 
 ```bash
 # Run seeder for initial roles/permissions
-php artisan db:seed --class=RolePermissionSeeder
+php artisan db:seed --class=RolesAndPermissionsSeeder
 ```
 
 **What this does:**
 
-- Creates predefined roles: Admin, Manager, Guard, Client, Works Council
+- Creates predefined roles: Employee, Employee Read Only, HR, Manager, Guard, Client, Works Council
 - Assigns permissions to each role
 - Roles are **shared across tenants** (same role definitions)
 - Role **assignments** are tenant-scoped (User X in Tenant 1 ≠ User X in Tenant 2)
@@ -425,38 +452,56 @@ Create automated tenant provisioning:
 // app/Services/TenantProvisioningService.php
 class TenantProvisioningService
 {
-    public function provisionTenant(string $customerName, string $adminEmail): array
+    public function provisionTenant(string $customerName, string $bootstrapEmail): array
     {
         DB::beginTransaction();
         try {
             // 1. Create tenant with encryption keys
             $tenant = TenantKey::create(TenantKey::generateEnvelopeKeys());
 
-            // 2. Create admin user
-            $admin = User::create([
-                'email' => $adminEmail,
+            // 2. Create bootstrap user
+            $bootstrapUser = User::create([
+                'email' => $bootstrapEmail,
                 'password' => Hash::make(Str::random(16)), // Send via email
-                'name' => 'Admin',
+                'name' => 'Initial Operator',
                 'tenant_id' => $tenant->id,
             ]);
 
-            // 3. Assign admin role (tenant-scoped)
-            app(PermissionRegistrar::class)->setPermissionsTeamId($tenant->id);
-            $admin->assignRole('Admin');
-
-            // 4. Create default organizational unit
+            // 3. Create default organizational unit
             $orgUnit = OrganizationalUnit::create([
                 'name' => 'Headquarters',
                 'type' => 'branch',
                 'tenant_id' => $tenant->id,
             ]);
 
+            // 4. Grant explicit permissions and a root manage scope
+            app(PermissionRegistrar::class)->setPermissionsTeamId($tenant->id);
+            $bootstrapUser->syncPermissions(
+                Permission::query()->where('guard_name', 'sanctum')->pluck('name')->all()
+            );
+
+            UserInternalOrganizationalScope::updateOrCreate(
+                [
+                    'user_id' => $bootstrapUser->id,
+                    'organizational_unit_id' => $orgUnit->id,
+                    'min_viewable_rank' => null,
+                    'max_viewable_rank' => null,
+                    'min_assignable_rank' => null,
+                    'max_assignable_rank' => null,
+                ],
+                [
+                    'access_level' => 'manage',
+                    'include_descendants' => true,
+                    'allow_self_access' => true,
+                ]
+            );
+
             DB::commit();
 
             return [
                 'tenant_id' => $tenant->id,
-                'admin_user_id' => $admin->id,
-                'admin_email' => $adminEmail,
+                'bootstrap_user_id' => $bootstrapUser->id,
+                'bootstrap_email' => $bootstrapEmail,
             ];
         } catch (\Exception $e) {
             DB::rollBack();

--- a/docs/guides/permission-system.md
+++ b/docs/guides/permission-system.md
@@ -113,8 +113,8 @@ Domain-specific actions for workflows:
 | `read_salary`       | View sensitive salary data    | `employees.read_salary`         |
 | `read_all_branches` | Cross-branch access           | `employees.read_all_branches`   |
 | `generate`          | Create dynamic content        | `reports.generate`              |
-| `assign_temporary`  | Assign temporal roles         | `roles.assign_temporary`        |
-| `extend_expiration` | Extend role expiration        | `roles.extend_expiration`       |
+| `assign_temporary`  | Assign temporal roles         | `role.assign`                   |
+| `extend_expiration` | Extend role expiration        | `role.assign`                   |
 
 ---
 

--- a/docs/guides/permission-system.md
+++ b/docs/guides/permission-system.md
@@ -127,9 +127,10 @@ Customers and Sites intentionally use a two-layer model:
 
 ### Global Access
 
-- `Admin` receives `customers.*` and `sites.*`
-- `Manager` receives `customers.read`, `customers.create`, `customers.update`, `sites.read`, `sites.create`, and `sites.update`
-- Custom roles can opt in explicitly by assigning the matching `customers.*` or `sites.*` permissions
+- No predefined role receives global Customer or Site access through an implicit `Admin` shortcut.
+- `Manager` receives `customers.read`, `customers.create`, `customers.update`, `sites.read`, `sites.create`, and `sites.update`.
+- `HR`, `Employee`, `Employee Read Only`, `Guard`, `Client`, and `Works Council` do not receive Customer or Site module access by default.
+- Custom roles can opt in explicitly by assigning the matching `customers.*` or `sites.*` permissions.
 
 ### Scoped Access
 
@@ -147,7 +148,7 @@ Customers and Sites intentionally use a two-layer model:
 ### Detail And Mutation Rules
 
 - Opening `/v1/customers` or `/v1/sites` does not imply access to every individual record; detail endpoints still require the concrete object to be in scope
-- `customers.create` and `sites.create` are explicit admin or manager-style permissions
+- `customers.create` and `sites.create` are explicit manager or custom-role permissions
 - `customers.update` and `sites.update` may also be granted through direct assignment to the concrete customer or site
 - `customers.delete` and `sites.delete` remain explicit destructive permissions and are never granted through scoped visibility alone
 
@@ -167,34 +168,61 @@ Customers and Sites intentionally use a two-layer model:
 
 ## Permission Matrix
 
-Permissions assigned to predefined roles:
+Representative permissions assigned to predefined roles. There is no predefined `Admin` role; broad access is assembled from explicit permissions plus explicit `manage` scopes.
 
-### Admin Role
+### Employee Role
 
-**Philosophy:** Full system access
+**Philosophy:** Self-service employee access
 
 ```text
-Permissions: * (all permissions)
+- employee.read
+- employee.update
+- employee_qualification.read
+- employee_document.read
+- qualification.read
+- shifts.read
+- shifts.update
+- work_instructions.read
+- work_instructions.acknowledge
+```
 
-Or explicitly:
-- customers.*
-- sites.*
-- assignments.*
-- cost-centers.*
-- employees.*
-- shifts.*
-- work_instructions.*
-- roles.*
-- permissions.*
-- works_council.*
-- reports.*
+---
+
+### Employee Read Only Role
+
+**Philosophy:** Read-only employee self-service
+
+```text
+- employee.read
+- employee_qualification.read
+- employee_document.read
+- qualification.read
+- shifts.read
+- work_instructions.read
+```
+
+---
+
+### HR Role
+
+**Philosophy:** HR lifecycle, compliance, and onboarding
+
+```text
+- employees.read / create / update / delete
+- employees.read_sensitive / read_salary / export
+- employee.read / write / activate / terminate
+- employee_qualification.read / write
+- employee_document.read / write
+- qualification.read / write
+- onboarding.read / write / approve / confirm
+- reports.view / generate
 ```
 
 ---
 
 ### Manager Role
 
-**Philosophy:** Branch-level management
+**Philosophy:** Operational management within explicit organizational scopes
 
 ```text
 Customers:
@@ -220,12 +248,13 @@ Employees:
 - employees.read
 - employees.create
 - employees.update
-- employees.delete (optional - some orgs restrict)
+- employees.read_salary
 
 Shifts:
 - shifts.read
 - shifts.create
 - shifts.update
+- shifts.delete
 - shifts.publish
 
 Work Instructions:
@@ -234,13 +263,15 @@ Work Instructions:
 - work_instructions.update
 - work_instructions.publish
 
+Onboarding / Audit:
+- onboarding.read
+- onboarding.write
+- activity_log.read
+- activity_log.read_system
+
 Reports:
 - reports.view
 - reports.generate
-
-Roles:
-- role.read (view team roles)
-- role.assign (assign roles to team)
 ```
 
 ---
@@ -568,7 +599,7 @@ $shiftPermissions = [
  *
  * Allows viewing salary data for employees.
  *
- * Scope: Branch-scoped for Manager, Global for Admin
+ * Scope: Available only when the user has `employees.read_salary` plus explicit scope coverage for the target employees
  * Policy: EmployeePolicy::viewSalary()
  * Use Case: Payroll review, compensation analysis
  * GDPR Note: Subject to data protection logs

--- a/docs/guides/role-management.md
+++ b/docs/guides/role-management.md
@@ -42,36 +42,88 @@ See [RBAC Architecture](../rbac-architecture.md) for full system design.
 
 ## Predefined Roles
 
-SecPal includes five predefined roles that cover common use cases:
+SecPal seeds seven predefined roles that cover common use cases. There is no predefined `Admin` role. Broad access is modeled by combining explicit permissions with explicit organizational scopes.
 
-### Admin
+### Employee
 
-**Description:** Full system access
+**Description:** Standard employee self-service access
 
 **Typical Permissions:**
 
-- `*` (all permissions)
-- Or: All individual permissions listed explicitly
+- `employee.read`, `employee.update`
+- `employee_qualification.read`, `employee_document.read`
+- `qualification.read`
+- `shifts.read`, `shifts.update`
+- `work_instructions.read`, `work_instructions.acknowledge`
 
 **Use Cases:**
 
-- System administrators
-- Technical support staff
-- Organization owners
+- Internal employees managing their own profile data
+- Staff reviewing their own qualifications and documents
+- Guards acknowledging work instructions
 
-**Scope:** Global (all branches, all locations)
+**Scope:** Own data and policy-limited operational records
+
+---
+
+### Employee Read Only
+
+**Description:** Read-only employee self-service access
+
+**Typical Permissions:**
+
+- `employee.read`
+- `employee_qualification.read`, `employee_document.read`
+- `qualification.read`
+- `shifts.read`
+- `work_instructions.read`
+
+**Use Cases:**
+
+- Employees who may inspect but not edit their records
+- Temporary viewer-style self-service access
+
+**Scope:** Own data only, without write operations
+
+---
+
+### HR
+
+**Description:** HR and onboarding operations
+
+**Typical Permissions:**
+
+- `employees.read`, `employees.create`, `employees.update`, `employees.delete`
+- `employees.read_sensitive`, `employees.read_salary`, `employees.export`
+- `employee.read`, `employee.write`, `employee.activate`, `employee.terminate`
+- `employee_qualification.write`, `employee_document.write`
+- `onboarding.read`, `onboarding.write`, `onboarding.approve`, `onboarding.confirm`
+- `reports.view`, `reports.generate`
+
+**Use Cases:**
+
+- HR teams
+- Recruiting and onboarding operators
+- Compliance staff handling employee master data
+
+**Scope:** Organizational-scope limited HR workflows
 
 ---
 
 ### Manager
 
-**Description:** Branch-level management
+**Description:** Operational management across assigned organizational scopes
 
 **Typical Permissions:**
 
-- `employees.read`, `employees.create`, `employees.update`
-- `shifts.read`, `shifts.create`, `shifts.update`, `shifts.publish`
-- `work_instructions.read`, `work_instructions.create`
+- `customers.read`, `customers.create`, `customers.update`
+- `sites.read`, `sites.create`, `sites.update`
+- `assignments.create`, `assignments.update`
+- `cost-centers.read`, `cost-centers.create`, `cost-centers.update`
+- `employees.read`, `employees.create`, `employees.update`, `employees.read_salary`
+- `shifts.read`, `shifts.create`, `shifts.update`, `shifts.delete`, `shifts.publish`
+- `work_instructions.read`, `work_instructions.create`, `work_instructions.update`, `work_instructions.publish`
+- `activity_log.read`, `activity_log.read_system`, `onboarding.read`, `onboarding.write`
 
 **Use Cases:**
 
@@ -79,7 +131,7 @@ SecPal includes five predefined roles that cover common use cases:
 - Team leads
 - Operations managers
 
-**Scope:** Branch-scoped (can only manage employees/shifts in their branch)
+**Scope:** Limited by explicit organizational scopes, not by any implicit global shortcut role
 
 ---
 
@@ -90,7 +142,7 @@ SecPal includes five predefined roles that cover common use cases:
 **Typical Permissions:**
 
 - `employees.read` (own data only)
-- `shifts.read`
+- `shifts.read`, `shifts.update` (policy-limited)
 - `work_instructions.read`, `work_instructions.acknowledge`
 
 **Use Cases:**
@@ -99,18 +151,19 @@ SecPal includes five predefined roles that cover common use cases:
 - On-site personnel
 - Field workers
 
-**Scope:** Own data only (can view own employee record, assigned shifts)
+**Scope:** Own data plus assigned operational records
 
 ---
 
 ### Client
 
-**Description:** Customer access (read-only)
+**Description:** External stakeholder access
 
 **Typical Permissions:**
 
-- `shifts.read` (location-specific)
+- `shifts.read`
 - `work_instructions.read`
+- `reports.view`
 
 **Use Cases:**
 
@@ -118,19 +171,20 @@ SecPal includes five predefined roles that cover common use cases:
 - Property managers
 - External stakeholders
 
-**Scope:** Location-scoped (can only view data for their location)
+**Scope:** Customer, site, and organizational assignment scoped
 
 ---
 
 ### Works Council
 
-**Description:** Employee representation (special permissions)
+**Description:** Employee representation with approval rights
 
 **Typical Permissions:**
 
-- `employees.read` (limited)
-- `shifts.approve_as_br`
-- `works_council.*`
+- `employees.read`, `employees.read_all_branches`
+- `shifts.read`, `shifts.approve_as_br`
+- `works_council.access_employee_files`, `works_council.approve_shift_plans`
+- `reports.view`
 
 **Use Cases:**
 
@@ -138,7 +192,7 @@ SecPal includes five predefined roles that cover common use cases:
 - Employee representatives
 - Union representatives
 
-**Scope:** Organization-wide (for approval workflows)
+**Scope:** Organization-wide approval workflows within assigned scope boundaries
 
 ---
 
@@ -614,7 +668,7 @@ curl -X DELETE https://api.secpal.dev/v1/roles/6 \
 
 ### Predefined Roles Recovery
 
-**If you delete a predefined role** (Admin, Manager, Guard, Client, Works Council):
+**If you delete a predefined role** (Employee, Employee Read Only, HR, Manager, Guard, Client, or Works Council):
 
 1. ✅ Deletion succeeds (if not assigned to users)
 2. ✅ Next time `RolesAndPermissionsSeeder` runs, role is recreated
@@ -689,7 +743,7 @@ Need to grant access?
 
 **❌ DON'T:**
 
-- Assign Admin role liberally (use Manager or custom roles)
+- Simulate full access with ad-hoc role sprawl; use explicit permissions plus `manage` scopes or a documented custom role instead
 - Forget to revoke roles when users leave
 - Use permanent assignments for temporary needs
 - Skip the `reason` field on temporal assignments (needed for audits)
@@ -826,14 +880,14 @@ curl -X GET https://api.secpal.dev/v1/roles/{id} \
 
 **Cause:** User lacks required permission
 
-**Solution:** Only Admin role can manage roles. Check:
+**Solution:** Role-management endpoints require explicit management permissions. Check:
 
 ```bash
 curl -X GET https://api.secpal.dev/v1/me \
   -H "Authorization: Bearer YOUR_TOKEN"
 ```
 
-Ensure the response includes the Admin role or the `roles.create`, `roles.update`, and `roles.delete` permissions.
+Ensure the response includes the relevant `roles.create`, `roles.update`, and `roles.delete` permissions.
 
 ---
 

--- a/docs/guides/sanctum-spa-auth.md
+++ b/docs/guides/sanctum-spa-auth.md
@@ -263,8 +263,8 @@ Content-Type: application/json
     "id": "uuid",
     "email": "user@example.com",
     "name": "John Doe",
-    "roles": ["Admin"],
-    "permissions": ["*"],
+    "roles": ["Manager"],
+    "permissions": ["employees.read", "shifts.read", "work_instructions.read"],
     "hasOrganizationalScopes": true
   }
 }
@@ -285,8 +285,8 @@ Content-Type: application/json
   "id": "uuid",
   "email": "user@example.com",
   "name": "John Doe",
-  "roles": ["Admin"],
-  "permissions": ["*"],
+  "roles": ["Manager"],
+  "permissions": ["employees.read", "shifts.read", "work_instructions.read"],
   "hasOrganizationalScopes": true
 }
 ```

--- a/docs/guides/tenant-provisioning.md
+++ b/docs/guides/tenant-provisioning.md
@@ -124,10 +124,8 @@ class ProvisionTenant extends Command
             $this->info('3️⃣  Creating default organizational structure...');
             $orgUnit = OrganizationalUnit::create([
                 'name' => 'Headquarters',
-                'short_name' => 'HQ',
                 'type' => 'branch',
                 'tenant_id' => $tenant->id,
-                'is_active' => true,
             ]);
             $this->line("   ✅ Organizational unit created (ID: {$orgUnit->id})");
 
@@ -174,7 +172,7 @@ class ProvisionTenant extends Command
                     ['Customer Name', $customerName],
                     ['Bootstrap Email', $bootstrapEmail],
                     ['Bootstrap Password', $password],
-                    ['Organizational Unit', "HQ ({$orgUnit->id})"],
+                    ['Organizational Unit', "{$orgUnit->name} ({$orgUnit->id})"],
                 ]
             );
 
@@ -268,10 +266,8 @@ echo "Bootstrap user created: {$bootstrapUser->email}\n";
 // 3. Create default organizational unit
 $orgUnit = OrganizationalUnit::create([
     'name' => 'Headquarters',
-    'short_name' => 'HQ',
     'type' => 'branch',
     'tenant_id' => $tenant->id,
-    'is_active' => true,
 ]);
 echo "Organizational unit created: {$orgUnit->name}\n";
 
@@ -321,7 +317,7 @@ Authorization: Bearer {TENANT_PROVISIONING_TOKEN}
     "bootstrap_password": "SecurePassword123!",
   "organizational_unit": {
     "name": "Headquarters",
-    "short_name": "HQ"
+        "type": "branch"
   }
 }
 ```
@@ -353,27 +349,26 @@ php artisan tinker
 use App\Models\OrganizationalUnit;
 
 $tenantId = 1; // Replace with actual tenant ID
-$hq = OrganizationalUnit::where('tenant_id', $tenantId)->where('name', 'Headquarters')->first();
+$hq = OrganizationalUnit::where('tenant_id', $tenantId)
+    ->where('name', 'Headquarters')
+    ->firstOrFail();
 
 // Add branch
 $branch = OrganizationalUnit::create([
     'name' => 'Frankfurt Branch',
-    'short_name' => 'FFM',
     'type' => 'branch',
-    'parent_id' => $hq->id,
     'tenant_id' => $tenantId,
-    'is_active' => true,
 ]);
+$branch->setParent($hq);
 
-// Add team
+// Add team via the closure-table hierarchy
 $team = OrganizationalUnit::create([
     'name' => 'Night Shift Team A',
-    'short_name' => 'NSA',
-    'type' => 'team',
-    'parent_id' => $branch->id,
+    'type' => 'custom',
+    'custom_type_name' => 'Team',
     'tenant_id' => $tenantId,
-    'is_active' => true,
 ]);
+$team->setParent($branch);
 
 echo "Organizational structure created:\n";
 echo "- {$hq->name}\n";

--- a/docs/guides/tenant-provisioning.md
+++ b/docs/guides/tenant-provisioning.md
@@ -12,9 +12,9 @@ Step-by-step guide for provisioning new tenants (customers) in SecPal's multi-te
 **Tenant provisioning** is the process of onboarding a new customer to SecPal. Each tenant gets:
 
 1. ✅ **Unique encryption keys** (DEK + IDX for envelope encryption)
-2. ✅ **Admin user account** with full permissions
+2. ✅ **Bootstrap user account** with explicit permissions and scoped access
 3. ✅ **Default organizational structure** (HQ organizational unit)
-4. ✅ **Predefined roles** (Admin, Manager, Guard, Client, Works Council)
+4. ✅ **Predefined roles** (Employee, Employee Read Only, HR, Manager, Guard, Client, Works Council)
 5. ✅ **Isolated data space** (cannot access other tenants)
 
 ---
@@ -47,7 +47,7 @@ This section is relevant when onboarding **additional customer organizations** i
 - ✅ SecPal deployed in multi-tenant mode ([Deployment Guide](/docs/guides/multi-tenant-deployment.md))
 - ✅ Database migrations completed (`php artisan migrate`)
 - ✅ KEK (Key Encryption Key) generated and secured
-- ✅ SSH access to production server (or admin API access)
+- ✅ SSH access to production server (or provisioning API access)
 
 ---
 
@@ -73,8 +73,10 @@ Edit `app/Console/Commands/ProvisionTenant.php`:
 namespace App\Console\Commands;
 
 use App\Models\OrganizationalUnit;
+use App\Models\Permission;
 use App\Models\TenantKey;
 use App\Models\User;
+use App\Models\UserInternalOrganizationalScope;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
@@ -85,16 +87,16 @@ class ProvisionTenant extends Command
 {
     protected $signature = 'tenant:provision
                             {customer-name : Name of the customer/organization}
-                            {admin-email : Email address for the admin user}
-                            {--password= : Admin password (auto-generated if not provided)}
+                            {bootstrap-email : Email address for the initial bootstrap user}
+                            {--password= : Initial password (auto-generated if not provided)}
                             {--skip-email : Do not send welcome email}';
 
-    protected $description = 'Provision a new tenant with encryption keys, admin user, and defaults';
+    protected $description = 'Provision a new tenant with encryption keys, a bootstrap user, and default scoped access';
 
     public function handle(): int
     {
         $customerName = $this->argument('customer-name');
-        $adminEmail = $this->argument('admin-email');
+        $bootstrapEmail = $this->argument('bootstrap-email');
         $password = $this->option('password') ?? Str::random(16);
 
         $this->info("🚀 Provisioning tenant: {$customerName}");
@@ -108,24 +110,18 @@ class ProvisionTenant extends Command
             $tenant = TenantKey::create($keys);
             $this->line("   ✅ Tenant created (ID: {$tenant->id})");
 
-            // Step 2: Create admin user
-            $this->info('2️⃣  Creating admin user...');
-            $admin = User::create([
-                'email' => $adminEmail,
+            // Step 2: Create bootstrap user
+            $this->info('2️⃣  Creating bootstrap user...');
+            $bootstrapUser = User::create([
+                'email' => $bootstrapEmail,
                 'password' => Hash::make($password),
-                'name' => 'Admin',
+                'name' => 'Tenant Bootstrap User',
                 'tenant_id' => $tenant->id,
             ]);
-            $this->line("   ✅ Admin user created (ID: {$admin->id})");
+            $this->line("   ✅ Bootstrap user created (ID: {$bootstrapUser->id})");
 
-            // Step 3: Assign admin role (tenant-scoped)
-            $this->info('3️⃣  Assigning admin role...');
-            app(PermissionRegistrar::class)->setPermissionsTeamId($tenant->id);
-            $admin->assignRole('Admin');
-            $this->line('   ✅ Admin role assigned');
-
-            // Step 4: Create default organizational unit
-            $this->info('4️⃣  Creating default organizational structure...');
+            // Step 3: Create default organizational unit
+            $this->info('3️⃣  Creating default organizational structure...');
             $orgUnit = OrganizationalUnit::create([
                 'name' => 'Headquarters',
                 'short_name' => 'HQ',
@@ -134,6 +130,35 @@ class ProvisionTenant extends Command
                 'is_active' => true,
             ]);
             $this->line("   ✅ Organizational unit created (ID: {$orgUnit->id})");
+
+            // Step 4: Grant explicit permissions and a root manage scope
+            $this->info('4️⃣  Granting bootstrap permissions and root scope...');
+            app(PermissionRegistrar::class)->setPermissionsTeamId($tenant->id);
+
+            /** @var list<string> $permissionNames */
+            $permissionNames = Permission::query()
+                ->where('guard_name', 'sanctum')
+                ->pluck('name')
+                ->all();
+
+            $bootstrapUser->syncPermissions($permissionNames);
+
+            UserInternalOrganizationalScope::updateOrCreate(
+                [
+                    'user_id' => $bootstrapUser->id,
+                    'organizational_unit_id' => $orgUnit->id,
+                    'min_viewable_rank' => null,
+                    'max_viewable_rank' => null,
+                    'min_assignable_rank' => null,
+                    'max_assignable_rank' => null,
+                ],
+                [
+                    'access_level' => 'manage',
+                    'include_descendants' => true,
+                    'allow_self_access' => true,
+                ]
+            );
+            $this->line('   ✅ Bootstrap permissions and root manage scope granted');
 
             DB::commit();
 
@@ -147,8 +172,8 @@ class ProvisionTenant extends Command
                 [
                     ['Tenant ID', $tenant->id],
                     ['Customer Name', $customerName],
-                    ['Admin Email', $adminEmail],
-                    ['Admin Password', $password],
+                    ['Bootstrap Email', $bootstrapEmail],
+                    ['Bootstrap Password', $password],
                     ['Organizational Unit', "HQ ({$orgUnit->id})"],
                 ]
             );
@@ -157,15 +182,15 @@ class ProvisionTenant extends Command
             if (!$this->option('skip-email')) {
                 $this->info('📧 Sending welcome email...');
                 // TODO: Implement email sending
-                // Mail::to($adminEmail)->send(new WelcomeEmail($admin, $password));
+                // Mail::to($bootstrapEmail)->send(new WelcomeEmail($bootstrapUser, $password));
                 $this->warn('⚠️  Email sending not implemented yet. Send credentials manually.');
             }
 
             // Security reminder
             $this->newLine();
             $this->warn('⚠️  SECURITY REMINDER:');
-            $this->warn('   - Store admin password securely (e.g., password manager)');
-            $this->warn('   - Admin should change password after first login');
+            $this->warn('   - Store the bootstrap password securely (e.g., password manager)');
+            $this->warn('   - Bootstrap user should rotate the password after first login');
             $this->warn('   - Tenant encryption keys backed up automatically');
 
             return Command::SUCCESS;
@@ -183,18 +208,18 @@ class ProvisionTenant extends Command
 
 ```bash
 # Provision new tenant
-php artisan tenant:provision "Customer Corp" "admin@customercorp.com"
+php artisan tenant:provision "Customer Corp" "ops@customercorp.com"
 
 # Output:
 # 🚀 Provisioning tenant: Customer Corp
 # 1️⃣  Creating tenant encryption keys...
 #    ✅ Tenant created (ID: 1)
-# 2️⃣  Creating admin user...
-#    ✅ Admin user created (ID: 9d8e7f...)
-# 3️⃣  Assigning admin role...
-#    ✅ Admin role assigned
-# 4️⃣  Creating default organizational structure...
+# 2️⃣  Creating bootstrap user...
+#    ✅ Bootstrap user created (ID: 9d8e7f...)
+# 3️⃣  Creating default organizational structure...
 #    ✅ Organizational unit created (ID: 1)
+# 4️⃣  Granting bootstrap permissions and root scope...
+#    ✅ Bootstrap permissions and root manage scope granted
 # 🎉 Tenant provisioned successfully!
 #
 # ┌─────────────────────┬────────────────────────────────────┐
@@ -202,8 +227,8 @@ php artisan tenant:provision "Customer Corp" "admin@customercorp.com"
 # ├─────────────────────┼────────────────────────────────────┤
 # │ Tenant ID           │ 1                                  │
 # │ Customer Name       │ Customer Corp                      │
-# │ Admin Email         │ admin@customercorp.com             │
-# │ Admin Password      │ XyZ9aBc...                         │
+# │ Bootstrap Email     │ ops@customercorp.com               │
+# │ Bootstrap Password  │ XyZ9aBc...                         │
 # │ Organizational Unit │ HQ (1)                             │
 # └─────────────────────┴────────────────────────────────────┘
 ```
@@ -222,6 +247,8 @@ php artisan tinker
 use App\Models\TenantKey;
 use App\Models\User;
 use App\Models\OrganizationalUnit;
+use App\Models\Permission;
+use App\Models\UserInternalOrganizationalScope;
 use Illuminate\Support\Facades\Hash;
 use Spatie\Permission\PermissionRegistrar;
 
@@ -229,21 +256,16 @@ use Spatie\Permission\PermissionRegistrar;
 $tenant = TenantKey::create(TenantKey::generateEnvelopeKeys());
 echo "Tenant created: ID = {$tenant->id}\n";
 
-// 2. Create admin user
-$admin = User::create([
-    'email' => 'admin@tenant1.com',
+// 2. Create bootstrap user
+$bootstrapUser = User::create([
+    'email' => 'ops@tenant1.com',
     'password' => Hash::make('SecurePassword123!'),
-    'name' => 'Admin User',
+    'name' => 'Tenant Bootstrap User',
     'tenant_id' => $tenant->id,
 ]);
-echo "Admin created: {$admin->email}\n";
+echo "Bootstrap user created: {$bootstrapUser->email}\n";
 
-// 3. Assign admin role (IMPORTANT: Set team ID first!)
-app(PermissionRegistrar::class)->setPermissionsTeamId($tenant->id);
-$admin->assignRole('Admin');
-echo "Admin role assigned\n";
-
-// 4. Create default organizational unit
+// 3. Create default organizational unit
 $orgUnit = OrganizationalUnit::create([
     'name' => 'Headquarters',
     'short_name' => 'HQ',
@@ -253,9 +275,32 @@ $orgUnit = OrganizationalUnit::create([
 ]);
 echo "Organizational unit created: {$orgUnit->name}\n";
 
+// 4. Grant explicit permissions and a root manage scope
+app(PermissionRegistrar::class)->setPermissionsTeamId($tenant->id);
+$bootstrapUser->syncPermissions(
+    Permission::query()->where('guard_name', 'sanctum')->pluck('name')->all()
+);
+
+UserInternalOrganizationalScope::updateOrCreate(
+    [
+        'user_id' => $bootstrapUser->id,
+        'organizational_unit_id' => $orgUnit->id,
+        'min_viewable_rank' => null,
+        'max_viewable_rank' => null,
+        'min_assignable_rank' => null,
+        'max_assignable_rank' => null,
+    ],
+    [
+        'access_level' => 'manage',
+        'include_descendants' => true,
+        'allow_self_access' => true,
+    ]
+);
+echo "Bootstrap permissions and root scope granted\n";
+
 echo "\n✅ Tenant provisioned successfully!\n";
 echo "Tenant ID: {$tenant->id}\n";
-echo "Admin: {$admin->email}\n";
+echo "Bootstrap user: {$bootstrapUser->email}\n";
 ```
 
 ---
@@ -265,15 +310,15 @@ echo "Admin: {$admin->email}\n";
 For SaaS self-service registration (planned Phase 2):
 
 ```http
-POST /api/v1/admin/tenants
+POST /api/v1/provisioning/tenants
 Content-Type: application/json
-Authorization: Bearer {SUPER_ADMIN_TOKEN}
+Authorization: Bearer {TENANT_PROVISIONING_TOKEN}
 
 {
   "customer_name": "Customer Corp",
-  "admin_email": "admin@customercorp.com",
-  "admin_name": "John Admin",
-  "admin_password": "SecurePassword123!",
+    "bootstrap_email": "ops@customercorp.com",
+    "bootstrap_name": "Initial Operator",
+    "bootstrap_password": "SecurePassword123!",
   "organizational_unit": {
     "name": "Headquarters",
     "short_name": "HQ"
@@ -286,8 +331,8 @@ Authorization: Bearer {SUPER_ADMIN_TOKEN}
 ```json
 {
   "tenant_id": 1,
-  "admin_user_id": "9d8e7f6a-5b4c-3d2e-1f0e-9d8c7b6a5f4e",
-  "admin_email": "admin@customercorp.com",
+  "bootstrap_user_id": "9d8e7f6a-5b4c-3d2e-1f0e-9d8c7b6a5f4e",
+  "bootstrap_email": "ops@customercorp.com",
   "status": "active"
 }
 ```
@@ -354,7 +399,7 @@ app(PermissionRegistrar::class)->setPermissionsTeamId($tenantId);
 
 // Create manager
 $manager = User::create([
-    'email' => 'manager@customercorp.com',
+    'email' => 'manager@tenant1.com',
     'password' => Hash::make('password'),
     'name' => 'Branch Manager',
     'tenant_id' => $tenantId,
@@ -363,7 +408,7 @@ $manager->assignRole('Manager');
 
 // Create guard
 $guard = User::create([
-    'email' => 'guard@customercorp.com',
+    'email' => 'guard@tenant1.com',
     'password' => Hash::make('password'),
     'name' => 'Security Guard',
     'tenant_id' => $tenantId,
@@ -429,14 +474,14 @@ echo "- Site: {$site->name}\n";
 
 After provisioning, verify tenant isolation:
 
-### 1. Test Admin Login
+### 1. Test Bootstrap User Login
 
 ```bash
-# Login as admin
+# Login as the bootstrap user
 curl -X POST https://api.secpal.dev/v1/auth/token \
   -H "Content-Type: application/json" \
   -d '{
-    "email": "admin@customercorp.com",
+        "email": "ops@customercorp.com",
     "password": "SecurePassword123!"
   }'
 
@@ -445,7 +490,7 @@ curl -X POST https://api.secpal.dev/v1/auth/token \
 #   "token": "1|XYZ...",
 #   "user": {
 #     "id": "9d8e7f...",
-#     "email": "admin@customercorp.com",
+#     "email": "ops@customercorp.com",
 #     "tenant_id": 1
 #   }
 # }
@@ -454,7 +499,7 @@ curl -X POST https://api.secpal.dev/v1/auth/token \
 ### 2. Verify Tenant Isolation
 
 ```bash
-# Get admin token
+# Get bootstrap user token
 TOKEN="1|XYZ..."
 
 # List organizational units (should only see tenant's data)
@@ -469,21 +514,20 @@ curl -X GET https://api.secpal.dev/v1/organizational-units \
 # }
 ```
 
-### 3. Verify Admin Permissions
+### 3. Verify Bootstrap Permissions
 
 ```bash
-# Admin should have all permissions
+# Bootstrap user should expose explicit permissions and organizational scopes
 curl -X GET https://api.secpal.dev/v1/me \
   -H "Authorization: Bearer $TOKEN"
 
-# Response includes roles
+# Response includes direct permissions and scope metadata
 # {
 #   "id": "9d8e7f...",
-#   "email": "admin@customercorp.com",
-#   "roles": [
-#     {"name": "Admin"}
-#   ],
-#   "permissions": ["*"]
+#   "email": "ops@customercorp.com",
+#   "roles": [],
+#   "permissions": ["employees.read", "roles.create", "permissions.assign_direct", "..."],
+#   "hasOrganizationalScopes": true
 # }
 ```
 
@@ -493,48 +537,51 @@ curl -X GET https://api.secpal.dev/v1/me \
 
 ### Issue: "User has no assigned tenant"
 
-**Symptom:** Admin user cannot login or gets 500 error
+**Symptom:** Bootstrap user cannot login or gets 500 error
 
 **Cause:** User created without `tenant_id`
 
 **Fix:**
 
 ```php
-$user = User::where('email', 'admin@customercorp.com')->first();
+$user = User::where('email', 'ops@customercorp.com')->first();
 $user->update(['tenant_id' => 1]); // Assign to tenant
 ```
 
-### Issue: "Role 'Admin' not found"
+### Issue: "Bootstrap user cannot manage tenant resources"
 
-**Symptom:** Cannot assign admin role
+**Symptom:** Newly provisioned user cannot create roles, assign permissions, or review onboarding
 
-**Cause:** Roles not seeded or team ID not set
+**Cause:** Permissions were not granted directly or the tenant team ID was not set before assignment
 
 **Fix:**
 
 ```bash
 # 1. Seed roles
-php artisan db:seed --class=RolePermissionSeeder
+php artisan db:seed --class=RolesAndPermissionsSeeder
 
-# 2. Set team ID before assigning role
+# 2. Set team ID before granting permissions
 php artisan tinker
 ```
 
 ```php
+use App\Models\Permission;
 use Spatie\Permission\PermissionRegistrar;
 
 $tenantId = 1;
 app(PermissionRegistrar::class)->setPermissionsTeamId($tenantId);
 
-$admin = User::where('email', 'admin@customercorp.com')->first();
-$admin->assignRole('Admin');
+$bootstrapUser = User::where('email', 'ops@customercorp.com')->first();
+$bootstrapUser->syncPermissions(
+    Permission::query()->where('guard_name', 'sanctum')->pluck('name')->all()
+);
 ```
 
 ### Issue: "Cannot see organizational units"
 
-**Symptom:** Admin cannot list organizational units
+**Symptom:** Bootstrap user cannot list organizational units
 
-**Cause:** InjectTenantId middleware not applied or Policy blocking access
+**Cause:** Root `manage` scope is missing or `InjectTenantId` middleware is not active
 
 **Fix:**
 
@@ -560,7 +607,7 @@ public function provisionTenant(Request $request)
 {
     $validated = $request->validate([
         'customer_name' => 'required|string',
-        'admin_email' => 'required|email',
+        'bootstrap_email' => 'required|email',
         'webhook_secret' => 'required|string',
     ]);
 
@@ -572,7 +619,7 @@ public function provisionTenant(Request $request)
     // Provision tenant
     $result = (new TenantProvisioningService())->provisionTenant(
         $validated['customer_name'],
-        $validated['admin_email']
+        $validated['bootstrap_email']
     );
 
     return response()->json($result, 201);
@@ -605,9 +652,9 @@ class TenantKeyObserver
 
 ## Security Considerations
 
-### 1. Admin Password Policy
+### 1. Bootstrap Credential Policy
 
-**Requirement:** Admin passwords must be:
+**Requirement:** Initial bootstrap credentials must be:
 
 - ✅ Minimum 12 characters
 - ✅ Include uppercase, lowercase, numbers, symbols
@@ -668,14 +715,14 @@ Log all tenant provisioning events:
 // In ProvisionTenant command:
 Log::info('Tenant provisioning started', [
     'customer_name' => $customerName,
-    'admin_email' => $adminEmail,
+    'bootstrap_email' => $bootstrapEmail,
     'initiated_by' => Auth::user()->email ?? 'system',
 ]);
 
 // After success:
 Log::info('Tenant provisioning completed', [
     'tenant_id' => $tenant->id,
-    'admin_user_id' => $admin->id,
+    'bootstrap_user_id' => $bootstrapUser->id,
 ]);
 ```
 
@@ -686,7 +733,7 @@ Log::info('Tenant provisioning completed', [
 Before provisioning a new tenant:
 
 - [ ] Customer name confirmed (legal entity name)
-- [ ] Admin email verified (will receive credentials)
+- [ ] Bootstrap user email verified (will receive initial credentials)
 - [ ] Organizational structure requirements gathered
 - [ ] Initial user list prepared (roles defined)
 - [ ] Data migration plan (if migrating from another system)
@@ -695,8 +742,8 @@ Before provisioning a new tenant:
 
 After provisioning:
 
-- [ ] Admin credentials sent securely (encrypted email/password manager)
-- [ ] Admin login tested successfully
+- [ ] Bootstrap credentials sent securely (encrypted email/password manager)
+- [ ] Bootstrap login tested successfully
 - [ ] Tenant isolation verified (cannot see other tenants)
 - [ ] Organizational structure created
 - [ ] Initial users created and roles assigned

--- a/docs/rbac-architecture.md
+++ b/docs/rbac-architecture.md
@@ -210,15 +210,15 @@ Roles are **named collections of permissions** that define what a user can do wi
 
 SecPal seeds seven predefined roles that cover common use cases. There is no predefined `Admin` role; broad access is assembled from explicit permissions plus explicit organizational scopes.
 
-| Role                   | Description                   | Typical Permissions                                                           | Scope                           |
-| ---------------------- | ----------------------------- | ----------------------------------------------------------------------------- | ------------------------------- |
-| **Employee**           | Self-service employee access  | `employee.read`, `employee.update`, `shifts.read`, `work_instructions.read`   | Own data only                   |
-| **Employee Read Only** | Read-only self-service access | `employee.read`, `shifts.read`, `work_instructions.read`                      | Own data only                   |
-| **HR**                 | HR lifecycle operations       | `employees.*`, `employee.*`, `qualification.*`, `onboarding.*`                | Explicit organizational scopes  |
-| **Manager**            | Operational management        | `customers.*`, `sites.*`, `employees.read`, `shifts.*`, `work_instructions.*` | Explicit organizational scopes  |
-| **Guard**              | Security personnel            | `employee.read`, `shifts.read`, `shifts.update`, `work_instructions.read`     | Own data and assigned records   |
-| **Client**             | External stakeholder access   | `shifts.read`, `work_instructions.read`, `reports.view`                       | Customer/site scoped            |
-| **Works Council**      | Employee representation       | `employees.read`, `shifts.approve_as_br`, `works_council.*`                   | Approval workflows within scope |
+| Role                   | Description                   | Typical Permissions                                                                                            | Scope                           |
+| ---------------------- | ----------------------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| **Employee**           | Self-service employee access  | `employee.read`, `employee.update`, `shifts.read`, `work_instructions.read`                                    | Own data only                   |
+| **Employee Read Only** | Read-only self-service access | `employee.read`, `shifts.read`, `work_instructions.read`                                                       | Own data only                   |
+| **HR**                 | HR lifecycle operations       | `employees.read`, `employees.create`, `employees.read_sensitive`, `onboarding.approve`                         | Explicit organizational scopes  |
+| **Manager**            | Operational management        | `customers.read`, `customers.update`, `sites.read`, `shifts.read`, `work_instructions.publish`                 | Explicit organizational scopes  |
+| **Guard**              | Security personnel            | `employee.read`, `shifts.read`, `shifts.update`, `work_instructions.read`                                      | Own data and assigned records   |
+| **Client**             | External stakeholder access   | `shifts.read`, `work_instructions.read`, `reports.view`                                                        | Customer/site scoped            |
+| **Works Council**      | Employee representation       | `employees.read`, `employees.read_all_branches`, `shifts.approve_as_br`, `works_council.access_employee_files` | Approval workflows within scope |
 
 #### All Roles Are Equal
 
@@ -396,9 +396,9 @@ User Permissions = Role Permissions ∪ Direct Permissions
 
 Example:
 User "John" has role "Manager":
-  - Role "Manager" grants: [employees.read, employees.update, shifts.*]
+  - Role "Manager" grants: [employees.read, employees.update, shifts.read]
   - Direct permissions: [employees.export, reports.generate]
-  - Total permissions: [employees.read, employees.update, shifts.*,
+  - Total permissions: [employees.read, employees.update, shifts.read,
                         employees.export, reports.generate]
 
 If "Manager" role is removed:
@@ -760,14 +760,14 @@ $john->roles()->pluck('name');  // ["Manager"]
 
 // Manager role grants these permissions:
 $managerRole->permissions()->pluck('name');
-// ["employees.read", "employees.update", "shifts.*"]
+// ["employees.read", "employees.update", "shifts.read"]
 
 // John gets ADDITIONAL direct permission:
 $john->givePermissionTo('employees.export');
 
 // John's TOTAL permissions:
 $john->getAllPermissions()->pluck('name');
-// ["employees.read", "employees.update", "shifts.*", "employees.export"]
+// ["employees.read", "employees.update", "shifts.read", "employees.export"]
 
 // If Manager role is removed:
 $john->removeRole('Manager');
@@ -839,7 +839,7 @@ $user->assignRole('manager', [
 │  │         ▼               │  │         ▼          │  │
 │  │  employees.read         │  │  employees.export  │  │
 │  │  employees.update       │  │  reports.generate  │  │
-│  │  shifts.*               │  │                    │  │
+│  │  shifts.read            │  │                    │  │
 │  └─────────────────────────┘  └──────────────────────┘  │
 │               │                          │               │
 │               └──────────┬───────────────┘               │
@@ -854,7 +854,7 @@ $user->assignRole('manager', [
 │        │ Total Permissions:              │              │
 │        │ - employees.read                │              │
 │        │ - employees.update              │              │
-│        │ - shifts.*                      │              │
+│        │ - shifts.read                   │              │
 │        │ - employees.export              │              │
 │        │ - reports.generate              │              │
 │        └─────────────────────────────────┘              │
@@ -873,7 +873,7 @@ Direct Permissions: None
 Result:
 ✅ employees.read    (from Manager role)
 ✅ employees.update  (from Manager role)
-✅ shifts.*          (from Manager role)
+✅ shifts.read       (from Manager role)
 ```
 
 #### Example 2: User with Only Direct Permissions
@@ -898,7 +898,7 @@ Direct Permissions: employees.export, reports.generate
 Result:
 ✅ employees.read     (from Manager)
 ✅ employees.update   (from Manager)
-✅ shifts.*           (from Manager)
+✅ shifts.read        (from Manager)
 ✅ employees.export   (direct)
 ✅ reports.generate   (direct)
 ```
@@ -911,7 +911,7 @@ User: Mike
 Role: Manager
 Direct Permissions: employees.export
 
-Permissions: [employees.read, employees.update, shifts.*, employees.export]
+Permissions: [employees.read, employees.update, shifts.read, employees.export]
 
 After Role Removal:
 $mike->removeRole('Manager');
@@ -1239,7 +1239,7 @@ SecPal's RBAC API is split across four functional areas:
 | `DELETE` | `/v1/users/{id}/roles/{role}`        | Revoke role from user                  |
 | `PATCH`  | `/v1/users/{id}/roles/{role}/extend` | Extend role expiration date            |
 
-**Authorization:** Requires `employees.update`; cross-branch updates additionally require explicit cross-branch visibility
+**Authorization:** Requires the corresponding role-assignment permission (`role.assign`, `role.read`, `role.revoke`); extending an existing assignment currently reuses `role.assign`
 
 **Documentation:** See Issue #5 and ADR-004 for implementation details
 
@@ -1255,7 +1255,7 @@ SecPal's RBAC API is split across four functional areas:
 | `POST`   | `/v1/roles/{id}/permissions`              | Assign permissions to role        |
 | `DELETE` | `/v1/roles/{id}/permissions/{permission}` | Remove permission from role       |
 
-**Authorization:** Requires the corresponding role-management permission (`role.read`, `role.assign`, `role.revoke`, `roles.extend_expiration`, `roles.create`, `roles.update`, `roles.delete`)
+**Authorization:** Requires the corresponding role-management permission (`roles.read`, `roles.create`, `roles.update`, `roles.delete`)
 
 **Documentation:** See Issue #137 and Issue #140
 

--- a/docs/rbac-architecture.md
+++ b/docs/rbac-architecture.md
@@ -154,17 +154,17 @@ $tenant1 = TenantKey::find(1);
 $tenant2 = TenantKey::find(2);
 
 // Create users in different tenants
-$user1 = User::create(['email' => 'admin@tenant1.com', 'tenant_id' => 1]);
-$user2 = User::create(['email' => 'admin@tenant2.com', 'tenant_id' => 2]);
+$user1 = User::create(['email' => 'manager@tenant1.com', 'tenant_id' => 1]);
+$user2 = User::create(['email' => 'manager@tenant2.com', 'tenant_id' => 2]);
 
-// Assign same role "Admin" to both users (but in different tenants)
+// Assign same role "Manager" to both users (but in different tenants)
 app(PermissionRegistrar::class)->setPermissionsTeamId(1); // Tenant 1
-$user1->assignRole('Admin');
+$user1->assignRole('Manager');
 
 app(PermissionRegistrar::class)->setPermissionsTeamId(2); // Tenant 2
-$user2->assignRole('Admin');
+$user2->assignRole('Manager');
 
-// Result: User1 is Admin in Tenant1, User2 is Admin in Tenant2
+// Result: User1 is Manager in Tenant1, User2 is Manager in Tenant2
 // These are SEPARATE role assignments (different team_id in pivot table)
 ```
 
@@ -208,15 +208,17 @@ Roles are **named collections of permissions** that define what a user can do wi
 
 #### Predefined Roles
 
-SecPal includes five predefined roles that cover common use cases:
+SecPal seeds seven predefined roles that cover common use cases. There is no predefined `Admin` role; broad access is assembled from explicit permissions plus explicit organizational scopes.
 
-| Role              | Description             | Typical Permissions                                             | Scope             |
-| ----------------- | ----------------------- | --------------------------------------------------------------- | ----------------- |
-| **Admin**         | Full system access      | `*` (all permissions)                                           | Global            |
-| **Manager**       | Branch management       | `employees.*`, `shifts.*`, `work_instructions.*`                | Branch-scoped     |
-| **Guard**         | Security personnel      | `employees.read` (own), `shifts.read`, `work_instructions.read` | Own data only     |
-| **Client**        | Customer access         | `shifts.read`, `work_instructions.read`                         | Location-scoped   |
-| **Works Council** | Employee representation | `employees.read`, `shifts.approve_as_br`, `works_council.*`     | Organization-wide |
+| Role                   | Description                   | Typical Permissions                                                           | Scope                           |
+| ---------------------- | ----------------------------- | ----------------------------------------------------------------------------- | ------------------------------- |
+| **Employee**           | Self-service employee access  | `employee.read`, `employee.update`, `shifts.read`, `work_instructions.read`   | Own data only                   |
+| **Employee Read Only** | Read-only self-service access | `employee.read`, `shifts.read`, `work_instructions.read`                      | Own data only                   |
+| **HR**                 | HR lifecycle operations       | `employees.*`, `employee.*`, `qualification.*`, `onboarding.*`                | Explicit organizational scopes  |
+| **Manager**            | Operational management        | `customers.*`, `sites.*`, `employees.read`, `shifts.*`, `work_instructions.*` | Explicit organizational scopes  |
+| **Guard**              | Security personnel            | `employee.read`, `shifts.read`, `shifts.update`, `work_instructions.read`     | Own data and assigned records   |
+| **Client**             | External stakeholder access   | `shifts.read`, `work_instructions.read`, `reports.view`                       | Customer/site scoped            |
+| **Works Council**      | Employee representation       | `employees.read`, `shifts.approve_as_br`, `works_council.*`                   | Approval workflows within scope |
 
 #### All Roles Are Equal
 
@@ -301,7 +303,7 @@ Examples:
 **Special Actions:**
 
 - `read_salary` - View sensitive salary data
-- `read_all_branches` - Cross-branch access (Admin only)
+- `read_all_branches` - Cross-branch access when granted explicitly alongside suitable scopes
 - `publish` - Publish/activate resource
 - `approve_as_br` - Works council approval action
 - `assign_temporary` - Assign temporal roles
@@ -610,7 +612,7 @@ Developer needs production access for critical hotfix
 Solution:
 POST /v1/users/{developer_id}/roles
 {
-  "role": "admin",
+  "role": "incident_responder",
   "valid_from": "2025-11-11T14:00:00Z",
   "valid_until": "2025-11-11T16:00:00Z",  // 2 hours
   "auto_revoke": true,
@@ -618,7 +620,7 @@ POST /v1/users/{developer_id}/roles
 }
 
 Result:
-✅ Developer gets admin access immediately
+✅ Developer gets the temporary incident-response permission bundle immediately
 ✅ Access expires after 2 hours
 ✅ Audit trail proves least-privilege compliance
 ✅ No manual revocation needed
@@ -684,7 +686,7 @@ SecPal's RBAC system is built on three core design decisions. Each decision prio
 ```php
 use Illuminate\Validation\ValidationException;
 
-// Single rule applies to ALL roles (Admin, Manager, Guard, Custom, etc.)
+// Single rule applies to ALL roles (Employee, HR, Manager, Guard, custom, etc.)
 public function destroy(Role $role)
 {
     if ($role->users()->count() > 0) {
@@ -706,14 +708,21 @@ class RolesAndPermissionsSeeder extends Seeder
     public function run()
     {
         // firstOrCreate = creates if not exists, skips if exists
-        $admin = Role::firstOrCreate(
-            ['name' => 'Admin', 'guard_name' => 'sanctum'],
-            ['description' => 'Full system access']
+        $manager = Role::firstOrCreate(
+            ['name' => 'Manager', 'guard_name' => 'sanctum'],
+            ['description' => 'Operational management within assigned scopes']
         );
 
         // Sync permissions only if role has none
-        if ($admin->permissions()->count() === 0) {
-            $admin->syncPermissions(Permission::all());
+        if ($manager->permissions()->count() === 0) {
+            $manager->syncPermissions([
+                'customers.read',
+                'customers.create',
+                'sites.read',
+                'employees.read',
+                'shifts.read',
+                'shifts.publish',
+            ]);
         }
     }
 }
@@ -1099,7 +1108,7 @@ public function update(User $user, Employee $employee): bool
 
     // Check scope (branch-level access)
     if ($user->branch_id !== $employee->branch_id) {
-        // Admin can access all branches
+        // Users with the explicit cross-branch permission can access all branches
         return $user->hasPermissionTo('employees.read_all_branches');
     }
 
@@ -1230,7 +1239,7 @@ SecPal's RBAC API is split across four functional areas:
 | `DELETE` | `/v1/users/{id}/roles/{role}`        | Revoke role from user                  |
 | `PATCH`  | `/v1/users/{id}/roles/{role}/extend` | Extend role expiration date            |
 
-**Authorization:** Manager or Admin only
+**Authorization:** Requires `employees.update`; cross-branch updates additionally require explicit cross-branch visibility
 
 **Documentation:** See Issue #5 and ADR-004 for implementation details
 
@@ -1246,7 +1255,7 @@ SecPal's RBAC API is split across four functional areas:
 | `POST`   | `/v1/roles/{id}/permissions`              | Assign permissions to role        |
 | `DELETE` | `/v1/roles/{id}/permissions/{permission}` | Remove permission from role       |
 
-**Authorization:** Admin only
+**Authorization:** Requires the corresponding role-management permission (`role.read`, `role.assign`, `role.revoke`, `roles.extend_expiration`, `roles.create`, `roles.update`, `roles.delete`)
 
 **Documentation:** See Issue #137 and Issue #140
 
@@ -1260,7 +1269,7 @@ SecPal's RBAC API is split across four functional areas:
 | `PATCH`  | `/v1/permissions/{id}` | Update permission description              |
 | `DELETE` | `/v1/permissions/{id}` | Delete permission (if not assigned)        |
 
-**Authorization:** Admin only
+**Authorization:** Requires the corresponding permission-management permission (`permissions.read`, `permissions.create`, `permissions.update`, `permissions.delete`)
 
 **Documentation:** See Issue #138 and Issue #140
 
@@ -1273,7 +1282,7 @@ SecPal's RBAC API is split across four functional areas:
 | `DELETE` | `/v1/users/{id}/permissions/{permission}` | Revoke direct permission                        |
 | `GET`    | `/v1/users/{id}/permissions/direct`       | List only direct permissions                    |
 
-**Authorization:** Admin only (assign/revoke), User can view own
+**Authorization:** Users may view their own direct permissions; assignment and revocation require `permissions.assign_direct` / `permissions.revoke_direct`, and viewing another user's permissions requires `permissions.read`
 
 **Documentation:** See Issue #139 and Issue #140
 
@@ -1425,13 +1434,14 @@ test('manager cannot update employees in other branch', function () {
     expect($manager->can('update', $employee))->toBeFalse();
 });
 
-test('admin can update employees in all branches', function () {
-    $admin = User::factory()->create(['branch_id' => 1]);
-    $admin->assignRole('admin');
+test('user with explicit cross-branch permission can update employees in all branches', function () {
+    $operator = User::factory()->create(['branch_id' => 1]);
+    $operator->givePermissionTo('employees.update');
+    $operator->givePermissionTo('employees.read_all_branches');
 
     $employee = Employee::factory()->create(['branch_id' => 2]);
 
-    expect($admin->can('update', $employee))->toBeTrue();
+    expect($operator->can('update', $employee))->toBeTrue();
 });
 ```
 

--- a/tests/Feature/Policies/ActivityPolicyTest.php
+++ b/tests/Feature/Policies/ActivityPolicyTest.php
@@ -483,7 +483,7 @@ test('view allows activity when user views their OWN activity without employee r
         'max_viewable_rank' => 5,
     ]);
 
-    // User causes activity but has no employee record (e.g., admin login)
+    // User causes activity but has no employee record (e.g., a privileged service login)
     // This should be ALLOWED - users can always view their own activities
     $activity = Activity::factory()->create([
         'tenant_id' => $this->tenant->id,
@@ -509,7 +509,7 @@ test('view allows activity when OTHER user without employee record caused it (sy
         'max_viewable_rank' => 5,
     ]);
 
-    // Causer without employee record (orphaned user, admin, or system user)
+    // Causer without employee record (orphaned user, privileged service user, or system user)
     $causerUser = User::factory()->create(['tenant_id' => $this->tenant->id]);
 
     // Activity caused by user without employee record

--- a/tests/Feature/RoleApiTest.php
+++ b/tests/Feature/RoleApiTest.php
@@ -601,7 +601,7 @@ describe('Edge Cases - N+1 Query Prevention', function () {
         $registrar->setPermissionsTeamId($tenant->id);
 
         $roles = [
-            createRoleApiRole('admin'),
+            createRoleApiRole('regional_manager'),
             createRoleApiRole('editor'),
             createRoleApiRole('viewer'),
         ];

--- a/tests/Unit/ActivityLog/ActivityLogServiceTest.php
+++ b/tests/Unit/ActivityLog/ActivityLogServiceTest.php
@@ -134,7 +134,7 @@ test('logRoleAssignment creates rbac_changes log', function (): void {
     $activity = $this->service->logRoleAssignment(
         $this->user,
         $targetUser,
-        ['admin', 'manager'],
+        ['Manager', 'HR'],
         'Promotion'
     );
 
@@ -144,7 +144,7 @@ test('logRoleAssignment creates rbac_changes log', function (): void {
         ->and($activity->causer_id)->toBe((string) $this->user->id)
         ->and($activity->subject_id)->toBe((string) $targetUser->id)
         ->and($activity->properties['event'])->toBe('role_assigned')
-        ->and($activity->properties['roles'])->toBe(['admin', 'manager'])
+        ->and($activity->properties['roles'])->toBe(['Manager', 'HR'])
         ->and($activity->properties['reason'])->toBe('Promotion')
         ->and(Activity::getRetentionYearsForLogType($activity->log_name))->toBeIn([3, 8]);
 });
@@ -155,7 +155,7 @@ test('logRoleRevocation creates rbac_changes log', function (): void {
     $activity = $this->service->logRoleRevocation(
         $this->user,
         $targetUser,
-        ['admin'],
+        ['HR'],
         'Contract termination'
     );
 
@@ -163,7 +163,7 @@ test('logRoleRevocation creates rbac_changes log', function (): void {
         ->and($activity->log_name)->toBe('rbac_changes')
         ->and($activity->description)->toBe('Revoked roles from user')
         ->and($activity->properties['event'])->toBe('role_revoked')
-        ->and($activity->properties['roles'])->toBe(['admin'])
+        ->and($activity->properties['roles'])->toBe(['HR'])
         ->and($activity->properties['reason'])->toBe('Contract termination');
 });
 


### PR DESCRIPTION
## Summary

- remove the remaining Admin-role and admin-scope documentation drift from API auth, RBAC, provisioning, deployment, and architecture guides
- align examples and guidance with the current explicit-permission plus explicit-manage-scope model
- rename lingering admin-flavored audit and role test fixtures/comments to current privileged-access terminology

## Validation

- vendor/bin/pint --dirty
- php artisan test tests/Unit/ActivityLog/ActivityLogServiceTest.php tests/Feature/Policies/ActivityPolicyTest.php tests/Feature/RoleApiTest.php tests/Feature/Models/UserInternalOrganizationalScopeTest.php tests/Feature/Integration/RbacIntegrationTest.php

## References

- Refs SecPal/.github#404
