### PR TITLE
feat: Contract-aligned tests and RBAC docs (US-003, US-005, US-007)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Comprehensive RBAC system with temporal role assignments and direct permission m
 - **Direct Permissions**: Assign permissions directly to users, bypassing roles for fine-grained control
 - **Permission Inheritance**: User permissions = Role permissions ∪ Direct permissions
 - **Idempotent Seeder**: Predefined roles auto-recreate if deleted
-- **16 REST API Endpoints**: Full CRUD for roles, permissions, assignments, and direct permissions
+- **RBAC REST surface**: Role and permission CRUD, user role assignment (including extend), and direct user permissions — see [`docs/api/rbac-endpoints.md`](docs/api/rbac-endpoints.md) and `routes/api.php` (avoid relying on a hand-maintained endpoint count)
 
 **API Examples:**
 

--- a/docs/api/rbac-endpoints.md
+++ b/docs/api/rbac-endpoints.md
@@ -10,9 +10,9 @@ Complete API reference for SecPal's Role-Based Access Control (RBAC) system.
 SecPal's RBAC API provides four functional areas:
 
 1. **[Role Assignment API](#role-assignment-api)** - Assign/revoke roles to/from users (Phase 3 ✅)
-2. **[Role Management API](#role-management-api)** - CRUD operations for roles (Phase 4 ⏳)
-3. **[Permission Management API](#permission-management-api)** - CRUD operations for permissions (Phase 4 ⏳)
-4. **[Direct Permission API](#direct-permission-api)** - Assign permissions directly to users (Phase 4 ⏳)
+2. **[Role Management API](#role-management-api)** - CRUD operations for roles (Phase 4 ✅)
+3. **[Permission Management API](#permission-management-api)** - CRUD operations for permissions (Phase 4 ✅)
+4. **[Direct Permission API](#direct-permission-api)** - Assign permissions directly to users (Phase 4 ✅)
 
 **Base URL:** `https://api.secpal.dev/v1`
 

--- a/docs/rbac-architecture.md
+++ b/docs/rbac-architecture.md
@@ -1223,12 +1223,12 @@ $user->hasRole('manager');  // Only checks active roles
 
 SecPal's RBAC API is split across four functional areas:
 
-| API Area                  | Endpoints | Status                   | Documentation |
-| ------------------------- | --------- | ------------------------ | ------------- |
-| **Role Assignment**       | 4         | ✅ Phase 3 complete      | Issue #5      |
-| **Role Management**       | 5         | ✅ Phase 4 shipped       | Issue #137 / Issue #140 |
-| **Permission Management** | 5         | ✅ Phase 4 shipped       | Issue #138 / Issue #140 |
-| **Direct Permissions**    | 4         | ✅ Phase 4 shipped       | Issue #139 / Issue #140 |
+| API Area                  | Endpoints | Status              | Documentation           |
+| ------------------------- | --------- | ------------------- | ----------------------- |
+| **Role Assignment**       | 4         | ✅ Phase 3 complete | Issue #5                |
+| **Role Management**       | 5         | ✅ Phase 4 shipped  | Issue #137 / Issue #140 |
+| **Permission Management** | 5         | ✅ Phase 4 shipped  | Issue #138 / Issue #140 |
+| **Direct Permissions**    | 4         | ✅ Phase 4 shipped  | Issue #139 / Issue #140 |
 
 ### Role Assignment API (Phase 3)
 
@@ -1245,13 +1245,13 @@ SecPal's RBAC API is split across four functional areas:
 
 ### Role Management API (Phase 4)
 
-| Method   | Endpoint         | Description                       |
-| -------- | ---------------- | --------------------------------- |
-| `GET`    | `/v1/roles`      | List all roles (system + custom)  |
+| Method   | Endpoint         | Description                                   |
+| -------- | ---------------- | --------------------------------------------- |
+| `GET`    | `/v1/roles`      | List all roles (system + custom)              |
 | `POST`   | `/v1/roles`      | Create custom role (optional permission list) |
-| `GET`    | `/v1/roles/{id}` | Get role details with permissions |
-| `PATCH`  | `/v1/roles/{id}` | Update role name and/or sync permissions |
-| `DELETE` | `/v1/roles/{id}` | Delete role (if not assigned)     |
+| `GET`    | `/v1/roles/{id}` | Get role details with permissions             |
+| `PATCH`  | `/v1/roles/{id}` | Update role name and/or sync permissions      |
+| `DELETE` | `/v1/roles/{id}` | Delete role (if not assigned)                 |
 
 Role permission membership is managed through create/update payloads (`permissions` array) and `PATCH /v1/roles/{id}` — there are no separate `/v1/roles/{id}/permissions` routes in `routes/api.php`.
 

--- a/docs/rbac-architecture.md
+++ b/docs/rbac-architecture.md
@@ -1223,12 +1223,12 @@ $user->hasRole('manager');  // Only checks active roles
 
 SecPal's RBAC API is split across four functional areas:
 
-| API Area                  | Endpoints | Status                  | Documentation |
-| ------------------------- | --------- | ----------------------- | ------------- |
-| **Role Assignment**       | 4         | ✅ Phase 3 Complete     | Issue #5      |
-| **Role Management**       | 7         | ⏳ Phase 4 (Issue #137) | Issue #140    |
-| **Permission Management** | 5         | ⏳ Phase 4 (Issue #138) | Issue #140    |
-| **Direct Permissions**    | 4         | ⏳ Phase 4 (Issue #139) | Issue #140    |
+| API Area                  | Endpoints | Status                   | Documentation |
+| ------------------------- | --------- | ------------------------ | ------------- |
+| **Role Assignment**       | 4         | ✅ Phase 3 complete      | Issue #5      |
+| **Role Management**       | 5         | ✅ Phase 4 shipped       | Issue #137 / Issue #140 |
+| **Permission Management** | 5         | ✅ Phase 4 shipped       | Issue #138 / Issue #140 |
+| **Direct Permissions**    | 4         | ✅ Phase 4 shipped       | Issue #139 / Issue #140 |
 
 ### Role Assignment API (Phase 3)
 
@@ -1245,15 +1245,15 @@ SecPal's RBAC API is split across four functional areas:
 
 ### Role Management API (Phase 4)
 
-| Method   | Endpoint                                  | Description                       |
-| -------- | ----------------------------------------- | --------------------------------- |
-| `GET`    | `/v1/roles`                               | List all roles (system + custom)  |
-| `POST`   | `/v1/roles`                               | Create custom role                |
-| `GET`    | `/v1/roles/{id}`                          | Get role details with permissions |
-| `PATCH`  | `/v1/roles/{id}`                          | Update role (name + permissions)  |
-| `DELETE` | `/v1/roles/{id}`                          | Delete role (if not assigned)     |
-| `POST`   | `/v1/roles/{id}/permissions`              | Assign permissions to role        |
-| `DELETE` | `/v1/roles/{id}/permissions/{permission}` | Remove permission from role       |
+| Method   | Endpoint         | Description                       |
+| -------- | ---------------- | --------------------------------- |
+| `GET`    | `/v1/roles`      | List all roles (system + custom)  |
+| `POST`   | `/v1/roles`      | Create custom role (optional permission list) |
+| `GET`    | `/v1/roles/{id}` | Get role details with permissions |
+| `PATCH`  | `/v1/roles/{id}` | Update role name and/or sync permissions |
+| `DELETE` | `/v1/roles/{id}` | Delete role (if not assigned)     |
+
+Role permission membership is managed through create/update payloads (`permissions` array) and `PATCH /v1/roles/{id}` — there are no separate `/v1/roles/{id}/permissions` routes in `routes/api.php`.
 
 **Authorization:** Requires the corresponding role-management permission (`roles.read`, `roles.create`, `roles.update`, `roles.delete`)
 

--- a/tests/Feature/AuthTest.php
+++ b/tests/Feature/AuthTest.php
@@ -857,7 +857,7 @@ describe('Login Rate Limiting', function () {
         // Clear rate limiter cache between tests
         // RateLimiter::clear('login') doesn't work because it expects full key like 'login:ip|email'
         // Using Cache::flush() ensures clean state for each test
-        Illuminate\Support\Facades\Cache::flush();
+        Cache::flush();
     });
 
     test('token endpoint is rate limited after 5 failed attempts', function () {

--- a/tests/Feature/AuthTest.php
+++ b/tests/Feature/AuthTest.php
@@ -10,6 +10,7 @@ use App\Models\Site;
 use App\Models\User;
 use Illuminate\Auth\Notifications\VerifyEmail;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\URL;
@@ -775,6 +776,47 @@ describe('Email Verification', function () {
             ]);
 
         Notification::assertSentTo($user, VerifyEmail::class);
+    });
+
+    test('verified users receive 200 when resending email verification', function () {
+        $user = User::factory()->create();
+        $token = $user->createToken('test-device')->plainTextToken;
+
+        $this->withHeader('Authorization', "Bearer {$token}")
+            ->postJson('/v1/auth/email/verification-notification')
+            ->assertOk()
+            ->assertJson([
+                'message' => 'Email address is already verified.',
+            ]);
+    });
+
+    test('verification notification requires authentication', function () {
+        $this->postJson('/v1/auth/email/verification-notification')
+            ->assertUnauthorized()
+            ->assertJson([
+                'message' => 'Unauthenticated.',
+            ]);
+    });
+
+    test('verification resend is throttled after six requests per minute', function () {
+        Cache::flush();
+        Notification::fake();
+
+        $user = User::factory()->unverified()->create();
+        $token = $user->createToken('test-device')->plainTextToken;
+
+        for ($i = 0; $i < 6; $i++) {
+            $this->withHeader('Authorization', "Bearer {$token}")
+                ->postJson('/v1/auth/email/verification-notification')
+                ->assertStatus(202);
+        }
+
+        $this->withHeader('Authorization', "Bearer {$token}")
+            ->postJson('/v1/auth/email/verification-notification')
+            ->assertStatus(429)
+            ->assertJson([
+                'message' => 'Too Many Attempts.',
+            ]);
     });
 
     test('signed verification links mark the user email as verified', function () {

--- a/tests/Feature/Controllers/QualificationControllerTest.php
+++ b/tests/Feature/Controllers/QualificationControllerTest.php
@@ -328,6 +328,22 @@ describe('GET /v1/qualifications/{qualification}', function () {
                     'id' => $qualification->id,
                     'name' => 'Test Qualification',
                 ],
+            ])
+            ->assertJsonStructure([
+                'data' => [
+                    'id',
+                    'tenant_id',
+                    'name',
+                    'description',
+                    'category',
+                    'requires_renewal',
+                    'renewal_period_months',
+                    'is_mandatory',
+                    'is_system_qualification',
+                    'sort_order',
+                    'created_at',
+                    'updated_at',
+                ],
             ]);
     });
 
@@ -399,7 +415,8 @@ describe('PATCH /v1/qualifications/{qualification}', function () {
                 'description' => 'Attempt update',
             ]);
 
-        $response->assertStatus(403);
+        $response->assertStatus(403)
+            ->assertJsonStructure(['message']);
     });
 });
 
@@ -450,6 +467,7 @@ describe('DELETE /v1/qualifications/{qualification}', function () {
         $response = $this->withToken($this->token)
             ->deleteJson("/v1/qualifications/{$qualification->id}");
 
-        $response->assertStatus(403);
+        $response->assertStatus(403)
+            ->assertJsonStructure(['message']);
     });
 });


### PR DESCRIPTION
## Summary

Drift cleanup for **SecPal/api**: email verification resend tests (US-003), qualification catalog test assertions (US-005), RBAC documentation corrections (US-007).

## Validation (US-008)

```bash
php artisan test \
  tests/Feature/AuthTest.php \
  tests/Feature/Controllers/EmployeeDocumentControllerTest.php \
  tests/Feature/Controllers/EmployeeQualificationControllerTest.php \
  tests/Feature/Controllers/QualificationControllerTest.php
```

**Result:** 151 tests passed (781 assertions).

## Live VPS (smoke)

Unauthenticated requests to `https://api.secpal.dev/v1/qualifications`, `.../employees/{uuid}/documents`, and `POST .../auth/email/verification-notification` return **401** with `{"message":"Unauthenticated."}`.

Full throttle, multipart, and tenant-scoped flows require credentials — not run here.

## Related

- Org-wide evidence: `SecPal/.github` includes `docs/contract-drift/US-008-validation-and-draft-prs.md` (US-008 PR on this org repo).

## Additional drift (unchanged in this PR)

Frontend types/payloads may still diverge from API field names for qualifications — tracked in US-001 matrix; SPA alignment is separate work.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and test-only changes; no production logic is modified, so risk is low aside from catching previously-untested contract mismatches in CI.
> 
> **Overview**
> **Documentation drift cleanup for RBAC.** Replaces a hard-coded endpoint count with a pointer to `docs/api/rbac-endpoints.md`/`routes/api.php`, marks Phase 4 RBAC areas as shipped, and corrects the Role Management API description to reflect that permission membership is managed via role create/update payloads (no separate role-permission routes).
> 
> **Contract-aligned feature tests.** Expands `AuthTest` coverage for `POST /v1/auth/email/verification-notification` (verified-user response, auth requirement, and throttling), and strengthens `QualificationControllerTest` assertions to validate the full response shape on `GET /v1/qualifications/{id}` and ensure `403` responses include a JSON `message`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c5234d296fe610c8a3d999340c4353511ddb577. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->