### PR TITLE
fix: remove admin-prefixed review routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- renamed the onboarding review and Android provisioning API surfaces from `/v1/admin/...` to neutral `/v1/onboarding-review/...` and `/v1/android-enrollment-sessions...` paths, and corrected HR lifecycle emails to link to the shipped frontend employee detail route under `FRONTEND_URL` instead of the dead `/admin/employees/...` SPA path
 - removed the remaining Admin-role and `admin`-scope documentation drift from the API guides, auth examples, ADR-linked RBAC references, and supporting test fixtures so the documented bootstrap, authorization, and audit examples now consistently use explicit permissions plus explicit `manage` scopes instead of the deleted legacy model
 - centralized organizational-scope access resolution in `User::hasAccessToUnit()` so persisted checks and in-memory self-lockout simulations now share the same direct-scope-first descendant semantics instead of duplicating that logic in `OrganizationalScopeController` (refs `api#982`)
 - removed the predefined `Admin` role and the `admin` organizational scope access level from the API runtime, seeded fixtures, and RBAC/auth test bootstraps; privileged access is now modeled through explicit permissions plus `manage` organizational scopes, and existing `admin` scope rows are normalized to `manage` during migration

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Comprehensive RBAC system with temporal role assignments and direct permission m
 **Features:**
 
 - **7 Predefined Roles**: Employee, Employee Read Only, HR, Manager, Guard, Client, Works Council
-- **52 Permissions** across 7 resources (employees, shifts, work_instructions, roles, permissions, works_council, reports)
+- **Comprehensive Permissions** across core operational resources, administration, onboarding, and device enrollment
 - **Temporal Role Assignments**: Assign roles with `valid_from`/`valid_until` dates for automatic expiration
 - **Direct Permissions**: Assign permissions directly to users, bypassing roles for fine-grained control
 - **Permission Inheritance**: User permissions = Role permissions ∪ Direct permissions
@@ -117,7 +117,7 @@ GET /v1/users/{id}/permissions
 - [Temporal Roles](docs/guides/temporal-roles.md)
 - [Direct Permissions](docs/guides/direct-permissions.md)
 - [Activity Logging User Guide](docs/ACTIVITY_LOGGING_USER_GUIDE.md)
-- [Activity Logging Operations Guide](docs/ACTIVITY_LOGGING_ADMIN_GUIDE.md)
+- [Activity Logging Admin Guide](docs/ACTIVITY_LOGGING_ADMIN_GUIDE.md)
 - [Activity Logging Legal Guide](docs/ACTIVITY_LOGGING_LEGAL_GUIDE.md)
 - [API Reference](docs/api/rbac-endpoints.md)
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Comprehensive RBAC system with temporal role assignments and direct permission m
 
 **Features:**
 
-- **5 Predefined Roles**: Admin, Manager, Guard, Client, Works Council
+- **7 Predefined Roles**: Employee, Employee Read Only, HR, Manager, Guard, Client, Works Council
 - **52 Permissions** across 7 resources (employees, shifts, work_instructions, roles, permissions, works_council, reports)
 - **Temporal Role Assignments**: Assign roles with `valid_from`/`valid_until` dates for automatic expiration
 - **Direct Permissions**: Assign permissions directly to users, bypassing roles for fine-grained control
@@ -117,7 +117,7 @@ GET /v1/users/{id}/permissions
 - [Temporal Roles](docs/guides/temporal-roles.md)
 - [Direct Permissions](docs/guides/direct-permissions.md)
 - [Activity Logging User Guide](docs/ACTIVITY_LOGGING_USER_GUIDE.md)
-- [Activity Logging Admin Guide](docs/ACTIVITY_LOGGING_ADMIN_GUIDE.md)
+- [Activity Logging Operations Guide](docs/ACTIVITY_LOGGING_ADMIN_GUIDE.md)
 - [Activity Logging Legal Guide](docs/ACTIVITY_LOGGING_LEGAL_GUIDE.md)
 - [API Reference](docs/api/rbac-endpoints.md)
 
@@ -131,7 +131,7 @@ SecPal uses exactly five valid employee lifecycle statuses:
 - `on_leave`: Employee is temporarily absent but still employed. Onboarding invitations are not allowed, and runtime access is reduced to the read-only baseline until the employee returns.
 - `terminated`: Employment has ended. Onboarding invitations are not allowed.
 
-Admin rule of thumb:
+Status rule of thumb:
 
 - Use `pre_contract` if you want to invite the employee into onboarding.
 - Do not rely on form submission to discover the rule. The UI should explain the restriction before submit, and the API rejects `send_invitation: true` for every status other than `pre_contract`.
@@ -437,7 +437,7 @@ SecPal implements a comprehensive Role-Based Access Control (RBAC) system with t
 
 ### Core Features
 
-- **Role-based access control** with predefined roles (Admin, Manager, Guard, Client, Works Council)
+- **Role-based access control** with predefined roles (Employee, Employee Read Only, HR, Manager, Guard, Client, Works Council)
 - **Temporal role assignments** with automatic expiration for time-limited access
 - **Direct permissions** allowing exceptions without creating new roles
 - **All roles are equal** and fully manageable (no system/custom distinction)
@@ -447,7 +447,7 @@ SecPal implements a comprehensive Role-Based Access Control (RBAC) system with t
 
 #### 1. No System Roles
 
-All roles are equal - predefined roles (Admin, Manager, etc.) can be deleted if not assigned to users. Deleted predefined roles are automatically recreated on next seeder run. This approach provides simplicity and flexibility without artificial distinctions. See [ADR-005](https://github.com/SecPal/.github/blob/main/docs/adr/005-rbac-design-decisions.md) for rationale.
+All roles are equal - predefined roles (Employee, HR, Manager, etc.) can be deleted if not assigned to users. Deleted predefined roles are automatically recreated on next seeder run. This approach provides simplicity and flexibility without artificial distinctions. See [ADR-005](https://github.com/SecPal/.github/blob/main/docs/adr/005-rbac-design-decisions.md) for rationale.
 
 #### 2. Direct Permissions
 

--- a/app/Http/Controllers/Api/V1/OnboardingController.php
+++ b/app/Http/Controllers/Api/V1/OnboardingController.php
@@ -679,7 +679,7 @@ class OnboardingController extends Controller
     /**
      * Approve onboarding form submission (HR only).
      *
-     * POST /api/v1/admin/onboarding/submissions/{submission}/approve
+     * POST /api/v1/onboarding-review/submissions/{submission}/approve
      */
     public function approveSubmission(Request $request, OnboardingFormSubmission $submission): JsonResponse
     {
@@ -719,7 +719,7 @@ class OnboardingController extends Controller
     /**
      * Reject onboarding form submission (HR only).
      *
-     * POST /api/v1/admin/onboarding/submissions/{submission}/reject
+     * POST /api/v1/onboarding-review/submissions/{submission}/reject
      */
     public function rejectSubmission(Request $request, OnboardingFormSubmission $submission): JsonResponse
     {
@@ -837,7 +837,7 @@ class OnboardingController extends Controller
     /**
      * Confirm a pre-contract onboarding dossier after HR/compliance review.
      *
-     * POST /v1/admin/onboarding/employees/{employee}/confirm
+     * POST /v1/onboarding-review/employees/{employee}/confirm
      */
     public function confirmEmployeeOnboarding(Request $request, Employee $employee): JsonResponse
     {

--- a/app/Http/Controllers/Api/V1/OnboardingController.php
+++ b/app/Http/Controllers/Api/V1/OnboardingController.php
@@ -679,7 +679,7 @@ class OnboardingController extends Controller
     /**
      * Approve onboarding form submission (HR only).
      *
-     * POST /api/v1/onboarding-review/submissions/{submission}/approve
+     * POST /v1/onboarding-review/submissions/{submission}/approve
      */
     public function approveSubmission(Request $request, OnboardingFormSubmission $submission): JsonResponse
     {
@@ -719,7 +719,7 @@ class OnboardingController extends Controller
     /**
      * Reject onboarding form submission (HR only).
      *
-     * POST /api/v1/onboarding-review/submissions/{submission}/reject
+     * POST /v1/onboarding-review/submissions/{submission}/reject
      */
     public function rejectSubmission(Request $request, OnboardingFormSubmission $submission): JsonResponse
     {

--- a/resources/views/emails/hr/bwr-id-document-auto-deleted.blade.php
+++ b/resources/views/emails/hr/bwr-id-document-auto-deleted.blade.php
@@ -1,6 +1,8 @@
 {{-- SPDX-FileCopyrightText: 2026 SecPal Contributors --}}
 {{-- SPDX-License-Identifier: AGPL-3.0-or-later --}}
 
+@php($employeeDetailUrl = rtrim((string) (config('app.frontend_url') ?: url('/')), '/') . '/employees/' . $employee->id)
+
 <x-mail::message>
 # {{ __('ID Document Copy Deleted After BWR Approval') }}
 
@@ -20,7 +22,7 @@
 
 **{{ __('Legal Basis') }}:** {{ $legalBasis }}
 
-<x-mail::button :url="url('/admin/employees/' . $employee->id)">
+<x-mail::button :url="$employeeDetailUrl">
 {{ __('View Employee Details') }}
 </x-mail::button>
 

--- a/resources/views/emails/hr/bwr-id-document-auto-deleted.blade.php
+++ b/resources/views/emails/hr/bwr-id-document-auto-deleted.blade.php
@@ -1,7 +1,7 @@
 {{-- SPDX-FileCopyrightText: 2026 SecPal Contributors --}}
 {{-- SPDX-License-Identifier: AGPL-3.0-or-later --}}
 
-@php($employeeDetailUrl = rtrim((string) (config('app.frontend_url') ?: url('/')), '/') . '/employees/' . $employee->id)
+@php($frontendUrl = rtrim((string) config('app.frontend_url', ''), '/'))
 
 <x-mail::message>
 # {{ __('ID Document Copy Deleted After BWR Approval') }}
@@ -22,9 +22,11 @@
 
 **{{ __('Legal Basis') }}:** {{ $legalBasis }}
 
-<x-mail::button :url="$employeeDetailUrl">
+@if ($frontendUrl)
+<x-mail::button :url="$frontendUrl . '/employees/' . $employee->id">
 {{ __('View Employee Details') }}
 </x-mail::button>
+@endif
 
 ---
 

--- a/resources/views/emails/hr/onboarding-name-changed.blade.php
+++ b/resources/views/emails/hr/onboarding-name-changed.blade.php
@@ -46,6 +46,8 @@
   @endif
 @endif
 
+@php($employeeDetailUrl = rtrim((string) (config('app.frontend_url') ?: url('/')), '/') . '/employees/' . $employee->id)
+
 ## {{ __('Action Required') }}
 
 @if ($firstNameSeverity === 'medium' || $lastNameSeverity === 'medium')
@@ -54,7 +56,7 @@
 ✅ **{{ __('Minor change detected. Review activity log if needed.') }}**
 @endif
 
-<x-mail::button :url="url('/admin/employees/' . $employee->id)">
+<x-mail::button :url="$employeeDetailUrl">
 {{ __('View Employee Details') }}
 </x-mail::button>
 

--- a/resources/views/emails/hr/onboarding-name-changed.blade.php
+++ b/resources/views/emails/hr/onboarding-name-changed.blade.php
@@ -46,7 +46,7 @@
   @endif
 @endif
 
-@php($employeeDetailUrl = rtrim((string) (config('app.frontend_url') ?: url('/')), '/') . '/employees/' . $employee->id)
+@php($frontendUrl = rtrim((string) config('app.frontend_url', ''), '/'))
 
 ## {{ __('Action Required') }}
 
@@ -56,9 +56,11 @@
 ✅ **{{ __('Minor change detected. Review activity log if needed.') }}**
 @endif
 
-<x-mail::button :url="$employeeDetailUrl">
+@if ($frontendUrl)
+<x-mail::button :url="$frontendUrl . '/employees/' . $employee->id">
 {{ __('View Employee Details') }}
 </x-mail::button>
+@endif
 
 ## {{ __('Security Notice') }}
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -102,13 +102,13 @@ Route::prefix('v1')->group(function () {
         Route::get('/me', [AuthController::class, 'me']);
 
         Route::middleware('verified')->group(function () {
-            Route::get('/admin/android-enrollment-sessions', [AndroidEnrollmentSessionController::class, 'index'])
+            Route::get('/android-enrollment-sessions', [AndroidEnrollmentSessionController::class, 'index'])
                 ->middleware('permission:android_enrollment.read');
-            Route::post('/admin/android-enrollment-sessions', [AndroidEnrollmentSessionController::class, 'store'])
+            Route::post('/android-enrollment-sessions', [AndroidEnrollmentSessionController::class, 'store'])
                 ->middleware('permission:android_enrollment.write');
-            Route::get('/admin/android-enrollment-sessions/{session}', [AndroidEnrollmentSessionController::class, 'show'])
+            Route::get('/android-enrollment-sessions/{session}', [AndroidEnrollmentSessionController::class, 'show'])
                 ->middleware('permission:android_enrollment.read');
-            Route::post('/admin/android-enrollment-sessions/{session}/revoke', [AndroidEnrollmentSessionController::class, 'revoke'])
+            Route::post('/android-enrollment-sessions/{session}/revoke', [AndroidEnrollmentSessionController::class, 'revoke'])
                 ->middleware('permission:android_enrollment.write');
 
             Route::patch('/me/language', [AuthController::class, 'updateLanguage']);
@@ -344,9 +344,9 @@ Route::prefix('v1')->group(function () {
             Route::get('/onboarding/completion-status', [OnboardingController::class, 'getCompletionStatus']);
 
             // HR approval endpoints
-            Route::post('/admin/onboarding/submissions/{submission}/approve', [OnboardingController::class, 'approveSubmission']);
-            Route::post('/admin/onboarding/submissions/{submission}/reject', [OnboardingController::class, 'rejectSubmission']);
-            Route::post('/admin/onboarding/employees/{employee}/confirm', [OnboardingController::class, 'confirmEmployeeOnboarding']);
+            Route::post('/onboarding-review/submissions/{submission}/approve', [OnboardingController::class, 'approveSubmission']);
+            Route::post('/onboarding-review/submissions/{submission}/reject', [OnboardingController::class, 'rejectSubmission']);
+            Route::post('/onboarding-review/employees/{employee}/confirm', [OnboardingController::class, 'confirmEmployeeOnboarding']);
         });
 
         // ==========================================================================

--- a/tests/Feature/Api/OnboardingCompletionTest.php
+++ b/tests/Feature/Api/OnboardingCompletionTest.php
@@ -395,7 +395,7 @@ describe('OnboardingController::approveSubmission completion integration', funct
         // Approve submission
         actingAs($hrUser, 'sanctum')
             ->withHeaders(['X-Tenant-ID' => (string) $this->tenant->id])
-            ->postJson("/v1/admin/onboarding/submissions/{$submission->id}/approve")
+            ->postJson("/v1/onboarding-review/submissions/{$submission->id}/approve")
             ->assertOk();
 
         // After approval - should be complete (only 1 required template)
@@ -437,7 +437,7 @@ describe('OnboardingController::approveSubmission completion integration', funct
         // Approve first submission
         actingAs($hrUser, 'sanctum')
             ->withHeaders(['X-Tenant-ID' => (string) $this->tenant->id])
-            ->postJson("/v1/admin/onboarding/submissions/{$submission1->id}/approve")
+            ->postJson("/v1/onboarding-review/submissions/{$submission1->id}/approve")
             ->assertOk();
 
         // Not complete yet (1 of 2 approved)
@@ -446,7 +446,7 @@ describe('OnboardingController::approveSubmission completion integration', funct
         // Approve second submission
         actingAs($hrUser, 'sanctum')
             ->withHeaders(['X-Tenant-ID' => (string) $this->tenant->id])
-            ->postJson("/v1/admin/onboarding/submissions/{$submission2->id}/approve")
+            ->postJson("/v1/onboarding-review/submissions/{$submission2->id}/approve")
             ->assertOk();
 
         // Now complete (2 of 2 approved)

--- a/tests/Feature/Api/V1/AndroidEnrollmentSessionApiTest.php
+++ b/tests/Feature/Api/V1/AndroidEnrollmentSessionApiTest.php
@@ -78,7 +78,7 @@ test('authorized user can create android enrollment session and receives private
 
     actingAs($admin, 'sanctum');
 
-    $response = postJson('/v1/admin/android-enrollment-sessions', [
+    $response = postJson('/v1/android-enrollment-sessions', [
         'device_label' => 'Front desk kiosk',
         'update_channel' => 'managed_device',
         'expires_in_minutes' => 15,
@@ -147,7 +147,7 @@ test('provisioning payload download URL reflects the session update_channel', fu
 
     actingAs($admin, 'sanctum');
 
-    $response = postJson('/v1/admin/android-enrollment-sessions', [
+    $response = postJson('/v1/android-enrollment-sessions', [
         'device_label' => 'BYOD device',
         'update_channel' => 'direct_apk',
         'expires_in_minutes' => 15,
@@ -171,7 +171,7 @@ test('reader can list sessions without receiving raw bootstrap tokens', function
 
     actingAs($reader, 'sanctum');
 
-    $response = getJson('/v1/admin/android-enrollment-sessions');
+    $response = getJson('/v1/android-enrollment-sessions');
 
     $response->assertOk()
         ->assertJsonPath('data.0.status', 'pending')
@@ -189,12 +189,12 @@ test('user without write permission cannot create or revoke android enrollment s
 
     actingAs($outsider, 'sanctum');
 
-    postJson('/v1/admin/android-enrollment-sessions', [
+    postJson('/v1/android-enrollment-sessions', [
         'update_channel' => 'managed_device',
         'provisioning_profile' => androidProvisioningProfile(),
     ])->assertForbidden();
 
-    postJson('/v1/admin/android-enrollment-sessions/'.$issued['model']->id.'/revoke', [
+    postJson('/v1/android-enrollment-sessions/'.$issued['model']->id.'/revoke', [
         'reason' => 'Not allowed',
     ])->assertForbidden();
 });
@@ -210,7 +210,7 @@ test('authorized user can revoke pending android enrollment session and the acti
 
     actingAs($admin, 'sanctum');
 
-    $response = postJson('/v1/admin/android-enrollment-sessions/'.$issued['model']->id.'/revoke', [
+    $response = postJson('/v1/android-enrollment-sessions/'.$issued['model']->id.'/revoke', [
         'reason' => 'Device handoff canceled.',
     ]);
 

--- a/tests/Feature/Auth/SanctumIntegrationTest.php
+++ b/tests/Feature/Auth/SanctumIntegrationTest.php
@@ -92,30 +92,29 @@ describe('Integration: CORS and Security', function () {
         expect($response->headers->get('Vary'))->toContain('Access-Control-Request-Method');
     })->with('disallowed CORS origins');
 
-    test('multiple configured origins are allowed exactly without widening matching', function () {
+    test('the authoritative SPA origin is allowed exactly without widening matching', function () {
         $originalAllowedOrigins = Config::get('cors.allowed_origins');
         $originalAllowedOriginsPatterns = Config::get('cors.allowed_origins_patterns');
 
         Config::set('cors.allowed_origins', []);
         Config::set('cors.allowed_origins_patterns', [
             '#^https://app\.secpal\.dev$#',
-            '#^https://admin\.secpal\.dev$#',
         ]);
 
         try {
             $allowedResponse = $this->call('OPTIONS', '/v1/auth/token', [], [], [], [
-                'HTTP_ORIGIN' => 'https://admin.secpal.dev',
+                'HTTP_ORIGIN' => 'https://app.secpal.dev',
                 'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
                 'HTTP_ACCESS_CONTROL_REQUEST_HEADERS' => 'Content-Type,X-XSRF-TOKEN',
             ]);
 
             $allowedResponse->assertNoContent();
-            expect($allowedResponse->headers->get('Access-Control-Allow-Origin'))->toBe('https://admin.secpal.dev');
+            expect($allowedResponse->headers->get('Access-Control-Allow-Origin'))->toBe('https://app.secpal.dev');
             expect($allowedResponse->headers->get('Access-Control-Allow-Credentials'))->toBe('true');
             expect($allowedResponse->headers->get('Vary'))->toContain('Origin');
 
             $disallowedResponse = $this->call('OPTIONS', '/v1/auth/token', [], [], [], [
-                'HTTP_ORIGIN' => 'https://admin.secpal.dev.evil.example',
+                'HTTP_ORIGIN' => 'https://app.secpal.dev.evil.example',
                 'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => 'POST',
                 'HTTP_ACCESS_CONTROL_REQUEST_HEADERS' => 'Content-Type,X-XSRF-TOKEN',
             ]);

--- a/tests/Feature/Auth/SanctumSpaConfigTest.php
+++ b/tests/Feature/Auth/SanctumSpaConfigTest.php
@@ -153,15 +153,14 @@ describe('CORS Configuration for SPA', function () {
             ->toContain('health/*');
     });
 
-    test('cors config builds exact patterns for multiple configured origins', function () {
-        $corsConfig = withCorsAllowedOrigins('https://app.secpal.dev,https://admin.secpal.dev',
+    test('cors config builds an exact pattern for the authoritative SPA origin', function () {
+        $corsConfig = withCorsAllowedOrigins('https://app.secpal.dev',
             static fn (): array => require base_path('config/cors.php')
         );
 
         expect($corsConfig['allowed_origins'])->toBe([])
             ->and($corsConfig['allowed_origins_patterns'])->toBe([
                 '#^https\://app\.secpal\.dev$#',
-                '#^https\://admin\.secpal\.dev$#',
             ]);
     });
 

--- a/tests/Feature/Auth/SanctumSpaConfigTest.php
+++ b/tests/Feature/Auth/SanctumSpaConfigTest.php
@@ -164,6 +164,18 @@ describe('CORS Configuration for SPA', function () {
             ]);
     });
 
+    test('cors config builds one exact pattern per origin when multiple origins are configured', function () {
+        $corsConfig = withCorsAllowedOrigins('https://app.secpal.dev,https://devtest.secpal.dev',
+            static fn (): array => require base_path('config/cors.php')
+        );
+
+        expect($corsConfig['allowed_origins'])->toBe([])
+            ->and($corsConfig['allowed_origins_patterns'])->toBe([
+                '#^https\://app\.secpal\.dev$#',
+                '#^https\://devtest\.secpal\.dev$#',
+            ]);
+    });
+
     test('cors config rejects wildcard origins when credentials are enabled', function () {
         expect(fn () => withCorsAllowedOrigins('https://*.secpal.dev',
             static fn (): array => require base_path('config/cors.php')

--- a/tests/Feature/Controllers/OnboardingControllerTest.php
+++ b/tests/Feature/Controllers/OnboardingControllerTest.php
@@ -824,7 +824,7 @@ describe('POST /v1/onboarding/submissions/{submission}/files', function () {
     });
 });
 
-describe('POST /v1/admin/onboarding/submissions/{submission}/approve', function () {
+describe('POST /v1/onboarding-review/submissions/{submission}/approve', function () {
     test('returns 401 when not authenticated', function (): void {
         $submission = OnboardingFormSubmission::factory()->create([
             'employee_id' => $this->employee->id,
@@ -832,7 +832,7 @@ describe('POST /v1/admin/onboarding/submissions/{submission}/approve', function 
             'status' => 'submitted',
         ]);
 
-        $response = $this->postJson("/v1/admin/onboarding/submissions/{$submission->id}/approve");
+        $response = $this->postJson("/v1/onboarding-review/submissions/{$submission->id}/approve");
         $response->assertStatus(401);
     });
 
@@ -844,7 +844,7 @@ describe('POST /v1/admin/onboarding/submissions/{submission}/approve', function 
         ]);
 
         $response = $this->withToken($this->token)
-            ->postJson("/v1/admin/onboarding/submissions/{$submission->id}/approve");
+            ->postJson("/v1/onboarding-review/submissions/{$submission->id}/approve");
 
         $response->assertStatus(403);
     });
@@ -862,7 +862,7 @@ describe('POST /v1/admin/onboarding/submissions/{submission}/approve', function 
         ]);
 
         $response = $this->withToken($this->token)
-            ->postJson("/v1/admin/onboarding/submissions/{$submission->id}/approve");
+            ->postJson("/v1/onboarding-review/submissions/{$submission->id}/approve");
 
         $response->assertStatus(200);
         expect($response->json('data.status'))->toBe('approved');
@@ -880,13 +880,13 @@ describe('POST /v1/admin/onboarding/submissions/{submission}/approve', function 
         ]);
 
         $response = $this->withToken($this->token)
-            ->postJson("/v1/admin/onboarding/submissions/{$submission->id}/approve");
+            ->postJson("/v1/onboarding-review/submissions/{$submission->id}/approve");
 
         $response->assertStatus(422);
     });
 });
 
-describe('POST /v1/admin/onboarding/submissions/{submission}/reject', function () {
+describe('POST /v1/onboarding-review/submissions/{submission}/reject', function () {
     test('returns 401 when not authenticated', function (): void {
         $submission = OnboardingFormSubmission::factory()->create([
             'employee_id' => $this->employee->id,
@@ -894,7 +894,7 @@ describe('POST /v1/admin/onboarding/submissions/{submission}/reject', function (
             'status' => 'submitted',
         ]);
 
-        $response = $this->postJson("/v1/admin/onboarding/submissions/{$submission->id}/reject", [
+        $response = $this->postJson("/v1/onboarding-review/submissions/{$submission->id}/reject", [
             'reason' => 'Incomplete information',
         ]);
 
@@ -909,7 +909,7 @@ describe('POST /v1/admin/onboarding/submissions/{submission}/reject', function (
         ]);
 
         $response = $this->withToken($this->token)
-            ->postJson("/v1/admin/onboarding/submissions/{$submission->id}/reject", [
+            ->postJson("/v1/onboarding-review/submissions/{$submission->id}/reject", [
                 'reason' => 'Incomplete information',
             ]);
 
@@ -929,7 +929,7 @@ describe('POST /v1/admin/onboarding/submissions/{submission}/reject', function (
         ]);
 
         $response = $this->withToken($this->token)
-            ->postJson("/v1/admin/onboarding/submissions/{$submission->id}/reject", []);
+            ->postJson("/v1/onboarding-review/submissions/{$submission->id}/reject", []);
 
         $response->assertStatus(422)
             ->assertJsonValidationErrors(['reason']);
@@ -948,7 +948,7 @@ describe('POST /v1/admin/onboarding/submissions/{submission}/reject', function (
         ]);
 
         $response = $this->withToken($this->token)
-            ->postJson("/v1/admin/onboarding/submissions/{$submission->id}/reject", [
+            ->postJson("/v1/onboarding-review/submissions/{$submission->id}/reject", [
                 'reason' => 'Missing required documents',
             ]);
 
@@ -970,7 +970,7 @@ describe('POST /v1/admin/onboarding/submissions/{submission}/reject', function (
         ]);
 
         $response = $this->withToken($this->token)
-            ->postJson("/v1/admin/onboarding/submissions/{$submission->id}/reject", [
+            ->postJson("/v1/onboarding-review/submissions/{$submission->id}/reject", [
                 'reason' => 'Attempt to reject approved submission',
             ]);
 
@@ -978,16 +978,16 @@ describe('POST /v1/admin/onboarding/submissions/{submission}/reject', function (
     });
 });
 
-describe('POST /v1/admin/onboarding/employees/{employee}/confirm', function () {
+describe('POST /v1/onboarding-review/employees/{employee}/confirm', function () {
     test('returns 401 when not authenticated', function (): void {
-        $response = $this->postJson("/v1/admin/onboarding/employees/{$this->employee->id}/confirm");
+        $response = $this->postJson("/v1/onboarding-review/employees/{$this->employee->id}/confirm");
 
         $response->assertStatus(401);
     });
 
     test('returns 403 when user lacks onboarding.confirm permission', function (): void {
         $response = $this->withToken($this->token)
-            ->postJson("/v1/admin/onboarding/employees/{$this->employee->id}/confirm");
+            ->postJson("/v1/onboarding-review/employees/{$this->employee->id}/confirm");
 
         $response->assertStatus(403);
     });
@@ -996,7 +996,7 @@ describe('POST /v1/admin/onboarding/employees/{employee}/confirm', function () {
         givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.confirm');
 
         $response = $this->withToken($this->token)
-            ->postJson("/v1/admin/onboarding/employees/{$this->employee->id}/confirm");
+            ->postJson("/v1/onboarding-review/employees/{$this->employee->id}/confirm");
 
         $response->assertStatus(422);
     });
@@ -1010,7 +1010,7 @@ describe('POST /v1/admin/onboarding/employees/{employee}/confirm', function () {
         ]);
 
         $response = $this->withToken($this->token)
-            ->postJson("/v1/admin/onboarding/employees/{$this->employee->id}/confirm");
+            ->postJson("/v1/onboarding-review/employees/{$this->employee->id}/confirm");
 
         $response->assertStatus(422);
     });
@@ -1025,7 +1025,7 @@ describe('POST /v1/admin/onboarding/employees/{employee}/confirm', function () {
         ]);
 
         $response = $this->withToken($this->token)
-            ->postJson("/v1/admin/onboarding/employees/{$this->employee->id}/confirm", [
+            ->postJson("/v1/onboarding-review/employees/{$this->employee->id}/confirm", [
                 'notes' => str_repeat('A', 1001),
             ]);
 
@@ -1043,7 +1043,7 @@ describe('POST /v1/admin/onboarding/employees/{employee}/confirm', function () {
         ]);
 
         $response = $this->withToken($this->token)
-            ->postJson("/v1/admin/onboarding/employees/{$this->employee->id}/confirm", [
+            ->postJson("/v1/onboarding-review/employees/{$this->employee->id}/confirm", [
                 'notes' => 'Contract signed and reviewed.',
             ]);
 
@@ -1071,7 +1071,7 @@ describe('POST /v1/admin/onboarding/employees/{employee}/confirm', function () {
         ]);
 
         $response = $this->withToken($this->token)
-            ->postJson("/v1/admin/onboarding/employees/{$this->employee->id}/confirm");
+            ->postJson("/v1/onboarding-review/employees/{$this->employee->id}/confirm");
 
         $response->assertStatus(200);
         expect($response->json('data.onboarding_workflow.status'))->toBe(Employee::WORKFLOW_STATUS_READY_FOR_ACTIVATION);

--- a/tests/Feature/Mail/EmployeeLifecycleMailTest.php
+++ b/tests/Feature/Mail/EmployeeLifecycleMailTest.php
@@ -376,5 +376,6 @@ test('bwr id document auto deleted mail includes employee details and deletion r
         ->and($mail->envelope()->subject)->toContain('BWR')
         ->and($mail->render())->toContain('Casey Secure')
         ->and($mail->render())->toContain('EMP-912')
+        ->and($mail->render())->toContain('https://app.secpal.dev/employees/'.$employee->id)
         ->and($mail->render())->toContain('deleted automatically because BWR approval made continued storage no longer necessary');
 });

--- a/tests/Unit/Services/BewacherregisterExportServiceTest.php
+++ b/tests/Unit/Services/BewacherregisterExportServiceTest.php
@@ -84,7 +84,7 @@ function createBewacherregisterReadyEmployee(TenantKey $tenant, OrganizationalUn
 test('exports a BWR-ready employee to CSV storage', function (): void {
     $employee = createBewacherregisterReadyEmployee($this->tenant, $this->organizationalUnit);
 
-    $export = $this->service->exportCsv($employee, 'HR Admin');
+    $export = $this->service->exportCsv($employee, 'HR Operations');
 
     expect($export['disk'])->toBe('local')
         ->and($export['file_name'])->toEndWith('.csv')
@@ -97,7 +97,7 @@ test('exports a BWR-ready employee to CSV storage', function (): void {
     expect($csv)->toContain('last_name;first_name;birth_name')
         ->and($csv)->toContain('Export;Taylor;"Taylor Birthname"')
         ->and($csv)->toContain('object_protection, event_security')
-        ->and($csv)->toContain('HR Admin')
+        ->and($csv)->toContain('HR Operations')
         ->and($export)->toHaveKey('file_size_bytes')
         ->and($export['file_size_bytes'])->toBe(strlen($csv));
 });
@@ -105,7 +105,7 @@ test('exports a BWR-ready employee to CSV storage', function (): void {
 test('exports a BWR-ready employee to XML storage', function (): void {
     $employee = createBewacherregisterReadyEmployee($this->tenant, $this->organizationalUnit);
 
-    $export = $this->service->exportXml($employee, 'HR Admin');
+    $export = $this->service->exportXml($employee, 'HR Operations');
 
     expect($export['disk'])->toBe('local')
         ->and($export['file_name'])->toEndWith('.xml')
@@ -119,7 +119,7 @@ test('exports a BWR-ready employee to XML storage', function (): void {
         ->and($xml)->toContain('<bewacherregisterExport>')
         ->and($xml)->toContain('<last_name>Export</last_name>')
         ->and($xml)->toContain('<first_name>Taylor</first_name>')
-        ->and($xml)->toContain('<exported_by>HR Admin</exported_by>')
+        ->and($xml)->toContain('<exported_by>HR Operations</exported_by>')
         ->and($export)->toHaveKey('file_size_bytes')
         ->and($export['file_size_bytes'])->toBe(strlen($xml));
 });
@@ -131,7 +131,7 @@ test('export throws when required BWR fields are missing', function (): void {
         'id_document_number' => null,
     ]);
 
-    expect(fn () => $this->service->exportCsv($employee, 'HR Admin'))
+    expect(fn () => $this->service->exportCsv($employee, 'HR Operations'))
         ->toThrow(RuntimeException::class, 'gender, address_history, id_document_number');
 });
 
@@ -143,7 +143,7 @@ test('export requires valid work authorization for non exempt nationalities', fu
         'work_permit_expiry' => null,
     ]);
 
-    expect(fn () => $this->service->exportCsv($employee, 'HR Admin'))
+    expect(fn () => $this->service->exportCsv($employee, 'HR Operations'))
         ->toThrow(RuntimeException::class, 'valid_work_authorization');
 });
 
@@ -152,7 +152,7 @@ test('export preserves seven digit BWR ids including leading zeroes', function (
         'bwr_id' => '0001234',
     ]);
 
-    $export = $this->service->exportCsv($employee, 'HR Admin');
+    $export = $this->service->exportCsv($employee, 'HR Operations');
     $csv = Storage::disk('local')->get($export['path']);
 
     $stream = fopen('php://temp', 'r+');
@@ -185,6 +185,6 @@ test('export throws when id_document_expiry is in the past', function (): void {
         'id_document_expiry' => now()->subDay()->toDateString(),
     ]);
 
-    expect(fn () => $this->service->exportCsv($employee, 'HR Admin'))
+    expect(fn () => $this->service->exportCsv($employee, 'HR Operations'))
         ->toThrow(RuntimeException::class, 'id_document_expiry_expired');
 });


### PR DESCRIPTION
## Summary
- rename the onboarding approval, rejection, and confirmation routes to the neutral `/v1/onboarding-review/...` surface
- rename the Android provisioning session routes to `/v1/android-enrollment-sessions...`
- update HR lifecycle emails, focused API tests, and supporting README/changelog wording to remove the dead `/admin/...` drift

## Validation
- `./vendor/bin/pint --dirty`
- `php artisan test tests/Feature/Controllers/OnboardingControllerTest.php tests/Feature/Api/OnboardingCompletionTest.php tests/Feature/Api/V1/AndroidEnrollmentSessionApiTest.php tests/Feature/Auth/SanctumIntegrationTest.php tests/Feature/Auth/SanctumSpaConfigTest.php tests/Feature/Mail/EmployeeLifecycleMailTest.php tests/Unit/Services/BewacherregisterExportServiceTest.php`
- live API probe on `api.secpal.dev`: new neutral routes return `401` while removed `/v1/admin/...` variants return `404`

Refs SecPal/.github#404
