### PR TITLE
fix: harden tax identification onboarding approval flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - fixed `OnboardingFormDataSchemaValidationService::isPropertySemanticallyEmpty` treating non-string values (e.g. integers) for `string`-type fields as empty, which previously allowed malformed payloads to bypass JSON Schema validation for optional templates; proved with a new regression test
+- wrapped onboarding submission approval state updates and completion checks in one transaction, and restricted tax-identifier employee sync to the canonical `tax_identification_number` template key so approval can no longer commit partial state or mutate PII from name-matched custom templates
 
 ### Changed
 

--- a/app/Http/Controllers/Api/V1/OnboardingController.php
+++ b/app/Http/Controllers/Api/V1/OnboardingController.php
@@ -744,7 +744,7 @@ class OnboardingController extends Controller
             $this->onboardingTaxIdentificationSyncService->syncFromApprovedSubmission($submission);
 
             /** @var Employee $employee */
-            $employee = $submission->employee;
+            $employee = $submission->employee()->firstOrFail();
             $this->onboardingCompletionService->checkCompletion($employee);
         });
 

--- a/app/Http/Controllers/Api/V1/OnboardingController.php
+++ b/app/Http/Controllers/Api/V1/OnboardingController.php
@@ -22,6 +22,7 @@ use App\Services\OnboardingCompletionService;
 use App\Services\OnboardingFormDataSchemaValidationService;
 use App\Services\OnboardingSchemaLocalizationService;
 use App\Services\OnboardingSubmissionFileStorageService;
+use App\Services\OnboardingTaxIdentificationSyncService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
@@ -49,6 +50,8 @@ class OnboardingController extends Controller
         private readonly OnboardingSubmissionFileStorageService $submissionFileStorageService,
         private readonly OnboardingSchemaLocalizationService $onboardingSchemaLocalizationService,
         private readonly OnboardingFormDataSchemaValidationService $onboardingFormDataSchemaValidationService,
+        private readonly OnboardingCompletionService $onboardingCompletionService,
+        private readonly OnboardingTaxIdentificationSyncService $onboardingTaxIdentificationSyncService,
     ) {}
 
     /**
@@ -731,20 +734,23 @@ class OnboardingController extends Controller
         /** @var \App\Models\User $user */
         $user = $request->user();
 
-        $submission->update([
-            'status' => 'approved',
-            'reviewed_by' => $user->id,
-            'reviewed_at' => now(),
-        ]);
+        DB::transaction(function () use ($submission, $user): void {
+            $submission->update([
+                'status' => 'approved',
+                'reviewed_by' => $user->id,
+                'reviewed_at' => now(),
+            ]);
+
+            $this->onboardingTaxIdentificationSyncService->syncFromApprovedSubmission($submission);
+
+            /** @var Employee $employee */
+            $employee = $submission->employee;
+            $this->onboardingCompletionService->checkCompletion($employee);
+        });
 
         /** @var OnboardingFormSubmission $fresh */
         $fresh = $submission->fresh();
         $fresh->load(['formTemplate', 'reviewer']);
-
-        // Check if employee's onboarding is now complete after approval
-        /** @var Employee $employee */
-        $employee = $submission->employee;
-        app(OnboardingCompletionService::class)->checkCompletion($employee);
 
         $this->prepareLocalizedSubmissionTemplate($fresh, $this->resolveTemplateLocale($request));
 

--- a/app/Services/OnboardingTaxIdentificationSyncService.php
+++ b/app/Services/OnboardingTaxIdentificationSyncService.php
@@ -1,0 +1,52 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace App\Services;
+
+use App\Models\Employee;
+use App\Models\OnboardingFormSubmission;
+use App\Models\OnboardingFormTemplate;
+
+class OnboardingTaxIdentificationSyncService
+{
+    public function syncFromApprovedSubmission(OnboardingFormSubmission $submission): void
+    {
+        $template = $submission->formTemplate;
+        if (! $template instanceof OnboardingFormTemplate || $template->template_key !== 'tax_identification_number') {
+            return;
+        }
+
+        $formData = $submission->form_data;
+        if (! is_array($formData)) {
+            return;
+        }
+
+        /** @var Employee|null $employee */
+        $employee = $submission->employee;
+        if (! $employee instanceof Employee) {
+            return;
+        }
+
+        $updates = [];
+
+        if (isset($formData['tax_id']) && is_string($formData['tax_id'])) {
+            $taxId = trim($formData['tax_id']);
+            if ($taxId !== '') {
+                $updates['tax_id'] = $taxId;
+            }
+        }
+
+        if (isset($formData['social_security_number']) && is_string($formData['social_security_number'])) {
+            $socialSecurityNumber = trim($formData['social_security_number']);
+            if ($socialSecurityNumber !== '') {
+                $updates['social_security_number'] = $socialSecurityNumber;
+            }
+        }
+
+        if ($updates !== []) {
+            $employee->forceFill($updates)->save();
+        }
+    }
+}

--- a/app/Services/OnboardingTaxIdentificationSyncService.php
+++ b/app/Services/OnboardingTaxIdentificationSyncService.php
@@ -13,8 +13,17 @@ class OnboardingTaxIdentificationSyncService
 {
     public function syncFromApprovedSubmission(OnboardingFormSubmission $submission): void
     {
+        if ($submission->status !== 'approved') {
+            return;
+        }
+
         $template = $submission->formTemplate;
-        if (! $template instanceof OnboardingFormTemplate || $template->template_key !== 'tax_identification_number') {
+        if (
+            ! $template instanceof OnboardingFormTemplate
+            || $template->template_key !== 'tax_identification_number'
+            || ! $template->is_system_template
+            || $template->tenant_id !== null
+        ) {
             return;
         }
 

--- a/database/seeders/OnboardingFormTemplatesSeeder.php
+++ b/database/seeders/OnboardingFormTemplatesSeeder.php
@@ -49,9 +49,9 @@ class OnboardingFormTemplatesSeeder extends Seeder
             [
                 'name' => 'Tax Identification Number',
                 'template_key' => 'tax_identification_number',
-                'description' => 'Optional eleven-digit tax identification number (§ 39e EStG)',
+                'description' => 'Required eleven-digit tax identification number (§ 39e EStG) and social security number.',
                 'form_schema' => $this->getTaxIdentificationSchema(),
-                'is_required' => false,
+                'is_required' => true,
                 'is_system_template' => true,
                 'sort_order' => 4,
                 'tenant_id' => null,
@@ -243,7 +243,7 @@ class OnboardingFormTemplatesSeeder extends Seeder
     {
         return [
             'title' => 'Tax Identification Number',
-            'description' => 'Optional eleven-digit tax identification number (§ 39e EStG)',
+            'description' => 'Required eleven-digit tax identification number (§ 39e EStG) and social security number.',
             'type' => 'object',
             'properties' => [
                 'tax_id' => [
@@ -251,13 +251,18 @@ class OnboardingFormTemplatesSeeder extends Seeder
                     'title' => 'Tax Identification Number',
                     'pattern' => '^\d{11}$',
                 ],
+                'social_security_number' => [
+                    'type' => 'string',
+                    'title' => 'Social Security Number',
+                    'pattern' => '^\d{2}\s?\d{6}\s?[A-Z]\s?\d{3}$',
+                ],
                 'children_count' => [
                     'type' => 'integer',
                     'title' => 'Number of Children',
                     'minimum' => 0,
                 ],
             ],
-            'required' => [],
+            'required' => ['tax_id', 'social_security_number'],
         ];
     }
 }

--- a/lang/de/onboarding_schemas.php
+++ b/lang/de/onboarding_schemas.php
@@ -93,13 +93,14 @@ return [
         ],
         'tax_identification_number' => [
             'name' => 'Steueridentifikationsnummer',
-            'description' => 'Optionale elfstellige Steueridentifikationsnummer (§ 39e EStG)',
+            'description' => 'Erforderliche elfstellige Steueridentifikationsnummer (§ 39e EStG) und Sozialversicherungsnummer.',
             'schema' => [
                 'title' => 'Steueridentifikationsnummer',
-                'description' => 'Optionale elfstellige Steueridentifikationsnummer (§ 39e EStG)',
+                'description' => 'Erforderliche elfstellige Steueridentifikationsnummer (§ 39e EStG) und Sozialversicherungsnummer.',
             ],
             'fields' => [
                 'tax_id' => ['title' => 'Steueridentifikationsnummer'],
+                'social_security_number' => ['title' => 'Sozialversicherungsnummer'],
                 'children_count' => ['title' => 'Anzahl Kinder'],
             ],
         ],

--- a/lang/en/onboarding_schemas.php
+++ b/lang/en/onboarding_schemas.php
@@ -93,13 +93,14 @@ return [
         ],
         'tax_identification_number' => [
             'name' => 'Tax Identification Number',
-            'description' => 'Optional eleven-digit tax identification number (Section 39e EStG)',
+            'description' => 'Required eleven-digit tax identification number (Section 39e EStG) and social security number.',
             'schema' => [
                 'title' => 'Tax Identification Number',
-                'description' => 'Optional eleven-digit tax identification number (Section 39e EStG)',
+                'description' => 'Required eleven-digit tax identification number (Section 39e EStG) and social security number.',
             ],
             'fields' => [
                 'tax_id' => ['title' => 'Tax Identification Number'],
+                'social_security_number' => ['title' => 'Social Security Number'],
                 'children_count' => ['title' => 'Number of Children'],
             ],
         ],

--- a/tests/Feature/Controllers/OnboardingControllerTest.php
+++ b/tests/Feature/Controllers/OnboardingControllerTest.php
@@ -1196,7 +1196,8 @@ describe('POST /v1/onboarding-review/submissions/{submission}/approve', function
         ]);
 
         $template = OnboardingFormTemplate::factory()->create([
-            'tenant_id' => $this->tenant->id,
+            'tenant_id' => null,
+            'is_system_template' => true,
             'template_key' => 'tax_identification_number',
             'name' => 'Tax Identification Number',
         ]);

--- a/tests/Feature/Controllers/OnboardingControllerTest.php
+++ b/tests/Feature/Controllers/OnboardingControllerTest.php
@@ -13,6 +13,7 @@ use App\Models\OrganizationalUnit;
 use App\Models\Permission;
 use App\Models\TenantKey;
 use App\Models\User;
+use App\Services\OnboardingCompletionService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\DB;
@@ -1184,6 +1185,99 @@ describe('POST /v1/onboarding-review/submissions/{submission}/approve', function
         expect($response->json('data.status'))->toBe('approved');
         expect($response->json('data.reviewed_by'))->toBe($this->user->id);
         expect($response->json('data.reviewed_at'))->not->toBeNull();
+    });
+
+    test('approving tax identification submission stores identifiers on employee', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.approve');
+        $this->employee->update([
+            'onboarding_workflow_status' => Employee::WORKFLOW_STATUS_SUBMITTED_FOR_REVIEW,
+            'tax_id' => null,
+            'social_security_number' => null,
+        ]);
+
+        $template = OnboardingFormTemplate::factory()->create([
+            'tenant_id' => $this->tenant->id,
+            'template_key' => 'tax_identification_number',
+            'name' => 'Tax Identification Number',
+        ]);
+        $submission = OnboardingFormSubmission::factory()->create([
+            'employee_id' => $this->employee->id,
+            'form_template_id' => $template->id,
+            'form_data' => [
+                'tax_id' => '12345678901',
+                'social_security_number' => '65 123456 A 123',
+            ],
+            'status' => 'submitted',
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->postJson("/v1/onboarding-review/submissions/{$submission->id}/approve");
+
+        $response->assertOk();
+
+        $freshEmployee = $this->employee->fresh();
+        expect($freshEmployee->tax_id)->toBe('12345678901')
+            ->and($freshEmployee->social_security_number)->toBe('65 123456 A 123');
+    });
+
+    test('approval changes are rolled back when completion check fails', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.approve');
+        $this->employee->update([
+            'onboarding_workflow_status' => Employee::WORKFLOW_STATUS_SUBMITTED_FOR_REVIEW,
+        ]);
+
+        $submission = OnboardingFormSubmission::factory()->create([
+            'employee_id' => $this->employee->id,
+            'form_template_id' => $this->template->id,
+            'status' => 'submitted',
+        ]);
+
+        $this->mock(OnboardingCompletionService::class, function ($mock): void {
+            $mock->shouldReceive('checkCompletion')
+                ->once()
+                ->andThrow(new RuntimeException('forced completion failure'));
+        });
+
+        $response = $this->withToken($this->token)
+            ->postJson("/v1/onboarding-review/submissions/{$submission->id}/approve");
+
+        $response->assertStatus(500);
+        expect($submission->fresh()->status)->toBe('submitted')
+            ->and($submission->fresh()->reviewed_by)->toBeNull()
+            ->and($submission->fresh()->reviewed_at)->toBeNull();
+    });
+
+    test('tax identifiers are not synced when template key is not tax identification', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.approve');
+        $this->employee->update([
+            'onboarding_workflow_status' => Employee::WORKFLOW_STATUS_SUBMITTED_FOR_REVIEW,
+            'tax_id' => null,
+            'social_security_number' => null,
+        ]);
+
+        $template = OnboardingFormTemplate::factory()->create([
+            'tenant_id' => $this->tenant->id,
+            'template_key' => 'custom_tax_form',
+            'name' => 'Tax Identification Follow-up',
+        ]);
+        $submission = OnboardingFormSubmission::factory()->create([
+            'employee_id' => $this->employee->id,
+            'form_template_id' => $template->id,
+            'form_data' => [
+                'tax_id' => '12345678901',
+                'social_security_number' => '65 123456 A 123',
+            ],
+            'status' => 'submitted',
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->postJson("/v1/onboarding-review/submissions/{$submission->id}/approve");
+
+        $response->assertOk();
+
+        $freshEmployee = $this->employee->fresh();
+        expect($freshEmployee->tax_id)->toBeNull()
+            ->and($freshEmployee->social_security_number)->toBeNull();
     });
 
     test('returns 422 when attempting to approve non-submitted submission', function (): void {

--- a/tests/Feature/Seeders/OnboardingFormTemplatesSeederTest.php
+++ b/tests/Feature/Seeders/OnboardingFormTemplatesSeederTest.php
@@ -45,11 +45,11 @@ test('personal information form is required', function () {
     expect($template->is_required)->toBeTrue();
 });
 
-test('other templates are not required', function () {
+test('bank and emergency templates are not required', function () {
     artisan('db:seed', ['--class' => OnboardingFormTemplatesSeeder::class]);
 
     $optionalTemplates = OnboardingFormTemplate::where('is_required', false)->count();
-    expect($optionalTemplates)->toBe(3); // Bank, Emergency, Tax
+    expect($optionalTemplates)->toBe(2); // Bank, Emergency
 });
 
 test('templates have correct sort order', function () {
@@ -200,10 +200,13 @@ test('tax identification schema has correct structure', function () {
     $schema = $template->form_schema;
 
     expect($schema['properties'])->toHaveKey('tax_id');
+    expect($schema['properties'])->toHaveKey('social_security_number');
     expect($schema['properties'])->not->toHaveKey('tax_class');
     expect($schema['properties'])->toHaveKey('children_count');
 
-    expect($schema['required'])->not->toContain('tax_id');
+    expect($template->is_required)->toBeTrue();
+    expect($schema['required'])->toContain('tax_id');
+    expect($schema['required'])->toContain('social_security_number');
     expect($schema['required'])->not->toContain('tax_class');
     expect($schema['required'])->not->toContain('children_count');
 });
@@ -215,6 +218,7 @@ test('tax identification validates 11-digit tax ID', function () {
     $schema = $template->form_schema;
 
     expect($schema['properties']['tax_id']['pattern'])->toBe('^\d{11}$');
+    expect($schema['properties']['social_security_number']['pattern'])->toBe('^\d{2}\s?\d{6}\s?[A-Z]\s?\d{3}$');
 });
 
 test('seeder is idempotent (can be run multiple times)', function () {


### PR DESCRIPTION
## Summary

- make the tax identification onboarding template required and include `social_security_number` in schema + localized labels
- harden onboarding approval flow by running approval state change, tax identifier sync, and completion check in a single DB transaction
- move tax identifier sync business logic out of the controller into `OnboardingTaxIdentificationSyncService`
- restrict sync trigger to the canonical `template_key = tax_identification_number` (remove name-based heuristic matching)
- add regression coverage for rollback behavior and non-canonical template-key safety
- update `CHANGELOG.md`

## Why

This removes a partial-write risk in approval and prevents accidental PII sync from custom templates that only match by display name.

## Validation

- `vendor/bin/pint --dirty`
- `php artisan test tests/Feature/Controllers/OnboardingControllerTest.php tests/Feature/Seeders/OnboardingFormTemplatesSeederTest.php`
- `./scripts/preflight.sh`
- `PREFLIGHT_RUN_TESTS=1 ./scripts/preflight.sh` (fails in this environment due PostgreSQL permission to create parallel test databases: `SQLSTATE[42501] permission denied to create database`)

## Scope

- Single topic PR
- Diff size is within the repository PR-size guideline (<600 LOC)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches onboarding approval and employee identifier (PII) writes by introducing a new sync service and transactional approval flow; mistakes could block approvals or incorrectly persist/rollback sensitive fields.
> 
> **Overview**
> **Hardens onboarding submission approval** by wrapping the approval status update, tax-identifier-to-employee sync, and onboarding completion check in a single DB transaction to prevent partial commits.
> 
> **Restricts and formalizes tax identifier syncing** via a new `OnboardingTaxIdentificationSyncService`, which only copies `tax_id` and `social_security_number` from *approved* submissions of the canonical system template (`template_key = tax_identification_number`).
> 
> **Updates the tax identification onboarding template** to be required, adds `social_security_number` to the seeded JSON schema (with validation pattern + required list), and updates EN/DE localized labels; adds regression tests for identifier persistence, rollback on completion-check failure, and non-canonical template safety.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 590c3929c4767480839b8b7dfde9a6cbc7560dfb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->