### PR TITLE
refactor: extract shared assignment compliance guard

### DIFF
--- a/app/Http/Controllers/Api/V1/AssignmentController.php
+++ b/app/Http/Controllers/Api/V1/AssignmentController.php
@@ -1,0 +1,36 @@
+<?php
+
+// SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Models\Employee;
+use App\Models\User;
+use App\Services\EmployeeComplianceService;
+use Illuminate\Http\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+
+abstract class AssignmentController extends Controller
+{
+    private const COMPLIANCE_BLOCKING_MESSAGE = 'Employee cannot be assigned while critical compliance documents are expired or due within 7 days.';
+
+    protected function complianceBlockingResponse(User $targetUser, EmployeeComplianceService $complianceService): ?JsonResponse
+    {
+        $blockingDocuments = $targetUser->employee instanceof Employee
+            ? $complianceService->blockingDocuments($targetUser->employee)
+            : collect();
+
+        if ($blockingDocuments->isEmpty()) {
+            return null;
+        }
+
+        return response()->json([
+            'message' => self::COMPLIANCE_BLOCKING_MESSAGE,
+            'blocking_documents' => $blockingDocuments->all(),
+        ], Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+}

--- a/app/Http/Controllers/Api/V1/CustomerAssignmentController.php
+++ b/app/Http/Controllers/Api/V1/CustomerAssignmentController.php
@@ -7,14 +7,12 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\Api\V1;
 
-use App\Http\Controllers\Controller;
 use App\Http\Requests\Api\V1\Assignment\IndexCustomerAssignmentRequest;
 use App\Http\Requests\Api\V1\Assignment\StoreCustomerAssignmentRequest;
 use App\Http\Requests\Api\V1\Assignment\UpdateAssignmentRequest;
 use App\Http\Resources\Api\V1\CustomerAssignmentResource;
 use App\Models\Customer;
 use App\Models\CustomerAssignment;
-use App\Models\Employee;
 use App\Models\User;
 use App\Services\EmployeeComplianceService;
 use Illuminate\Http\JsonResponse;
@@ -31,7 +29,7 @@ use Symfony\Component\HttpFoundation\Response;
  * @see SecPal/api#315 Assignment API endpoints
  * @see SecPal/.github#210 Customer & Site Management Epic
  */
-class CustomerAssignmentController extends Controller
+class CustomerAssignmentController extends AssignmentController
 {
     /**
      * List assignments for a customer.
@@ -85,15 +83,10 @@ class CustomerAssignmentController extends Controller
 
         /** @var User $targetUser */
         $targetUser = User::query()->with('employee')->findOrFail($validated['user_id']);
-        $blockingDocuments = $targetUser->employee instanceof Employee
-            ? $complianceService->blockingDocuments($targetUser->employee)
-            : collect();
+        $complianceBlockingResponse = $this->complianceBlockingResponse($targetUser, $complianceService);
 
-        if ($blockingDocuments->isNotEmpty()) {
-            return response()->json([
-                'message' => 'Employee cannot be assigned while critical compliance documents are expired or due within 7 days.',
-                'blocking_documents' => $blockingDocuments->all(),
-            ], Response::HTTP_UNPROCESSABLE_ENTITY);
+        if ($complianceBlockingResponse instanceof JsonResponse) {
+            return $complianceBlockingResponse;
         }
 
         // Check for existing assignment with same user+role

--- a/app/Http/Controllers/Api/V1/CustomerAssignmentController.php
+++ b/app/Http/Controllers/Api/V1/CustomerAssignmentController.php
@@ -85,7 +85,7 @@ class CustomerAssignmentController extends AssignmentController
         $targetUser = User::query()->with('employee')->findOrFail($validated['user_id']);
         $complianceBlockingResponse = $this->complianceBlockingResponse($targetUser, $complianceService);
 
-        if ($complianceBlockingResponse instanceof JsonResponse) {
+        if ($complianceBlockingResponse !== null) {
             return $complianceBlockingResponse;
         }
 

--- a/app/Http/Controllers/Api/V1/SiteAssignmentController.php
+++ b/app/Http/Controllers/Api/V1/SiteAssignmentController.php
@@ -83,7 +83,7 @@ class SiteAssignmentController extends AssignmentController
         $targetUser = User::query()->with('employee')->findOrFail($validated['user_id']);
         $complianceBlockingResponse = $this->complianceBlockingResponse($targetUser, $complianceService);
 
-        if ($complianceBlockingResponse instanceof JsonResponse) {
+        if ($complianceBlockingResponse !== null) {
             return $complianceBlockingResponse;
         }
 

--- a/app/Http/Controllers/Api/V1/SiteAssignmentController.php
+++ b/app/Http/Controllers/Api/V1/SiteAssignmentController.php
@@ -7,12 +7,10 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\Api\V1;
 
-use App\Http\Controllers\Controller;
 use App\Http\Requests\Api\V1\Assignment\IndexSiteAssignmentRequest;
 use App\Http\Requests\Api\V1\Assignment\StoreSiteAssignmentRequest;
 use App\Http\Requests\Api\V1\Assignment\UpdateAssignmentRequest;
 use App\Http\Resources\Api\V1\SiteAssignmentResource;
-use App\Models\Employee;
 use App\Models\Site;
 use App\Models\SiteAssignment;
 use App\Models\User;
@@ -31,7 +29,7 @@ use Symfony\Component\HttpFoundation\Response;
  * @see SecPal/api#315 Assignment API endpoints
  * @see SecPal/.github#210 Customer & Site Management Epic
  */
-class SiteAssignmentController extends Controller
+class SiteAssignmentController extends AssignmentController
 {
     /**
      * List assignments for a site.
@@ -83,15 +81,10 @@ class SiteAssignmentController extends Controller
 
         /** @var User $targetUser */
         $targetUser = User::query()->with('employee')->findOrFail($validated['user_id']);
-        $blockingDocuments = $targetUser->employee instanceof Employee
-            ? $complianceService->blockingDocuments($targetUser->employee)
-            : collect();
+        $complianceBlockingResponse = $this->complianceBlockingResponse($targetUser, $complianceService);
 
-        if ($blockingDocuments->isNotEmpty()) {
-            return response()->json([
-                'message' => 'Employee cannot be assigned while critical compliance documents are expired or due within 7 days.',
-                'blocking_documents' => $blockingDocuments->all(),
-            ], Response::HTTP_UNPROCESSABLE_ENTITY);
+        if ($complianceBlockingResponse instanceof JsonResponse) {
+            return $complianceBlockingResponse;
         }
 
         // Check for existing assignment with same user+role


### PR DESCRIPTION
## Summary
- extract the compliance-blocking assignment response into a shared `AssignmentController` helper
- update customer and site assignment controllers to reuse the same guard implementation and keep the 422 payload aligned
- centralize future changes to the blocking message, payload shape, and status code in one place

## Test plan
- [x] `php artisan test tests/Feature/Controllers/Api/V1/CustomerAssignmentControllerTest.php`
- [x] `php artisan test tests/Feature/Controllers/Api/V1/SiteAssignmentControllerTest.php`

Closes #1001

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that centralizes existing 422 compliance-blocking logic for assignment creation; main risk is unintended change to the error message/payload if controllers relied on subtle differences.
> 
> **Overview**
> Introduces a shared `AssignmentController` base with a reusable `complianceBlockingResponse()` helper to standardize the **422 Unprocessable Entity** response when an employee has blocking compliance documents.
> 
> Updates `CustomerAssignmentController` and `SiteAssignmentController` to extend `AssignmentController` and reuse this guard during `store()`, removing duplicated compliance-check code and keeping the error message/payload consistent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f7b8470c48faa9b6651d82bf93a28f492be5593. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->