### PR TITLE
feat: [US-009] Einladung und Wizard-Inhalte abgleichen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- fixed `OnboardingFormDataSchemaValidationService::isPropertySemanticallyEmpty` treating non-string values (e.g. integers) for `string`-type fields as empty, which previously allowed malformed payloads to bypass JSON Schema validation for optional templates; proved with a new regression test
+
+### Changed
+
+- removed duplicate assertion in `OnboardingControllerTest` consent-field test
+- updated `SPDX-FileCopyrightText` year in `SubmitOnboardingFormRequest`
+
 ### Changed
 
 - renamed the onboarding review and Android provisioning API surfaces from `/v1/admin/...` to neutral `/v1/onboarding-review/...` and `/v1/android-enrollment-sessions...` paths, and corrected HR lifecycle emails to link to the shipped frontend employee detail route under `FRONTEND_URL` instead of the dead `/admin/employees/...` SPA path

--- a/app/Http/Controllers/Api/V1/OnboardingController.php
+++ b/app/Http/Controllers/Api/V1/OnboardingController.php
@@ -489,6 +489,9 @@ class OnboardingController extends Controller
 
         $template = OnboardingFormTemplate::query()
             ->whereKey($validated['form_template_id'])
+            ->where(function ($q) use ($employee): void {
+                $q->whereNull('tenant_id')->orWhere('tenant_id', $employee->tenant_id);
+            })
             ->firstOrFail();
 
         /** @var array<string, mixed> $formData */

--- a/app/Http/Controllers/Api/V1/OnboardingController.php
+++ b/app/Http/Controllers/Api/V1/OnboardingController.php
@@ -502,11 +502,11 @@ class OnboardingController extends Controller
             $status === 'submitted',
         );
 
-        $submission = DB::transaction(function () use ($existing, $validated, $status, $submittedAt, $employee): OnboardingFormSubmission {
+        $submission = DB::transaction(function () use ($existing, $validated, $formData, $status, $submittedAt, $employee): OnboardingFormSubmission {
             if ($existing) {
                 // Update existing draft
                 $existing->update([
-                    'form_data' => $validated['form_data'],
+                    'form_data' => $formData,
                     'status' => $status,
                     'submitted_at' => $submittedAt,
                     'reviewed_by' => $existing->status === 'rejected' ? null : $existing->reviewed_by,
@@ -520,7 +520,7 @@ class OnboardingController extends Controller
                 $created = OnboardingFormSubmission::create([
                     'employee_id' => $employee->id,
                     'form_template_id' => $validated['form_template_id'],
-                    'form_data' => $validated['form_data'],
+                    'form_data' => $formData,
                     'status' => $status,
                     'submitted_at' => $submittedAt,
                 ]);

--- a/app/Http/Controllers/Api/V1/OnboardingController.php
+++ b/app/Http/Controllers/Api/V1/OnboardingController.php
@@ -491,9 +491,11 @@ class OnboardingController extends Controller
             ->whereKey($validated['form_template_id'])
             ->firstOrFail();
 
+        /** @var array<string, mixed> $formData */
+        $formData = (array) ($validated['form_data'] ?? []);
         $this->onboardingFormDataSchemaValidationService->assertMatchesTemplate(
             $template,
-            $validated['form_data'],
+            $formData,
             $status === 'submitted',
         );
 

--- a/app/Http/Controllers/Api/V1/OnboardingController.php
+++ b/app/Http/Controllers/Api/V1/OnboardingController.php
@@ -19,6 +19,7 @@ use App\Models\OnboardingFormSubmission;
 use App\Models\OnboardingFormTemplate;
 use App\Models\OnboardingSubmissionFile;
 use App\Services\OnboardingCompletionService;
+use App\Services\OnboardingFormDataSchemaValidationService;
 use App\Services\OnboardingSchemaLocalizationService;
 use App\Services\OnboardingSubmissionFileStorageService;
 use Illuminate\Http\JsonResponse;
@@ -47,6 +48,7 @@ class OnboardingController extends Controller
     public function __construct(
         private readonly OnboardingSubmissionFileStorageService $submissionFileStorageService,
         private readonly OnboardingSchemaLocalizationService $onboardingSchemaLocalizationService,
+        private readonly OnboardingFormDataSchemaValidationService $onboardingFormDataSchemaValidationService,
     ) {}
 
     /**
@@ -485,6 +487,16 @@ class OnboardingController extends Controller
         $status = $validated['status'] ?? 'submitted';
         $submittedAt = $status === 'submitted' ? now() : null;
 
+        $template = OnboardingFormTemplate::query()
+            ->whereKey($validated['form_template_id'])
+            ->firstOrFail();
+
+        $this->onboardingFormDataSchemaValidationService->assertMatchesTemplate(
+            $template,
+            $validated['form_data'],
+            $status === 'submitted',
+        );
+
         $submission = DB::transaction(function () use ($existing, $validated, $status, $submittedAt, $employee): OnboardingFormSubmission {
             if ($existing) {
                 // Update existing draft
@@ -580,6 +592,26 @@ class OnboardingController extends Controller
             : ($wasRejected ? 'draft' : $submission->status);
         $submittedAt = $status === 'submitted' ? now() : null;
         $shouldResetReview = $wasRejected && $status !== 'rejected';
+
+        $submission->loadMissing('formTemplate');
+        $formTemplate = $submission->formTemplate;
+        if ($formTemplate === null) {
+            return response()->json([
+                'message' => __('Form template not found for this submission'),
+            ], Response::HTTP_NOT_FOUND);
+        }
+
+        /** @var array<string, mixed> $effectiveFormData */
+        $effectiveFormData = $validated['form_data'] ?? $submission->form_data ?? [];
+        if (! is_array($effectiveFormData)) {
+            $effectiveFormData = [];
+        }
+
+        $this->onboardingFormDataSchemaValidationService->assertMatchesTemplate(
+            $formTemplate,
+            $effectiveFormData,
+            $status === 'submitted',
+        );
 
         $submission = DB::transaction(function () use ($employee, $status, $submittedAt, $submission, $validated, $shouldResetReview): OnboardingFormSubmission {
             $submission->update([

--- a/app/Http/Controllers/Api/V1/OnboardingController.php
+++ b/app/Http/Controllers/Api/V1/OnboardingController.php
@@ -618,9 +618,9 @@ class OnboardingController extends Controller
             $status === 'submitted',
         );
 
-        $submission = DB::transaction(function () use ($employee, $status, $submittedAt, $submission, $validated, $shouldResetReview): OnboardingFormSubmission {
+        $submission = DB::transaction(function () use ($employee, $status, $submittedAt, $submission, $effectiveFormData, $shouldResetReview): OnboardingFormSubmission {
             $submission->update([
-                'form_data' => $validated['form_data'] ?? $submission->form_data,
+                'form_data' => $effectiveFormData,
                 'status' => $status,
                 'submitted_at' => $submittedAt,
                 'reviewed_by' => $shouldResetReview ? null : $submission->reviewed_by,

--- a/app/Http/Requests/SubmitOnboardingFormRequest.php
+++ b/app/Http/Requests/SubmitOnboardingFormRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-// SPDX-FileCopyrightText: 2025 SecPal Contributors
+// SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 namespace App\Http\Requests;

--- a/app/Http/Requests/SubmitOnboardingFormRequest.php
+++ b/app/Http/Requests/SubmitOnboardingFormRequest.php
@@ -47,7 +47,7 @@ class SubmitOnboardingFormRequest extends FormRequest
         return [
             'form_template_id.required' => __('Form template is required'),
             'form_template_id.exists' => __('Selected form template does not exist'),
-            'form_data.required' => __('Form data is required'),
+            'form_data.present' => __('Form data is required'),
             'form_data.array' => __('Form data must be an array'),
         ];
     }

--- a/app/Http/Requests/SubmitOnboardingFormRequest.php
+++ b/app/Http/Requests/SubmitOnboardingFormRequest.php
@@ -32,7 +32,7 @@ class SubmitOnboardingFormRequest extends FormRequest
     {
         return [
             'form_template_id' => ['required', 'exists:onboarding_form_templates,id'],
-            'form_data' => ['required', 'array'],
+            'form_data' => ['present', 'array'],
             'status' => ['required', 'in:draft,submitted'],
         ];
     }

--- a/app/Services/BewacherregisterExportService.php
+++ b/app/Services/BewacherregisterExportService.php
@@ -76,16 +76,16 @@ class BewacherregisterExportService
 
         foreach ($this->requiredFieldValues($employee) as $field => $value) {
             if ($this->isMissing($value)) {
-                $errors[] = $field;
+                $errors[] = $this->missingExportFieldMessage($field);
             }
         }
 
         if ($employee->id_document_expiry !== null && $employee->id_document_expiry->lt(today())) {
-            $errors[] = 'id_document_expiry_expired';
+            $errors[] = $this->missingExportFieldMessage('id_document_expiry_expired');
         }
 
         if ($employee->requiresWorkPermit() && ! $employee->hasValidWorkAuthorization()) {
-            $errors[] = 'valid_work_authorization';
+            $errors[] = $this->missingExportFieldMessage('valid_work_authorization');
         }
 
         if ($errors !== []) {
@@ -119,6 +119,13 @@ class BewacherregisterExportService
             'sachkunde_type' => $employee->sachkunde_type,
             'sachkunde_certificate' => $employee->sachkunde_certificate,
         ];
+    }
+
+    private function missingExportFieldMessage(string $field): string
+    {
+        $key = 'bwr_export.missing_fields.'.$field;
+
+        return __($key);
     }
 
     private function isMissing(mixed $value): bool

--- a/app/Services/OnboardingFormDataSchemaValidationService.php
+++ b/app/Services/OnboardingFormDataSchemaValidationService.php
@@ -155,7 +155,7 @@ final class OnboardingFormDataSchemaValidationService
         $type = $property['type'] ?? 'string';
 
         return match ($type) {
-            'string' => (is_string($value) ? trim($value) : '') === '',
+            'string' => $value === null || (is_string($value) && trim($value) === ''),
             'integer', 'number' => $value === null || $value === '',
             'boolean' => $value === null || $value === '',
             'array' => ! is_array($value) || count($value) === 0,

--- a/app/Services/OnboardingFormDataSchemaValidationService.php
+++ b/app/Services/OnboardingFormDataSchemaValidationService.php
@@ -158,7 +158,7 @@ final class OnboardingFormDataSchemaValidationService
             'string' => $value === null || (is_string($value) && trim($value) === ''),
             'integer', 'number' => $value === null || $value === '',
             'boolean' => $value === null || $value === '',
-            'array' => ! is_array($value) || count($value) === 0,
+            'array' => is_array($value) && count($value) === 0,
             default => $value === null || $value === '',
         };
     }

--- a/app/Services/OnboardingFormDataSchemaValidationService.php
+++ b/app/Services/OnboardingFormDataSchemaValidationService.php
@@ -158,7 +158,7 @@ final class OnboardingFormDataSchemaValidationService
             'string' => $value === null || (is_string($value) && trim($value) === ''),
             'integer', 'number' => $value === null || $value === '',
             'boolean' => $value === null || $value === '',
-            'array' => is_array($value) && count($value) === 0,
+            'array' => $value === null || (is_array($value) && count($value) === 0),
             default => $value === null || $value === '',
         };
     }

--- a/app/Services/OnboardingFormDataSchemaValidationService.php
+++ b/app/Services/OnboardingFormDataSchemaValidationService.php
@@ -156,7 +156,7 @@ final class OnboardingFormDataSchemaValidationService
 
         return match ($type) {
             'string' => (is_string($value) ? trim($value) : '') === '',
-            'integer', 'number' => $value === null || $value === '' || ! is_numeric($value),
+            'integer', 'number' => $value === null || $value === '',
             'boolean' => $value === null || $value === '',
             'array' => ! is_array($value) || count($value) === 0,
             default => $value === null || $value === '',

--- a/app/Services/OnboardingFormDataSchemaValidationService.php
+++ b/app/Services/OnboardingFormDataSchemaValidationService.php
@@ -62,12 +62,13 @@ final class OnboardingFormDataSchemaValidationService
      * @param  array<string, mixed>  $schema
      * @param  array<string, mixed>  $formData
      *
-     * @throws JsonException
+     * @throws JsonEncodeException
      */
     private function assertJsonSchemaValid(array $schema, array $formData): void
     {
         $validator = new Validator(null, 100, false);
         $schemaObject = json_decode(json_encode($schema, JSON_THROW_ON_ERROR), false);
+        assert($schemaObject instanceof \stdClass);
 
         $dataObject = $formData === []
             ? new \stdClass
@@ -137,6 +138,7 @@ final class OnboardingFormDataSchemaValidationService
                 continue;
             }
 
+            /** @var array<string, mixed> $property */
             if (! $this->isPropertySemanticallyEmpty($property, $formData[$name] ?? null)) {
                 return false;
             }
@@ -153,7 +155,7 @@ final class OnboardingFormDataSchemaValidationService
         $type = $property['type'] ?? 'string';
 
         return match ($type) {
-            'string' => trim((string) ($value ?? '')) === '',
+            'string' => (is_string($value) ? trim($value) : '') === '',
             'integer', 'number' => $value === null || $value === '' || ! is_numeric($value),
             'boolean' => $value !== true,
             'array' => ! is_array($value) || count($value) === 0,

--- a/app/Services/OnboardingFormDataSchemaValidationService.php
+++ b/app/Services/OnboardingFormDataSchemaValidationService.php
@@ -1,0 +1,163 @@
+<?php
+
+// SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace App\Services;
+
+use App\Models\OnboardingFormTemplate;
+use Illuminate\Validation\ValidationException;
+use JsonException as JsonEncodeException;
+use Opis\JsonSchema\Errors\ErrorFormatter;
+use Opis\JsonSchema\Validator;
+
+/**
+ * Validates onboarding form payloads against the template JSON Schema.
+ *
+ * Runs when the submission status is `submitted`; drafts only receive request-level array validation.
+ */
+final class OnboardingFormDataSchemaValidationService
+{
+    /**
+     * @param  array<string, mixed>  $formData
+     *
+     * @throws ValidationException
+     */
+    public function assertMatchesTemplate(
+        OnboardingFormTemplate $template,
+        array $formData,
+        bool $forSubmittedStatus,
+    ): void {
+        if (! $forSubmittedStatus) {
+            return;
+        }
+
+        $schema = $template->form_schema ?? [];
+        if (! is_array($schema)) {
+            throw ValidationException::withMessages([
+                'form_data' => [__('The form template schema is invalid.')],
+            ]);
+        }
+
+        if (! $template->is_required && $this->isSemanticallyEmpty($schema, $formData)) {
+            return;
+        }
+
+        if (($schema['type'] ?? null) !== 'object') {
+            throw ValidationException::withMessages([
+                'form_data' => [__('The form template schema must declare a JSON object root.')],
+            ]);
+        }
+
+        try {
+            $this->assertJsonSchemaValid($schema, $formData);
+        } catch (JsonEncodeException) {
+            throw ValidationException::withMessages([
+                'form_data' => [__('The submitted form data could not be validated.')],
+            ]);
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $schema
+     * @param  array<string, mixed>  $formData
+     *
+     * @throws JsonException
+     */
+    private function assertJsonSchemaValid(array $schema, array $formData): void
+    {
+        $validator = new Validator(null, 100, false);
+        $schemaObject = json_decode(json_encode($schema, JSON_THROW_ON_ERROR), false);
+
+        $dataObject = $formData === []
+            ? new \stdClass
+            : json_decode(json_encode($formData, JSON_THROW_ON_ERROR), false);
+
+        $result = $validator->validate($dataObject, $schemaObject);
+
+        if ($result->isValid()) {
+            return;
+        }
+
+        $rootError = $result->error();
+        if ($rootError === null) {
+            return;
+        }
+
+        $formatter = new ErrorFormatter;
+
+        /** @var array<string, array<int, string>> $keyed */
+        $keyed = $formatter->formatKeyed($rootError);
+
+        $messages = [];
+        foreach ($keyed as $pointer => $msgs) {
+            $field = $this->jsonPointerToFieldKey($pointer);
+            $messages[$field] ??= [];
+            foreach ($msgs as $msg) {
+                $messages[$field][] = $msg;
+            }
+        }
+
+        throw ValidationException::withMessages($messages);
+    }
+
+    private function jsonPointerToFieldKey(string $pointer): string
+    {
+        $trimmed = trim($pointer, '/');
+        if ($trimmed === '') {
+            return 'form_data';
+        }
+
+        $parts = explode('/', $trimmed);
+
+        return $parts[0] ?? 'form_data';
+    }
+
+    /**
+     * Mirrors optional-step semantics in the onboarding wizard: if every schema field is empty,
+     * we do not enforce JSON Schema {@code required} / patterns so optional templates can be
+     * submitted with an empty payload (same as “all fields empty” on the client).
+     *
+     * @param  array<string, mixed>  $schema
+     * @param  array<string, mixed>  $formData
+     */
+    private function isSemanticallyEmpty(array $schema, array $formData): bool
+    {
+        if (($schema['type'] ?? null) !== 'object') {
+            return $formData === [];
+        }
+
+        $properties = $schema['properties'] ?? [];
+        if (! is_array($properties)) {
+            return $formData === [];
+        }
+
+        foreach ($properties as $name => $property) {
+            if (! is_array($property)) {
+                continue;
+            }
+
+            if (! $this->isPropertySemanticallyEmpty($property, $formData[$name] ?? null)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  array<string, mixed>  $property
+     */
+    private function isPropertySemanticallyEmpty(array $property, mixed $value): bool
+    {
+        $type = $property['type'] ?? 'string';
+
+        return match ($type) {
+            'string' => trim((string) ($value ?? '')) === '',
+            'integer', 'number' => $value === null || $value === '' || ! is_numeric($value),
+            'boolean' => $value !== true,
+            'array' => ! is_array($value) || count($value) === 0,
+            default => $value === null || $value === '',
+        };
+    }
+}

--- a/app/Services/OnboardingFormDataSchemaValidationService.php
+++ b/app/Services/OnboardingFormDataSchemaValidationService.php
@@ -157,7 +157,7 @@ final class OnboardingFormDataSchemaValidationService
         return match ($type) {
             'string' => (is_string($value) ? trim($value) : '') === '',
             'integer', 'number' => $value === null || $value === '' || ! is_numeric($value),
-            'boolean' => $value !== true,
+            'boolean' => $value === null || $value === '',
             'array' => ! is_array($value) || count($value) === 0,
             default => $value === null || $value === '',
         };

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     "laravel/framework": "^13.6",
     "laravel/sanctum": "^4.3",
     "laravel/tinker": "^3.0",
+    "opis/json-schema": "^2.4",
     "spatie/laravel-activitylog": "^5.0",
     "spatie/laravel-permission": "^7.4",
     "web-auth/webauthn-lib": "^5.2"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e9d8d7f9465074fc7d8f7707027c9e69",
+    "content-hash": "4037636747b34f5106776ea85be0feac",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -3024,6 +3024,196 @@
                 }
             ],
             "time": "2026-02-16T23:10:27+00:00"
+        },
+        {
+            "name": "opis/json-schema",
+            "version": "2.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/opis/json-schema.git",
+                "reference": "8458763e0dd0b6baa310e04f1829fc73da4e8c8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/opis/json-schema/zipball/8458763e0dd0b6baa310e04f1829fc73da4e8c8a",
+                "reference": "8458763e0dd0b6baa310e04f1829fc73da4e8c8a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "opis/string": "^2.1",
+                "opis/uri": "^1.0",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "ext-bcmath": "*",
+                "ext-intl": "*",
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Opis\\JsonSchema\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Sorin Sarca",
+                    "email": "sarca_sorin@hotmail.com"
+                },
+                {
+                    "name": "Marius Sarca",
+                    "email": "marius.sarca@gmail.com"
+                }
+            ],
+            "description": "Json Schema Validator for PHP",
+            "homepage": "https://opis.io/json-schema",
+            "keywords": [
+                "json",
+                "json-schema",
+                "schema",
+                "validation",
+                "validator"
+            ],
+            "support": {
+                "issues": "https://github.com/opis/json-schema/issues",
+                "source": "https://github.com/opis/json-schema/tree/2.6.0"
+            },
+            "time": "2025-10-17T12:46:48+00:00"
+        },
+        {
+            "name": "opis/string",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/opis/string.git",
+                "reference": "3e4d2aaff518ac518530b89bb26ed40f4503635e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/opis/string/zipball/3e4d2aaff518ac518530b89bb26ed40f4503635e",
+                "reference": "3e4d2aaff518ac518530b89bb26ed40f4503635e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "ext-json": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Opis\\String\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Marius Sarca",
+                    "email": "marius.sarca@gmail.com"
+                },
+                {
+                    "name": "Sorin Sarca",
+                    "email": "sarca_sorin@hotmail.com"
+                }
+            ],
+            "description": "Multibyte strings as objects",
+            "homepage": "https://opis.io/string",
+            "keywords": [
+                "multi-byte",
+                "opis",
+                "string",
+                "string manipulation",
+                "utf-8"
+            ],
+            "support": {
+                "issues": "https://github.com/opis/string/issues",
+                "source": "https://github.com/opis/string/tree/2.1.0"
+            },
+            "time": "2025-10-17T12:38:41+00:00"
+        },
+        {
+            "name": "opis/uri",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/opis/uri.git",
+                "reference": "0f3ca49ab1a5e4a6681c286e0b2cc081b93a7d5a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/opis/uri/zipball/0f3ca49ab1a5e4a6681c286e0b2cc081b93a7d5a",
+                "reference": "0f3ca49ab1a5e4a6681c286e0b2cc081b93a7d5a",
+                "shasum": ""
+            },
+            "require": {
+                "opis/string": "^2.0",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Opis\\Uri\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Marius Sarca",
+                    "email": "marius.sarca@gmail.com"
+                },
+                {
+                    "name": "Sorin Sarca",
+                    "email": "sarca_sorin@hotmail.com"
+                }
+            ],
+            "description": "Build, parse and validate URIs and URI-templates",
+            "homepage": "https://opis.io",
+            "keywords": [
+                "URI Template",
+                "parse url",
+                "punycode",
+                "uri",
+                "uri components",
+                "url",
+                "validate uri"
+            ],
+            "support": {
+                "issues": "https://github.com/opis/uri/issues",
+                "source": "https://github.com/opis/uri/tree/1.1.0"
+            },
+            "time": "2021-05-22T15:57:08+00:00"
         },
         {
             "name": "paragonie/constant_time_encoding",
@@ -11569,5 +11759,5 @@
         "php": "^8.4"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/database/factories/OnboardingFormTemplateFactory.php
+++ b/database/factories/OnboardingFormTemplateFactory.php
@@ -26,20 +26,13 @@ class OnboardingFormTemplateFactory extends Factory
             'template_key' => null,
             'description' => fake()->sentence(),
             'form_schema' => [
-                'fields' => [
-                    [
-                        'name' => 'field_1',
-                        'type' => 'text',
-                        'label' => fake()->words(3, true),
-                        'required' => true,
-                    ],
-                    [
-                        'name' => 'field_2',
-                        'type' => 'textarea',
-                        'label' => fake()->words(3, true),
-                        'required' => false,
-                    ],
+                'type' => 'object',
+                'properties' => [
+                    'name' => ['type' => 'string'],
+                    'email' => ['type' => 'string'],
+                    'field' => ['type' => 'string'],
                 ],
+                'additionalProperties' => true,
             ],
             'is_required' => fake()->boolean(70),
             'is_system_template' => false,

--- a/database/seeders/OnboardingFormTemplatesSeeder.php
+++ b/database/seeders/OnboardingFormTemplatesSeeder.php
@@ -230,7 +230,7 @@ class OnboardingFormTemplatesSeeder extends Seeder
                     ],
                 ],
             ],
-            'required' => [],
+            'required' => ['contact_1_name', 'contact_1_phone', 'contact_1_relationship'],
         ];
     }
 
@@ -257,7 +257,7 @@ class OnboardingFormTemplatesSeeder extends Seeder
                     'minimum' => 0,
                 ],
             ],
-            'required' => [],
+            'required' => ['tax_id', 'tax_class'],
         ];
     }
 }

--- a/database/seeders/OnboardingFormTemplatesSeeder.php
+++ b/database/seeders/OnboardingFormTemplatesSeeder.php
@@ -19,7 +19,7 @@ class OnboardingFormTemplatesSeeder extends Seeder
             [
                 'name' => 'Personal Information Form',
                 'template_key' => 'personal_information_form',
-                'description' => 'BewachV § 16 required information for Bewacherregister',
+                'description' => 'Your personal details for onboarding; HR may need to complete additional Bewacherregister fields before export.',
                 'form_schema' => $this->getPersonalInformationSchema(),
                 'is_required' => true,
                 'is_system_template' => true,
@@ -80,7 +80,7 @@ class OnboardingFormTemplatesSeeder extends Seeder
     {
         return [
             'title' => 'Personal Information Form',
-            'description' => 'BewachV § 16 required information',
+            'description' => 'Information required for onboarding; planned activities under §34a GewO can be completed later by HR for Bewacherregister export.',
             'type' => 'object',
             'properties' => [
                 'gender' => [
@@ -113,6 +113,7 @@ class OnboardingFormTemplatesSeeder extends Seeder
                 'intended_activities' => [
                     'type' => 'array',
                     'title' => 'Intended Activities (§ 34a GewO)',
+                    'description' => 'Optional during onboarding; HR must align this with the assignment before Bewacherregister export if you skip it.',
                     'items' => [
                         'type' => 'string',
                         'enum' => [
@@ -125,10 +126,9 @@ class OnboardingFormTemplatesSeeder extends Seeder
                             'personal_protection',
                         ],
                     ],
-                    'minItems' => 1,
                 ],
             ],
-            'required' => ['gender', 'nationalities', 'intended_activities'],
+            'required' => ['gender', 'nationalities'],
         ];
     }
 

--- a/database/seeders/OnboardingFormTemplatesSeeder.php
+++ b/database/seeders/OnboardingFormTemplatesSeeder.php
@@ -230,7 +230,7 @@ class OnboardingFormTemplatesSeeder extends Seeder
                     ],
                 ],
             ],
-            'required' => ['contact_1_name', 'contact_1_phone', 'contact_1_relationship'],
+            'required' => [],
         ];
     }
 
@@ -257,7 +257,7 @@ class OnboardingFormTemplatesSeeder extends Seeder
                     'minimum' => 0,
                 ],
             ],
-            'required' => ['tax_id', 'tax_class'],
+            'required' => [],
         ];
     }
 }

--- a/database/seeders/OnboardingFormTemplatesSeeder.php
+++ b/database/seeders/OnboardingFormTemplatesSeeder.php
@@ -49,7 +49,7 @@ class OnboardingFormTemplatesSeeder extends Seeder
             [
                 'name' => 'Tax Identification Number',
                 'template_key' => 'tax_identification_number',
-                'description' => 'Tax ID and tax class information (§ 39e EStG)',
+                'description' => 'Optional eleven-digit tax identification number (§ 39e EStG)',
                 'form_schema' => $this->getTaxIdentificationSchema(),
                 'is_required' => false,
                 'is_system_template' => true,

--- a/database/seeders/OnboardingFormTemplatesSeeder.php
+++ b/database/seeders/OnboardingFormTemplatesSeeder.php
@@ -230,7 +230,7 @@ class OnboardingFormTemplatesSeeder extends Seeder
                     ],
                 ],
             ],
-            'required' => ['contact_1_name', 'contact_1_phone', 'contact_1_relationship'],
+            'required' => [],
         ];
     }
 
@@ -257,7 +257,7 @@ class OnboardingFormTemplatesSeeder extends Seeder
                     'minimum' => 0,
                 ],
             ],
-            'required' => ['tax_id'],
+            'required' => [],
         ];
     }
 }

--- a/database/seeders/OnboardingFormTemplatesSeeder.php
+++ b/database/seeders/OnboardingFormTemplatesSeeder.php
@@ -230,7 +230,7 @@ class OnboardingFormTemplatesSeeder extends Seeder
                     ],
                 ],
             ],
-            'required' => [],
+            'required' => ['contact_1_name', 'contact_1_phone', 'contact_1_relationship'],
         ];
     }
 
@@ -257,7 +257,7 @@ class OnboardingFormTemplatesSeeder extends Seeder
                     'minimum' => 0,
                 ],
             ],
-            'required' => [],
+            'required' => ['tax_id'],
         ];
     }
 }

--- a/database/seeders/OnboardingFormTemplatesSeeder.php
+++ b/database/seeders/OnboardingFormTemplatesSeeder.php
@@ -243,7 +243,7 @@ class OnboardingFormTemplatesSeeder extends Seeder
     {
         return [
             'title' => 'Tax Identification Number',
-            'description' => 'Tax ID and tax class information (§ 39e EStG)',
+            'description' => 'Optional eleven-digit tax identification number (§ 39e EStG)',
             'type' => 'object',
             'properties' => [
                 'tax_id' => [
@@ -251,18 +251,13 @@ class OnboardingFormTemplatesSeeder extends Seeder
                     'title' => 'Tax Identification Number',
                     'pattern' => '^\d{11}$',
                 ],
-                'tax_class' => [
-                    'type' => 'integer',
-                    'title' => 'Tax Class',
-                    'enum' => [1, 2, 3, 4, 5, 6],
-                ],
                 'children_count' => [
                     'type' => 'integer',
                     'title' => 'Number of Children',
                     'minimum' => 0,
                 ],
             ],
-            'required' => ['tax_id', 'tax_class'],
+            'required' => [],
         ];
     }
 }

--- a/database/seeders/OnboardingFormTemplatesSeeder.php
+++ b/database/seeders/OnboardingFormTemplatesSeeder.php
@@ -39,7 +39,7 @@ class OnboardingFormTemplatesSeeder extends Seeder
             [
                 'name' => 'Emergency Contact',
                 'template_key' => 'emergency_contact',
-                'description' => 'Emergency contact persons',
+                'description' => 'Optional emergency contact persons',
                 'form_schema' => $this->getEmergencyContactSchema(),
                 'is_required' => false,
                 'is_system_template' => true,
@@ -180,7 +180,7 @@ class OnboardingFormTemplatesSeeder extends Seeder
     {
         return [
             'title' => 'Emergency Contact',
-            'description' => 'Emergency contact persons',
+            'description' => 'Optional emergency contact persons',
             'type' => 'object',
             'properties' => [
                 'contact_1_name' => [
@@ -230,7 +230,7 @@ class OnboardingFormTemplatesSeeder extends Seeder
                     ],
                 ],
             ],
-            'required' => ['contact_1_name', 'contact_1_phone', 'contact_1_relationship'],
+            'required' => [],
         ];
     }
 

--- a/lang/de/LC_MESSAGES/messages.po
+++ b/lang/de/LC_MESSAGES/messages.po
@@ -765,27 +765,39 @@ msgstr "Onboarding starten"
 msgid "What to expect:"
 msgstr "Was Sie erwartet:"
 
-#: /resources/views/emails/employees/onboarding-invitation.blade.php:55
-msgid "Complete personal information form"
-msgstr "Persönliches Informationsformular ausfüllen"
+#: /resources/views/emails/employees/onboarding-invitation.blade.php:54
+msgid "Required information"
+msgstr "Erforderliche Angaben"
 
-#: /resources/views/emails/employees/onboarding-invitation.blade.php:57
-msgid "Provide bank account details"
-msgstr "Ihre Bankverbindung angeben"
+#: /resources/views/emails/employees/onboarding-invitation.blade.php:56
+msgid "Personal information for onboarding (including gender and nationalities)"
+msgstr "Persönliche Angaben zum Onboarding (u. a. Geschlecht und Staatsangehörigkeiten)"
 
 #: /resources/views/emails/employees/onboarding-invitation.blade.php:59
-msgid "Add emergency contact"
-msgstr "Notfallkontakt hinzufügen"
+msgid "Optional sections"
+msgstr "Optionale Abschnitte"
 
 #: /resources/views/emails/employees/onboarding-invitation.blade.php:61
-msgid "Digitally sign employment contract"
-msgstr "Arbeitsvertrag digital unterzeichnen"
+msgid "Bank account details for salary payment"
+msgstr "Bankverbindung für die Gehaltszahlung"
+
+#: /resources/views/emails/employees/onboarding-invitation.blade.php:62
+msgid "Emergency contacts"
+msgstr "Notfallkontakte"
 
 #: /resources/views/emails/employees/onboarding-invitation.blade.php:63
-msgid "Upload certificates (if applicable)"
-msgstr "Zertifikate hochladen (falls zutreffend)"
+msgid "Tax identification number (Steuer-ID)"
+msgstr "Steuerliche Identifikationsnummer (Steuer-ID)"
 
 #: /resources/views/emails/employees/onboarding-invitation.blade.php:66
+msgid "Supporting documents"
+msgstr "Belege und Nachweise"
+
+#: /resources/views/emails/employees/onboarding-invitation.blade.php:68
+msgid "On every onboarding step you can upload PDF, JPG, or PNG files up to 10 MB — choose contract, identity document, or banking verification as appropriate."
+msgstr "In jedem Onboarding-Schritt können Sie PDF-, JPG- oder PNG-Dateien bis 10 MB hochladen — wählen Sie je nach Datei die Kategorie Vertrag, Ausweisdokument oder Banknachweis."
+
+#: /resources/views/emails/employees/onboarding-invitation.blade.php:74
 msgid "**Important:** Please complete the onboarding by **:deadline** at the latest."
 msgstr "**Wichtig:** Bitte schließen Sie das Onboarding spätestens bis **:deadline** ab."
 

--- a/lang/de/bwr_export.php
+++ b/lang/de/bwr_export.php
@@ -1,0 +1,30 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+return [
+    'missing_fields' => [
+        'first_name' => 'Der Vorname muss im Mitarbeiterprofil gesetzt sein.',
+        'last_name' => 'Der Nachname muss im Mitarbeiterprofil gesetzt sein.',
+        'date_of_birth' => 'Das Geburtsdatum muss im Mitarbeiterprofil gesetzt sein.',
+        'gender' => 'Das Geschlecht muss im Mitarbeiterprofil gesetzt sein.',
+        'birth_city' => 'Der Geburtsort (Ort) muss im Mitarbeiterprofil gesetzt sein.',
+        'birth_country' => 'Das Geburtsland muss im Mitarbeiterprofil gesetzt sein.',
+        'nationalities' => 'Die Staatsangehörigkeiten müssen im Mitarbeiterprofil gesetzt sein.',
+        'address_street' => 'Die Straße in der Adresse des Mitarbeiters muss gesetzt sein.',
+        'address_house_number' => 'Die Hausnummer in der Adresse des Mitarbeiters muss gesetzt sein.',
+        'address_postal_code' => 'Die Postleitzahl in der Adresse des Mitarbeiters muss gesetzt sein.',
+        'address_city' => 'Der Ort in der Adresse des Mitarbeiters muss gesetzt sein.',
+        'address_country' => 'Das Land in der Adresse des Mitarbeiters muss gesetzt sein.',
+        'address_history' => 'Die Ansässigkeitshistorie ist für den Export erforderlich (frühere Adressen im Mitarbeiterprofil eintragen).',
+        'intended_activities' => 'Die geplanten Tätigkeiten nach §34a GewO müssen vor dem Export im Mitarbeiterprofil gesetzt sein (bei Bedarf durch HR, falls nicht beim Onboarding erfasst).',
+        'id_document_type' => 'Die Ausweisart muss im Mitarbeiterprofil gesetzt sein.',
+        'id_document_number' => 'Die Ausweisnummer muss im Mitarbeiterprofil gesetzt sein.',
+        'id_document_expiry' => 'Das Ablaufdatum des Ausweises muss im Mitarbeiterprofil gesetzt sein.',
+        'sachkunde_type' => 'Die Sachkunde / Eingruppierung (§34a) muss vor dem Export gesetzt sein.',
+        'sachkunde_certificate' => 'Der Nachweis / das Sachkunde-Zertifikat muss vor dem Export gesetzt sein.',
+        'id_document_expiry_expired' => 'Der Ausweis ist abgelaufen — bitte das Ablaufdatum vor dem Export aktualisieren.',
+        'valid_work_authorization' => 'Für diese Staatsangehörigkeit ist eine gültige Arbeitserlaubnis vor dem Export erforderlich.',
+    ],
+];

--- a/lang/de/onboarding_schemas.php
+++ b/lang/de/onboarding_schemas.php
@@ -92,14 +92,13 @@ return [
         ],
         'tax_identification_number' => [
             'name' => 'Steueridentifikationsnummer',
-            'description' => 'Steuer-ID und Steuerklasseninformationen (Paragraf 39e EStG)',
+            'description' => 'Optionale elfstellige Steueridentifikationsnummer (§ 39e EStG)',
             'schema' => [
                 'title' => 'Steueridentifikationsnummer',
-                'description' => 'Steuer-ID und Steuerklasseninformationen (Paragraf 39e EStG)',
+                'description' => 'Optionale elfstellige Steueridentifikationsnummer (§ 39e EStG)',
             ],
             'fields' => [
                 'tax_id' => ['title' => 'Steueridentifikationsnummer'],
-                'tax_class' => ['title' => 'Steuerklasse'],
                 'children_count' => ['title' => 'Anzahl Kinder'],
             ],
         ],

--- a/lang/de/onboarding_schemas.php
+++ b/lang/de/onboarding_schemas.php
@@ -54,10 +54,10 @@ return [
         ],
         'emergency_contact' => [
             'name' => 'Notfallkontakt',
-            'description' => 'Ansprechpartner für Notfälle',
+            'description' => 'Optionale Angaben zu Notfallkontakten',
             'schema' => [
                 'title' => 'Notfallkontakt',
-                'description' => 'Ansprechpartner für Notfälle',
+                'description' => 'Optionale Angaben zu Notfallkontakten',
             ],
             'fields' => [
                 'contact_1_name' => ['title' => 'Kontakt 1: Name'],

--- a/lang/de/onboarding_schemas.php
+++ b/lang/de/onboarding_schemas.php
@@ -7,10 +7,10 @@ return [
     'templates' => [
         'personal_information_form' => [
             'name' => 'Persönliche Informationen',
-            'description' => 'BewachV Paragraf 16 erforderliche Informationen für das Bewacherregister',
+            'description' => 'Ihre persönlichen Angaben für das Onboarding; fehlende Bewacherregister-Felder kann die Personalabteilung später ergänzen.',
             'schema' => [
                 'title' => 'Persönliche Informationen',
-                'description' => 'BewachV Paragraf 16 erforderliche Informationen',
+                'description' => 'Für das Onboarding erforderliche Angaben; geplante Tätigkeiten nach Paragraf 34a GewO können bei Bedarf später durch HR für den Bewacherregister-Export ergänzt werden.',
             ],
             'fields' => [
                 'gender' => [
@@ -26,6 +26,7 @@ return [
                 'nationalities' => ['title' => 'Staatsangehörigkeiten'],
                 'intended_activities' => [
                     'title' => 'Beabsichtigte Tätigkeiten (Paragraf 34a GewO)',
+                    'description' => 'Beim Onboarding optional; vor dem Bewacherregister-Export müssen HR diese mit dem Einsatz abstimmen oder eintragen, falls Sie sie auslassen.',
                     'enum' => [
                         'door_control' => 'Einlasskontrolle',
                         'event_security' => 'Veranstaltungsschutz',

--- a/lang/en/LC_MESSAGES/messages.po
+++ b/lang/en/LC_MESSAGES/messages.po
@@ -765,27 +765,39 @@ msgstr "Start Onboarding"
 msgid "What to expect:"
 msgstr "What to expect:"
 
-#: /resources/views/emails/employees/onboarding-invitation.blade.php:55
-msgid "Complete personal information form"
-msgstr "Complete personal information form"
+#: /resources/views/emails/employees/onboarding-invitation.blade.php:54
+msgid "Required information"
+msgstr "Required information"
 
-#: /resources/views/emails/employees/onboarding-invitation.blade.php:57
-msgid "Provide bank account details"
-msgstr "Provide bank account details"
+#: /resources/views/emails/employees/onboarding-invitation.blade.php:56
+msgid "Personal information for onboarding (including gender and nationalities)"
+msgstr "Personal information for onboarding (including gender and nationalities)"
 
 #: /resources/views/emails/employees/onboarding-invitation.blade.php:59
-msgid "Add emergency contact"
-msgstr "Add emergency contact"
+msgid "Optional sections"
+msgstr "Optional sections"
 
 #: /resources/views/emails/employees/onboarding-invitation.blade.php:61
-msgid "Digitally sign employment contract"
-msgstr "Digitally sign employment contract"
+msgid "Bank account details for salary payment"
+msgstr "Bank account details for salary payment"
+
+#: /resources/views/emails/employees/onboarding-invitation.blade.php:62
+msgid "Emergency contacts"
+msgstr "Emergency contacts"
 
 #: /resources/views/emails/employees/onboarding-invitation.blade.php:63
-msgid "Upload certificates (if applicable)"
-msgstr "Upload certificates (if applicable)"
+msgid "Tax identification number (Steuer-ID)"
+msgstr "Tax identification number (Steuer-ID)"
 
 #: /resources/views/emails/employees/onboarding-invitation.blade.php:66
+msgid "Supporting documents"
+msgstr "Supporting documents"
+
+#: /resources/views/emails/employees/onboarding-invitation.blade.php:68
+msgid "On every onboarding step you can upload PDF, JPG, or PNG files up to 10 MB — choose contract, identity document, or banking verification as appropriate."
+msgstr "On every onboarding step you can upload PDF, JPG, or PNG files up to 10 MB — choose contract, identity document, or banking verification as appropriate."
+
+#: /resources/views/emails/employees/onboarding-invitation.blade.php:74
 msgid "**Important:** Please complete the onboarding by **:deadline** at the latest."
 msgstr "**Important:** Please complete the onboarding by **:deadline** at the latest."
 

--- a/lang/en/bwr_export.php
+++ b/lang/en/bwr_export.php
@@ -1,0 +1,30 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+return [
+    'missing_fields' => [
+        'first_name' => 'First name must be set on the employee record.',
+        'last_name' => 'Last name must be set on the employee record.',
+        'date_of_birth' => 'Date of birth must be set on the employee record.',
+        'gender' => 'Gender must be set on the employee record.',
+        'birth_city' => 'Place of birth (city) must be set on the employee record.',
+        'birth_country' => 'Place of birth (country) must be set on the employee record.',
+        'nationalities' => 'Nationalities must be set on the employee record.',
+        'address_street' => 'Street must be set in the employee address.',
+        'address_house_number' => 'House number must be set in the employee address.',
+        'address_postal_code' => 'Postal code must be set in the employee address.',
+        'address_city' => 'City must be set in the employee address.',
+        'address_country' => 'Country must be set in the employee address.',
+        'address_history' => 'Address history is required for export (add past addresses in the employee profile).',
+        'intended_activities' => 'Planned activities under Section 34a GewO must be set on the employee before export (typically by HR if not collected during onboarding).',
+        'id_document_type' => 'ID document type must be set on the employee record.',
+        'id_document_number' => 'ID document number must be set on the employee record.',
+        'id_document_expiry' => 'ID document expiry date must be set on the employee record.',
+        'sachkunde_type' => 'Qualification type (Sachkunde / §34a classification) must be set before export.',
+        'sachkunde_certificate' => 'Qualification certificate reference must be set before export.',
+        'id_document_expiry_expired' => 'ID document has expired; update the expiry date before export.',
+        'valid_work_authorization' => 'Valid work authorization is required for this nationality before export.',
+    ],
+];

--- a/lang/en/onboarding_schemas.php
+++ b/lang/en/onboarding_schemas.php
@@ -54,10 +54,10 @@ return [
         ],
         'emergency_contact' => [
             'name' => 'Emergency Contact',
-            'description' => 'Emergency contact persons',
+            'description' => 'Optional emergency contact persons',
             'schema' => [
                 'title' => 'Emergency Contact',
-                'description' => 'Emergency contact persons',
+                'description' => 'Optional emergency contact persons',
             ],
             'fields' => [
                 'contact_1_name' => ['title' => 'Contact 1: Name'],

--- a/lang/en/onboarding_schemas.php
+++ b/lang/en/onboarding_schemas.php
@@ -7,10 +7,10 @@ return [
     'templates' => [
         'personal_information_form' => [
             'name' => 'Personal Information Form',
-            'description' => 'BewachV Paragraf 16 required information for Bewacherregister',
+            'description' => 'Your personal details for onboarding; HR may complete further Bewacherregister fields later.',
             'schema' => [
                 'title' => 'Personal Information',
-                'description' => 'BewachV Paragraf 16 required information',
+                'description' => 'Information required for onboarding; planned activities under Section 34a GewO can be completed later by HR for Bewacherregister export.',
             ],
             'fields' => [
                 'gender' => [
@@ -26,6 +26,7 @@ return [
                 'nationalities' => ['title' => 'Nationalities'],
                 'intended_activities' => [
                     'title' => 'Intended Activities (Section 34a GewO)',
+                    'description' => 'Optional during onboarding; HR must confirm or enter these before Bewacherregister export if you skip them.',
                     'enum' => [
                         'door_control' => 'Door control',
                         'event_security' => 'Event security',

--- a/lang/en/onboarding_schemas.php
+++ b/lang/en/onboarding_schemas.php
@@ -92,14 +92,13 @@ return [
         ],
         'tax_identification_number' => [
             'name' => 'Tax Identification Number',
-            'description' => 'Tax ID and tax class information (Section 39e EStG)',
+            'description' => 'Optional eleven-digit tax identification number (Section 39e EStG)',
             'schema' => [
                 'title' => 'Tax Identification Number',
-                'description' => 'Tax ID and tax class information (Section 39e EStG)',
+                'description' => 'Optional eleven-digit tax identification number (Section 39e EStG)',
             ],
             'fields' => [
                 'tax_id' => ['title' => 'Tax Identification Number'],
-                'tax_class' => ['title' => 'Tax Class'],
                 'children_count' => ['title' => 'Number of Children'],
             ],
         ],

--- a/resources/views/emails/employees/onboarding-invitation.blade.php
+++ b/resources/views/emails/employees/onboarding-invitation.blade.php
@@ -18,11 +18,19 @@
 
 ## {{ __('What to expect:') }}
 
-- {{ __('Complete personal information form') }}
-- {{ __('Provide bank account details') }}
-- {{ __('Add emergency contact') }}
-- {{ __('Digitally sign employment contract') }}
-- {{ __('Upload certificates (if applicable)') }}
+### {{ __('Required information') }}
+
+- {{ __('Personal information for onboarding (including gender and nationalities)') }}
+
+### {{ __('Optional sections') }}
+
+- {{ __('Bank account details for salary payment') }}
+- {{ __('Emergency contacts') }}
+- {{ __('Tax identification number (Steuer-ID)') }}
+
+### {{ __('Supporting documents') }}
+
+- {{ __('On every onboarding step you can upload PDF, JPG, or PNG files up to 10 MB — choose contract, identity document, or banking verification as appropriate.') }}
 
 {{ __('**Important:** Please complete the onboarding by **:deadline** at the latest.', ['deadline' => $employee->contract_start_date->copy()->subDays(3)->format('d.m.Y')]) }}
 

--- a/tests/Feature/Controllers/EmployeeControllerTest.php
+++ b/tests/Feature/Controllers/EmployeeControllerTest.php
@@ -1424,7 +1424,7 @@ describe('POST /v1/employees/{employee}/bwr/export', function (): void {
         $response->assertStatus(422)
             ->assertJsonPath('message', 'Employee is not ready for BWR export.');
 
-        expect($response->json('errors'))->toContain('gender')
+        expect($response->json('errors'))->toContain(__('bwr_export.missing_fields.gender'))
             ->and($employee->fresh()->bwr_status)->toBe('not_registered');
     });
 

--- a/tests/Feature/Controllers/OnboardingControllerTest.php
+++ b/tests/Feature/Controllers/OnboardingControllerTest.php
@@ -481,6 +481,91 @@ describe('POST /v1/onboarding/submissions', function () {
             ->assertJson(['message' => 'Form has already been submitted and is awaiting review']);
         expect(OnboardingFormSubmission::where('employee_id', $this->employee->id)->count())->toBe(1);
     });
+
+    test('returns 422 with field errors when submitted data does not match the template JSON schema', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.write');
+
+        $template = OnboardingFormTemplate::factory()->create([
+            'tenant_id' => $this->tenant->id,
+            'is_required' => true,
+            'form_schema' => [
+                'type' => 'object',
+                'properties' => [
+                    'iban' => [
+                        'type' => 'string',
+                        'pattern' => '^[A-Z]{2}\d{2}[A-Z0-9]+$',
+                    ],
+                ],
+                'required' => ['iban'],
+            ],
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->postJson('/v1/onboarding/submissions', [
+                'form_template_id' => $template->id,
+                'form_data' => ['iban' => 'not-an-iban'],
+                'status' => 'submitted',
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['iban']);
+    });
+
+    test('allows draft saves even when data would fail JSON schema on submit', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.write');
+
+        $template = OnboardingFormTemplate::factory()->create([
+            'tenant_id' => $this->tenant->id,
+            'form_schema' => [
+                'type' => 'object',
+                'properties' => [
+                    'iban' => [
+                        'type' => 'string',
+                        'pattern' => '^[A-Z]{2}\d{2}[A-Z0-9]+$',
+                    ],
+                ],
+                'required' => ['iban'],
+            ],
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->postJson('/v1/onboarding/submissions', [
+                'form_template_id' => $template->id,
+                'form_data' => ['iban' => 'bad'],
+                'status' => 'draft',
+            ]);
+
+        $response->assertCreated()
+            ->assertJsonPath('data.status', 'draft');
+    });
+
+    test('skips full schema enforcement for optional templates with semantically empty payloads on submit', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.write');
+
+        $template = OnboardingFormTemplate::factory()->optional()->create([
+            'tenant_id' => $this->tenant->id,
+            'form_schema' => [
+                'type' => 'object',
+                'properties' => [
+                    'iban' => [
+                        'type' => 'string',
+                        'pattern' => '^[A-Z]{2}\d{2}[A-Z0-9]+$',
+                    ],
+                ],
+                'required' => ['iban'],
+            ],
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->postJson('/v1/onboarding/submissions', [
+                'form_template_id' => $template->id,
+                'form_data' => [],
+                'status' => 'submitted',
+            ]);
+
+        $response->assertCreated()
+            ->assertJsonPath('data.status', 'submitted');
+    });
 });
 
 describe('PATCH /v1/onboarding/submissions/{submission}', function () {

--- a/tests/Feature/Controllers/OnboardingControllerTest.php
+++ b/tests/Feature/Controllers/OnboardingControllerTest.php
@@ -702,6 +702,36 @@ describe('POST /v1/onboarding/submissions', function () {
 
         $response->assertStatus(422);
     });
+
+    test('does not treat a non-array value for an array-type field as semantically empty on submit', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.write');
+
+        $template = OnboardingFormTemplate::factory()->optional()->create([
+            'tenant_id' => $this->tenant->id,
+            'form_schema' => [
+                'type' => 'object',
+                'properties' => [
+                    'nationalities' => [
+                        'type' => 'array',
+                        'items' => ['type' => 'string'],
+                        'minItems' => 1,
+                    ],
+                ],
+                'required' => ['nationalities'],
+            ],
+        ]);
+
+        // 'DE' is not a valid array; it must not be silently treated as "empty"
+        // but must trigger schema validation and return 422.
+        $response = $this->withToken($this->token)
+            ->postJson('/v1/onboarding/submissions', [
+                'form_template_id' => $template->id,
+                'form_data' => ['nationalities' => 'DE'],
+                'status' => 'submitted',
+            ]);
+
+        $response->assertStatus(422);
+    });
 });
 
 describe('PATCH /v1/onboarding/submissions/{submission}', function () {

--- a/tests/Feature/Controllers/OnboardingControllerTest.php
+++ b/tests/Feature/Controllers/OnboardingControllerTest.php
@@ -566,6 +566,56 @@ describe('POST /v1/onboarding/submissions', function () {
         $response->assertCreated()
             ->assertJsonPath('data.status', 'submitted');
     });
+
+    test('returns 404 when employee submits a template from a different tenant', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.write');
+
+        // Create a template belonging to a different tenant
+        $otherTenant = TenantKey::create(TenantKey::generateEnvelopeKeys());
+        $otherTemplate = OnboardingFormTemplate::factory()->create([
+            'tenant_id' => $otherTenant->id,
+            'form_schema' => [
+                'type' => 'object',
+                'properties' => ['name' => ['type' => 'string']],
+                'required' => ['name'],
+            ],
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->postJson('/v1/onboarding/submissions', [
+                'form_template_id' => $otherTemplate->id,
+                'form_data' => ['name' => 'test'],
+                'status' => 'draft',
+            ]);
+
+        $response->assertStatus(404);
+    });
+
+    test('rejects partial optional-template payload when required schema fields are missing on submit', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.write');
+
+        $template = OnboardingFormTemplate::factory()->optional()->create([
+            'tenant_id' => $this->tenant->id,
+            'form_schema' => [
+                'type' => 'object',
+                'properties' => [
+                    'contact_name' => ['type' => 'string'],
+                    'contact_phone' => ['type' => 'string'],
+                ],
+                'required' => ['contact_name', 'contact_phone'],
+            ],
+        ]);
+
+        // Partial payload: provides one required field but not the other
+        $response = $this->withToken($this->token)
+            ->postJson('/v1/onboarding/submissions', [
+                'form_template_id' => $template->id,
+                'form_data' => ['contact_name' => 'Jane'],
+                'status' => 'submitted',
+            ]);
+
+        $response->assertStatus(422);
+    });
 });
 
 describe('PATCH /v1/onboarding/submissions/{submission}', function () {

--- a/tests/Feature/Controllers/OnboardingControllerTest.php
+++ b/tests/Feature/Controllers/OnboardingControllerTest.php
@@ -616,6 +616,34 @@ describe('POST /v1/onboarding/submissions', function () {
 
         $response->assertStatus(422);
     });
+
+    test('does not treat false boolean values as semantically empty for optional templates', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.write');
+
+        $template = OnboardingFormTemplate::factory()->optional()->create([
+            'tenant_id' => $this->tenant->id,
+            'form_schema' => [
+                'type' => 'object',
+                'properties' => [
+                    'consent' => [
+                        'type' => 'boolean',
+                        'enum' => [true],
+                    ],
+                ],
+                'required' => ['consent'],
+            ],
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->postJson('/v1/onboarding/submissions', [
+                'form_template_id' => $template->id,
+                'form_data' => ['consent' => false],
+                'status' => 'submitted',
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['consent']);
+    });
 });
 
 describe('PATCH /v1/onboarding/submissions/{submission}', function () {
@@ -711,6 +739,42 @@ describe('PATCH /v1/onboarding/submissions/{submission}', function () {
             ->and($response->json('data.review_notes'))->toBeNull()
             ->and($response->json('data.reviewed_at'))->toBeNull()
             ->and($this->employee->fresh()->onboarding_workflow_status)->toBe(Employee::WORKFLOW_STATUS_SUBMITTED_FOR_REVIEW);
+    });
+
+    test('persists the same empty array payload that gets schema validated during submit', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.write');
+
+        $template = OnboardingFormTemplate::factory()->optional()->create([
+            'tenant_id' => $this->tenant->id,
+            'form_schema' => [
+                'type' => 'object',
+                'properties' => [
+                    'iban' => [
+                        'type' => 'string',
+                        'pattern' => '^[A-Z]{2}\d{2}[A-Z0-9]+$',
+                    ],
+                ],
+                'required' => ['iban'],
+            ],
+        ]);
+
+        $submission = OnboardingFormSubmission::factory()->create([
+            'employee_id' => $this->employee->id,
+            'form_template_id' => $template->id,
+            'form_data' => null,
+            'status' => 'draft',
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->patchJson("/v1/onboarding/submissions/{$submission->id}", [
+                'status' => 'submitted',
+            ]);
+
+        $response->assertOk()
+            ->assertJsonPath('data.status', 'submitted')
+            ->assertJsonPath('data.form_data', []);
+
+        expect($submission->fresh()->form_data)->toBe([]);
     });
 
     test('does not allow patching another employees submission', function (): void {

--- a/tests/Feature/Controllers/OnboardingControllerTest.php
+++ b/tests/Feature/Controllers/OnboardingControllerTest.php
@@ -567,6 +567,35 @@ describe('POST /v1/onboarding/submissions', function () {
             ->assertJsonPath('data.status', 'submitted');
     });
 
+    test('skips full schema enforcement for optional templates with missing array fields on submit', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.write');
+
+        $template = OnboardingFormTemplate::factory()->optional()->create([
+            'tenant_id' => $this->tenant->id,
+            'form_schema' => [
+                'type' => 'object',
+                'properties' => [
+                    'nationalities' => [
+                        'type' => 'array',
+                        'items' => ['type' => 'string'],
+                        'minItems' => 1,
+                    ],
+                ],
+                'required' => ['nationalities'],
+            ],
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->postJson('/v1/onboarding/submissions', [
+                'form_template_id' => $template->id,
+                'form_data' => [],
+                'status' => 'submitted',
+            ]);
+
+        $response->assertCreated()
+            ->assertJsonPath('data.status', 'submitted');
+    });
+
     test('returns 404 when employee submits a template from a different tenant', function (): void {
         givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.write');
 

--- a/tests/Feature/Controllers/OnboardingControllerTest.php
+++ b/tests/Feature/Controllers/OnboardingControllerTest.php
@@ -643,6 +643,38 @@ describe('POST /v1/onboarding/submissions', function () {
 
         $response->assertStatus(422)
             ->assertJsonValidationErrors(['consent']);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['consent']);
+    });
+
+    test('does not treat invalid string input for integer fields as semantically empty on submit', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.write');
+
+        $template = OnboardingFormTemplate::factory()->optional()->create([
+            'tenant_id' => $this->tenant->id,
+            'form_schema' => [
+                'type' => 'object',
+                'properties' => [
+                    'count' => [
+                        'type' => 'integer',
+                        'minimum' => 0,
+                    ],
+                ],
+                'required' => ['count'],
+            ],
+        ]);
+
+        // 'abc' is not a valid integer; it must not be silently treated as "empty"
+        // but must trigger schema validation and return 422.
+        $response = $this->withToken($this->token)
+            ->postJson('/v1/onboarding/submissions', [
+                'form_template_id' => $template->id,
+                'form_data' => ['count' => 'abc'],
+                'status' => 'submitted',
+            ]);
+
+        $response->assertStatus(422);
     });
 });
 

--- a/tests/Feature/Controllers/OnboardingControllerTest.php
+++ b/tests/Feature/Controllers/OnboardingControllerTest.php
@@ -183,7 +183,7 @@ describe('GET /v1/onboarding/templates', function () {
         $personalInformationTemplate = $templates->firstWhere('name', 'Persönliche Informationen');
 
         expect($personalInformationTemplate)->not->toBeNull()
-            ->and($personalInformationTemplate['description'])->toBe('BewachV Paragraf 16 erforderliche Informationen für das Bewacherregister');
+            ->and($personalInformationTemplate['description'])->toBe('Ihre persönlichen Angaben für das Onboarding; fehlende Bewacherregister-Felder kann die Personalabteilung später ergänzen.');
     });
 });
 
@@ -235,7 +235,7 @@ describe('GET /v1/onboarding/templates/{template}', function () {
 
         $response->assertOk()
             ->assertJsonPath('data.name', 'Persönliche Informationen')
-            ->assertJsonPath('data.description', 'BewachV Paragraf 16 erforderliche Informationen für das Bewacherregister')
+            ->assertJsonPath('data.description', 'Ihre persönlichen Angaben für das Onboarding; fehlende Bewacherregister-Felder kann die Personalabteilung später ergänzen.')
             ->assertJsonPath('data.form_schema.title', 'Persönliche Informationen')
             ->assertJsonPath('data.form_schema.properties.gender.title', 'Geschlecht')
             ->assertJsonPath('data.form_schema.properties.gender.enumNames.0', 'Männlich')
@@ -334,7 +334,7 @@ describe('GET /v1/onboarding/submissions', function () {
 
         $response->assertOk()
             ->assertJsonPath('data.0.form_template.name', 'Persönliche Informationen')
-            ->assertJsonPath('data.0.form_template.description', 'BewachV Paragraf 16 erforderliche Informationen für das Bewacherregister')
+            ->assertJsonPath('data.0.form_template.description', 'Ihre persönlichen Angaben für das Onboarding; fehlende Bewacherregister-Felder kann die Personalabteilung später ergänzen.')
             ->assertJsonPath('data.0.form_template.form_schema.title', 'Persönliche Informationen');
     });
 });

--- a/tests/Feature/Controllers/OnboardingControllerTest.php
+++ b/tests/Feature/Controllers/OnboardingControllerTest.php
@@ -643,9 +643,35 @@ describe('POST /v1/onboarding/submissions', function () {
 
         $response->assertStatus(422)
             ->assertJsonValidationErrors(['consent']);
+    });
 
-        $response->assertStatus(422)
-            ->assertJsonValidationErrors(['consent']);
+    test('does not treat non-string values for string fields as semantically empty on submit', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.write');
+
+        $template = OnboardingFormTemplate::factory()->optional()->create([
+            'tenant_id' => $this->tenant->id,
+            'form_schema' => [
+                'type' => 'object',
+                'properties' => [
+                    'name' => [
+                        'type' => 'string',
+                        'minLength' => 1,
+                    ],
+                ],
+                'required' => ['name'],
+            ],
+        ]);
+
+        // 5 is not a valid string value; it must not be silently treated as "empty"
+        // but must trigger schema validation and return 422.
+        $response = $this->withToken($this->token)
+            ->postJson('/v1/onboarding/submissions', [
+                'form_template_id' => $template->id,
+                'form_data' => ['name' => 5],
+                'status' => 'submitted',
+            ]);
+
+        $response->assertStatus(422);
     });
 
     test('does not treat invalid string input for integer fields as semantically empty on submit', function (): void {

--- a/tests/Feature/Seeders/OnboardingFormTemplatesSeederTest.php
+++ b/tests/Feature/Seeders/OnboardingFormTemplatesSeederTest.php
@@ -201,12 +201,11 @@ test('tax identification schema has correct structure', function () {
     $schema = $template->form_schema;
 
     expect($schema['properties'])->toHaveKey('tax_id');
-    expect($schema['properties'])->toHaveKey('tax_class');
+    expect($schema['properties'])->not->toHaveKey('tax_class');
     expect($schema['properties'])->toHaveKey('children_count');
 
-    // Check required fields
-    expect($schema['required'])->toContain('tax_id');
-    expect($schema['required'])->toContain('tax_class');
+    expect($schema['required'])->not->toContain('tax_id');
+    expect($schema['required'])->not->toContain('tax_class');
     expect($schema['required'])->not->toContain('children_count');
 });
 
@@ -217,15 +216,6 @@ test('tax identification validates 11-digit tax ID', function () {
     $schema = $template->form_schema;
 
     expect($schema['properties']['tax_id']['pattern'])->toBe('^\d{11}$');
-});
-
-test('tax class enum includes all 6 tax classes', function () {
-    artisan('db:seed', ['--class' => OnboardingFormTemplatesSeeder::class]);
-
-    $template = OnboardingFormTemplate::where('name', 'Tax Identification Number')->first();
-    $schema = $template->form_schema;
-
-    expect($schema['properties']['tax_class']['enum'])->toBe([1, 2, 3, 4, 5, 6]);
 });
 
 test('seeder is idempotent (can be run multiple times)', function () {

--- a/tests/Feature/Seeders/OnboardingFormTemplatesSeederTest.php
+++ b/tests/Feature/Seeders/OnboardingFormTemplatesSeederTest.php
@@ -89,10 +89,10 @@ test('personal information schema has correct structure', function () {
     expect($schema['properties'])->toHaveKey('birth_name');
     expect($schema['properties'])->toHaveKey('previous_names');
 
-    // Verify required array
+    // Verify required array (intended activities are HR-aligned / optional at onboarding submit)
     expect($schema['required'])->toContain('gender');
     expect($schema['required'])->toContain('nationalities');
-    expect($schema['required'])->toContain('intended_activities');
+    expect($schema['required'])->not->toContain('intended_activities');
 });
 
 test('personal information schema validates gender enum', function () {

--- a/tests/Feature/Seeders/OnboardingFormTemplatesSeederTest.php
+++ b/tests/Feature/Seeders/OnboardingFormTemplatesSeederTest.php
@@ -158,21 +158,20 @@ test('emergency contact schema has correct structure', function () {
     $template = OnboardingFormTemplate::where('name', 'Emergency Contact')->first();
     $schema = $template->form_schema;
 
-    // Contact 1 fields (required)
     expect($schema['properties'])->toHaveKey('contact_1_name');
     expect($schema['properties'])->toHaveKey('contact_1_phone');
     expect($schema['properties'])->toHaveKey('contact_1_relationship');
 
-    // Contact 2 fields (optional)
     expect($schema['properties'])->toHaveKey('contact_2_name');
     expect($schema['properties'])->toHaveKey('contact_2_phone');
     expect($schema['properties'])->toHaveKey('contact_2_relationship');
 
-    // Only contact 1 is required
-    expect($schema['required'])->toContain('contact_1_name');
-    expect($schema['required'])->toContain('contact_1_phone');
-    expect($schema['required'])->toContain('contact_1_relationship');
+    expect($schema['required'])->not->toContain('contact_1_name');
+    expect($schema['required'])->not->toContain('contact_1_phone');
+    expect($schema['required'])->not->toContain('contact_1_relationship');
     expect($schema['required'])->not->toContain('contact_2_name');
+    expect($schema['required'])->not->toContain('contact_2_phone');
+    expect($schema['required'])->not->toContain('contact_2_relationship');
 });
 
 test('emergency contact relationship enum includes common relationships', function () {

--- a/tests/Unit/Services/BewacherregisterExportServiceTest.php
+++ b/tests/Unit/Services/BewacherregisterExportServiceTest.php
@@ -131,8 +131,14 @@ test('export throws when required BWR fields are missing', function (): void {
         'id_document_number' => null,
     ]);
 
+    $expectedMessage = implode(', ', [
+        __('bwr_export.missing_fields.gender'),
+        __('bwr_export.missing_fields.address_history'),
+        __('bwr_export.missing_fields.id_document_number'),
+    ]);
+
     expect(fn () => $this->service->exportCsv($employee, 'HR Operations'))
-        ->toThrow(RuntimeException::class, 'gender, address_history, id_document_number');
+        ->toThrow(RuntimeException::class, $expectedMessage);
 });
 
 test('export requires valid work authorization for non exempt nationalities', function (): void {
@@ -144,7 +150,7 @@ test('export requires valid work authorization for non exempt nationalities', fu
     ]);
 
     expect(fn () => $this->service->exportCsv($employee, 'HR Operations'))
-        ->toThrow(RuntimeException::class, 'valid_work_authorization');
+        ->toThrow(RuntimeException::class, __('bwr_export.missing_fields.valid_work_authorization'));
 });
 
 test('export preserves seven digit BWR ids including leading zeroes', function (): void {
@@ -186,5 +192,5 @@ test('export throws when id_document_expiry is in the past', function (): void {
     ]);
 
     expect(fn () => $this->service->exportCsv($employee, 'HR Operations'))
-        ->toThrow(RuntimeException::class, 'id_document_expiry_expired');
+        ->toThrow(RuntimeException::class, __('bwr_export.missing_fields.id_document_expiry_expired'));
 });

--- a/tests/Unit/Services/OnboardingSchemaLocalizationServiceTest.php
+++ b/tests/Unit/Services/OnboardingSchemaLocalizationServiceTest.php
@@ -13,10 +13,10 @@ test('it localizes schema labels descriptions and enum names for known system te
         'tenant_id' => null,
         'is_system_template' => true,
         'name' => 'Emergency Contact',
-        'description' => 'Emergency contact persons',
+        'description' => 'Optional emergency contact persons',
         'form_schema' => [
             'title' => 'Emergency Contact',
-            'description' => 'Emergency contact persons',
+            'description' => 'Optional emergency contact persons',
             'type' => 'object',
             'properties' => [
                 'contact_1_relationship' => [
@@ -31,8 +31,9 @@ test('it localizes schema labels descriptions and enum names for known system te
     $localized = app(OnboardingSchemaLocalizationService::class)->localizeTemplate($template, 'de');
 
     expect($localized['name'])->toBe('Notfallkontakt')
-        ->and($localized['description'])->toBe('Ansprechpartner für Notfälle')
+        ->and($localized['description'])->toBe('Optionale Angaben zu Notfallkontakten')
         ->and($localized['form_schema']['title'])->toBe('Notfallkontakt')
+        ->and($localized['form_schema']['description'])->toBe('Optionale Angaben zu Notfallkontakten')
         ->and($localized['form_schema']['properties']['contact_1_relationship']['title'])->toBe('Kontakt 1: Beziehung')
         ->and($localized['form_schema']['properties']['contact_1_relationship']['enumNames'])->toBe([
             'Ehepartner',
@@ -75,10 +76,10 @@ test('it uses template_key for translation lookup when name has changed', functi
         'is_system_template' => true,
         'name' => 'Renamed Emergency Contact Form',
         'template_key' => 'emergency_contact',
-        'description' => 'Emergency contact persons',
+        'description' => 'Optional emergency contact persons',
         'form_schema' => [
             'title' => 'Emergency Contact',
-            'description' => 'Emergency contact persons',
+            'description' => 'Optional emergency contact persons',
             'type' => 'object',
             'properties' => [
                 'contact_1_relationship' => [
@@ -93,7 +94,7 @@ test('it uses template_key for translation lookup when name has changed', functi
     $localized = app(OnboardingSchemaLocalizationService::class)->localizeTemplate($template, 'de');
 
     expect($localized['name'])->toBe('Notfallkontakt')
-        ->and($localized['description'])->toBe('Ansprechpartner für Notfälle')
+        ->and($localized['description'])->toBe('Optionale Angaben zu Notfallkontakten')
         ->and($localized['form_schema']['title'])->toBe('Notfallkontakt');
 });
 
@@ -103,7 +104,7 @@ test('it falls back to snake-case name when template_key is null', function (): 
         'is_system_template' => true,
         'name' => 'Emergency Contact',
         'template_key' => null,
-        'description' => 'Emergency contact persons',
+        'description' => 'Optional emergency contact persons',
         'form_schema' => [
             'title' => 'Emergency Contact',
             'type' => 'object',
@@ -114,5 +115,5 @@ test('it falls back to snake-case name when template_key is null', function (): 
     $localized = app(OnboardingSchemaLocalizationService::class)->localizeTemplate($template, 'de');
 
     expect($localized['name'])->toBe('Notfallkontakt')
-        ->and($localized['description'])->toBe('Ansprechpartner für Notfälle');
+        ->and($localized['description'])->toBe('Optionale Angaben zu Notfallkontakten');
 });


### PR DESCRIPTION
## US-009: Einladung und Wizard-Inhalte abgleichen

- Einladungs-E-Mail listet nur noch unterstützte Schritte: persönliche Pflichtangaben, optionale Abschnitte (Bank, Notfall, Steuer-ID) sowie Belege pro Schritt (Vertrag / Ausweis / Banknachweis).
- EN/DE gettext aktualisiert; Tax-Template-Beschreibung im Seeder ohne Steuerklasse.

**Weitere Repos:** Branch `onboarding-review-stories` (**frontend**), `onboarding-review-stories-link-2` (**contracts**).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds server-side JSON Schema validation to onboarding submissions (new dependency + new validation semantics) and adjusts seeded schemas/text, which could cause new 422/404 responses for previously accepted payloads or templates.
> 
> **Overview**
> **Onboarding form submissions are now schema-validated on the backend when `status=submitted`.** `OnboardingController` loads the referenced template (tenant-scoped) and uses a new `OnboardingFormDataSchemaValidationService` (powered by `opis/json-schema`) to enforce the template JSON Schema, while still allowing drafts to be saved without full schema enforcement and preserving the “optional template may submit empty payload” semantics.
> 
> **Request/seeded schema and content updates.** `SubmitOnboardingFormRequest` changes `form_data` from `required` to `present` (allowing empty arrays but requiring the key), system onboarding template schemas/descriptions are adjusted (e.g., making some fields optional and removing `tax_class`), onboarding invitation email copy is rewritten and translated (EN/DE), and BWR export readiness errors are switched from raw field keys to localized messages via new `lang/*/bwr_export.php` (with corresponding test updates).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4a7ceb1f376da45edcd29e7fd74689166c8967d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->