### PR TITLE
fix: stabilize local preflight test bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - forced the PHPUnit `DB_CONNECTION` and `DB_DATABASE` overrides so the early PostgreSQL test bootstrap always provisions `testing*_test_*` databases instead of inheriting runtime `secpal*` names from the shell environment during parallel runs
 - made local API preflight run `serial`-group tests outside the parallel Pest run, so the dedicated concurrency regressions no longer race each other by repeatedly `migrate:fresh`-ing the shared base `testing` database during `PREFLIGHT_RUN_TESTS=1`
+- made the PostgreSQL test bootstrap fail fast with an explicit owner/`public`-schema permission error when an existing `testing_test_*` database is not writable by the configured app user, so local ownership drift no longer degrades into late migration failures across large parallel test runs
 - fixed `OnboardingFormDataSchemaValidationService::isPropertySemanticallyEmpty` treating non-string values (e.g. integers) for `string`-type fields as empty, which previously allowed malformed payloads to bypass JSON Schema validation for optional templates; proved with a new regression test
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- forced the PHPUnit `DB_CONNECTION` and `DB_DATABASE` overrides so the early PostgreSQL test bootstrap always provisions `testing*_test_*` databases instead of inheriting runtime `secpal*` names from the shell environment during parallel runs
+- made local API preflight run `serial`-group tests outside the parallel Pest run, so the dedicated concurrency regressions no longer race each other by repeatedly `migrate:fresh`-ing the shared base `testing` database during `PREFLIGHT_RUN_TESTS=1`
 - fixed `OnboardingFormDataSchemaValidationService::isPropertySemanticallyEmpty` treating non-string values (e.g. integers) for `string`-type fields as empty, which previously allowed malformed payloads to bypass JSON Schema validation for optional templates; proved with a new regression test
 
 ### Changed

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -86,6 +86,7 @@ When running tests in **parallel** (e.g., with `php artisan test --parallel`), P
 - `phpunit.xml` sets `DB_DATABASE=testing` as base name
 - When running tests in parallel (e.g., with `php artisan test --parallel`), Pest automatically appends `_test_1`, `_test_2` suffixes to the database name for each process.
 - The test bootstrap creates the required database idempotently (checks existence first). Parallel workers create their own suffixed `testing_test_<token>` databases as needed.
+- For existing PostgreSQL test databases, the bootstrap now also validates that the configured app user can create tables in schema `public` and fails fast with the current owner details when local ownership drift is detected.
 
 ### How to Run Tests in Parallel
 
@@ -121,7 +122,7 @@ psql -h 127.0.0.1 -U "$DB_USERNAME" -d postgres -c '\du'
 php artisan test tests/Feature/HealthCheckTest.php
 ```
 
-If parallel test runs fail with errors such as `permission denied for schema public` after manually creating `testing_test_*` databases, fix the database ownership before rerunning the suite.
+If parallel test runs fail with errors such as `permission denied for schema public`, or the bootstrap reports that the configured user cannot create tables in schema `public`, fix the database ownership before rerunning the suite.
 
 ```bash
 # Inspect database owners first (uses local peer auth; adjust if your setup differs)

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -33,8 +33,8 @@ SPDX-License-Identifier: CC0-1.0
         <env name="APP_URL" value="https://api.secpal.dev" force="true"/>
         <env name="FRONTEND_URL" value="https://app.secpal.dev" force="true"/>
         <env name="CORS_ALLOWED_ORIGINS" value="https://app.secpal.dev" force="true"/>
-        <env name="DB_CONNECTION" value="pgsql"/>
-        <env name="DB_DATABASE" value="testing"/>
+        <env name="DB_CONNECTION" value="pgsql" force="true"/>
+        <env name="DB_DATABASE" value="testing" force="true"/>
         <env name="MAIL_MAILER" value="array" force="true"/>
         <env name="QUEUE_CONNECTION" value="sync" force="true"/>
         <env name="SANCTUM_STATEFUL_DOMAINS" value="app.secpal.dev" force="true"/>

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -139,7 +139,10 @@ if [ -f composer.json ]; then
       echo "→ Running tests (enabled via PREFLIGHT_RUN_TESTS=1)..."
       TEST_EXIT=0
       if [ -f artisan ]; then
-        ${CMD_PREFIX} php artisan test --parallel || TEST_EXIT=$?
+        ${CMD_PREFIX} php artisan test --parallel --exclude-group=serial || TEST_EXIT=$?
+        if [ "$TEST_EXIT" -eq 0 ]; then
+          ${CMD_PREFIX} php artisan test --group=serial || TEST_EXIT=$?
+        fi
       elif [ -x ./vendor/bin/pest ]; then
         ${CMD_PREFIX} ./vendor/bin/pest --parallel || TEST_EXIT=$?
       elif [ -x ./vendor/bin/phpunit ]; then

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -140,9 +140,7 @@ if [ -f composer.json ]; then
       TEST_EXIT=0
       if [ -f artisan ]; then
         ${CMD_PREFIX} php artisan test --parallel --exclude-group=serial || TEST_EXIT=$?
-        if [ "$TEST_EXIT" -eq 0 ]; then
-          ${CMD_PREFIX} php artisan test --group=serial || TEST_EXIT=$?
-        fi
+        ${CMD_PREFIX} php artisan test --group=serial || TEST_EXIT=$?
       elif [ -x ./vendor/bin/pest ]; then
         ${CMD_PREFIX} ./vendor/bin/pest --parallel || TEST_EXIT=$?
       elif [ -x ./vendor/bin/phpunit ]; then

--- a/tests/Support/TestCaseBootstrapEnvironmentProbe.php
+++ b/tests/Support/TestCaseBootstrapEnvironmentProbe.php
@@ -13,6 +13,14 @@ final class TestCaseBootstrapEnvironmentProbe extends TestCase
 {
     private static ?string $probeEnvironmentPath = null;
 
+    /**
+     * @param  array{current_user: string, database_owner: string, schema_owner: string, can_create: bool}  $access
+     */
+    public static function assertWritableParallelTestDatabase(string $databaseName, array $access): void
+    {
+        parent::assertWritableParallelTestDatabase($databaseName, $access);
+    }
+
     public static function useProbeEnvironmentPath(string $path): void
     {
         self::$probeEnvironmentPath = $path;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -123,9 +123,32 @@ abstract class TestCase extends BaseTestCase
                     );
                 }
             }
+
+            self::assertWritableParallelTestDatabase(
+                $candidate,
+                self::parallelTestDatabaseAccess(self::connectToDatabase($candidate)),
+            );
         }
 
         self::$postgresTestDatabasesEnsured = true;
+    }
+
+    /**
+     * @param  array{current_user: string, database_owner: string, schema_owner: string, can_create: bool}  $access
+     */
+    protected static function assertWritableParallelTestDatabase(string $databaseName, array $access): void
+    {
+        if ($access['can_create']) {
+            return;
+        }
+
+        throw new \RuntimeException(sprintf(
+            'PostgreSQL test database "%s" exists but the configured user "%s" cannot create tables in schema "public". Current database owner: "%s". Current schema owner: "%s". Ensure the database is owned by the configured app user or grant CREATE on schema public before running the test suite.',
+            $databaseName,
+            $access['current_user'],
+            $access['database_owner'],
+            $access['schema_owner'],
+        ));
     }
 
     /**
@@ -151,11 +174,6 @@ abstract class TestCase extends BaseTestCase
 
     private static function connectToMaintenanceDatabase(): \PDO
     {
-        $host = self::environmentValue('DB_HOST', '127.0.0.1');
-        $port = self::environmentValue('DB_PORT', '5432');
-        $username = self::environmentValue('DB_USERNAME', 'postgres');
-        $password = self::environmentValue('DB_PASSWORD', '');
-
         $configuredDatabase = self::environmentValue('DB_DATABASE', 'postgres');
         $maintenanceDatabases = array_values(array_unique([
             $configuredDatabase,
@@ -165,20 +183,52 @@ abstract class TestCase extends BaseTestCase
 
         foreach ($maintenanceDatabases as $maintenanceDatabase) {
             try {
-                $pdo = new \PDO(
-                    sprintf('pgsql:host=%s;port=%s;dbname=%s', $host, $port, $maintenanceDatabase),
-                    $username,
-                    $password,
-                    [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION],
-                );
-
-                return $pdo;
+                return self::connectToDatabase($maintenanceDatabase);
             } catch (\PDOException $exception) {
                 continue;
             }
         }
 
         throw new \RuntimeException('Unable to connect to a PostgreSQL maintenance database for test bootstrap.');
+    }
+
+    private static function connectToDatabase(string $databaseName): \PDO
+    {
+        $host = self::environmentValue('DB_HOST', '127.0.0.1');
+        $port = self::environmentValue('DB_PORT', '5432');
+        $username = self::environmentValue('DB_USERNAME', 'postgres');
+        $password = self::environmentValue('DB_PASSWORD', '');
+
+        return new \PDO(
+            sprintf('pgsql:host=%s;port=%s;dbname=%s', $host, $port, $databaseName),
+            $username,
+            $password,
+            [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION],
+        );
+    }
+
+    /**
+     * @return array{current_user: string, database_owner: string, schema_owner: string, can_create: bool}
+     */
+    private static function parallelTestDatabaseAccess(\PDO $pdo): array
+    {
+        $statement = $pdo->query(
+            "SELECT current_user AS current_user, pg_catalog.pg_get_userbyid(database_row.datdba) AS database_owner, pg_catalog.pg_get_userbyid(namespace_row.nspowner) AS schema_owner, has_schema_privilege(current_user, namespace_row.nspname, 'CREATE') AS can_create FROM pg_database AS database_row JOIN pg_namespace AS namespace_row ON namespace_row.nspname = 'public' WHERE database_row.datname = current_database()"
+        );
+
+        /** @var array{current_user?: mixed, database_owner?: mixed, schema_owner?: mixed, can_create?: mixed}|false $access */
+        $access = $statement->fetch(\PDO::FETCH_ASSOC);
+
+        if (! is_array($access)) {
+            throw new \RuntimeException('Unable to determine PostgreSQL test database access details for schema validation.');
+        }
+
+        return [
+            'current_user' => (string) ($access['current_user'] ?? ''),
+            'database_owner' => (string) ($access['database_owner'] ?? ''),
+            'schema_owner' => (string) ($access['schema_owner'] ?? ''),
+            'can_create' => in_array($access['can_create'] ?? false, [true, 1, '1', 't', 'true'], true),
+        ];
     }
 
     private static function environmentValue(string $key, string $default): string

--- a/tests/Unit/PhpUnitDatabaseEnvironmentConfigTest.php
+++ b/tests/Unit/PhpUnitDatabaseEnvironmentConfigTest.php
@@ -1,0 +1,39 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+/**
+ * @return array{value: string, force: string}
+ */
+function phpunitEnvSetting(string $name): array
+{
+    $configuration = simplexml_load_file(base_path('phpunit.xml'));
+
+    expect($configuration)->toBeInstanceOf(SimpleXMLElement::class);
+
+    $envNodes = $configuration->xpath(sprintf('/phpunit/php/env[@name="%s"]', $name));
+
+    expect($envNodes)->not->toBeFalse()
+        ->and($envNodes)->toHaveCount(1);
+
+    /** @var SimpleXMLElement $envNode */
+    $envNode = $envNodes[0];
+
+    return [
+        'value' => (string) $envNode['value'],
+        'force' => (string) $envNode['force'],
+    ];
+}
+
+test('phpunit forces postgres test environment overrides before early bootstrap code runs', function (): void {
+    expect(phpunitEnvSetting('DB_CONNECTION'))->toBe([
+        'value' => 'pgsql',
+        'force' => 'true',
+    ])->and(phpunitEnvSetting('DB_DATABASE'))->toBe([
+        'value' => 'testing',
+        'force' => 'true',
+    ]);
+});

--- a/tests/Unit/PreflightSerialGroupConfigTest.php
+++ b/tests/Unit/PreflightSerialGroupConfigTest.php
@@ -1,0 +1,23 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+function preflightScriptContents(): string
+{
+    $contents = file_get_contents(base_path('scripts/preflight.sh'));
+
+    expect($contents)->not->toBeFalse();
+
+    return $contents;
+}
+
+test('preflight excludes serial tests from the parallel run and executes them separately', function (): void {
+    $contents = preflightScriptContents();
+
+    expect($contents)
+        ->toContain('${CMD_PREFIX} php artisan test --parallel --exclude-group=serial || TEST_EXIT=$?')
+        ->toContain('${CMD_PREFIX} php artisan test --group=serial || TEST_EXIT=$?');
+});

--- a/tests/Unit/TestCasePostgresParallelDatabaseAccessTest.php
+++ b/tests/Unit/TestCasePostgresParallelDatabaseAccessTest.php
@@ -1,0 +1,32 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+use Tests\Support\TestCaseBootstrapEnvironmentProbe;
+
+test('accepts writable postgres parallel test database access details', function (): void {
+    TestCaseBootstrapEnvironmentProbe::assertWritableParallelTestDatabase('testing_test_3', [
+        'current_user' => 'secpal_app',
+        'database_owner' => 'secpal_app',
+        'schema_owner' => 'pg_database_owner',
+        'can_create' => true,
+    ]);
+
+    expect(true)->toBeTrue();
+});
+
+test('fails fast when an existing postgres parallel test database is not writable', function (): void {
+    expect(fn (): bool => TestCaseBootstrapEnvironmentProbe::assertWritableParallelTestDatabase('testing_test_8', [
+        'current_user' => 'secpal_app',
+        'database_owner' => 'postgres',
+        'schema_owner' => 'pg_database_owner',
+        'can_create' => false,
+    ]))
+        ->toThrow(
+            RuntimeException::class,
+            'PostgreSQL test database "testing_test_8" exists but the configured user "secpal_app" cannot create tables in schema "public". Current database owner: "postgres". Current schema owner: "pg_database_owner". Ensure the database is owned by the configured app user or grant CREATE on schema public before running the test suite.'
+        );
+});

--- a/tests/Unit/TestCasePostgresParallelDatabaseAccessTest.php
+++ b/tests/Unit/TestCasePostgresParallelDatabaseAccessTest.php
@@ -19,12 +19,14 @@ test('accepts writable postgres parallel test database access details', function
 });
 
 test('fails fast when an existing postgres parallel test database is not writable', function (): void {
-    expect(fn (): bool => TestCaseBootstrapEnvironmentProbe::assertWritableParallelTestDatabase('testing_test_8', [
-        'current_user' => 'secpal_app',
-        'database_owner' => 'postgres',
-        'schema_owner' => 'pg_database_owner',
-        'can_create' => false,
-    ]))
+    expect(function (): void {
+        TestCaseBootstrapEnvironmentProbe::assertWritableParallelTestDatabase('testing_test_8', [
+            'current_user' => 'secpal_app',
+            'database_owner' => 'postgres',
+            'schema_owner' => 'pg_database_owner',
+            'can_create' => false,
+        ]);
+    })
         ->toThrow(
             RuntimeException::class,
             'PostgreSQL test database "testing_test_8" exists but the configured user "secpal_app" cannot create tables in schema "public". Current database owner: "postgres". Current schema owner: "pg_database_owner". Ensure the database is owned by the configured app user or grant CREATE on schema public before running the test suite.'


### PR DESCRIPTION
## Summary

- force PHPUnit to override `DB_CONNECTION` and `DB_DATABASE` for the early PostgreSQL test bootstrap
- make local preflight exclude `serial` tests from the parallel run and execute them separately
- fail fast when an existing PostgreSQL `testing_test_*` database is not writable by the configured app user
- add regression coverage for the PHPUnit/preflight contracts and the writable-parallel-database guard
- document the expected local PostgreSQL ownership state for parallel API tests

## Validation

- `php artisan test tests/Unit/PhpUnitDatabaseEnvironmentConfigTest.php tests/Unit/TestCaseBootstrapEnvironmentFileTest.php tests/Unit/TestCaseBootstrapEnvironmentProbeAutoloadTest.php tests/Unit/PreflightSerialGroupConfigTest.php tests/Unit/TestCasePostgresParallelDatabaseAccessTest.php`
- `php artisan test --parallel tests/Feature/ActivityLog/ActivityLogSchemaTest.php`
- `PREFLIGHT_RUN_TESTS=1 ./scripts/preflight.sh`
- `vendor/bin/pint --dirty`

## Issue

- Closes #1024

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the global test bootstrap and local preflight script; failures would block or destabilize developer test runs, but runtime/production code paths are unaffected.
> 
> **Overview**
> Improves local/CI test determinism for PostgreSQL + parallel runs by **forcing PHPUnit `DB_CONNECTION`/`DB_DATABASE` overrides** in `phpunit.xml`, preventing shell env leakage into early test bootstrap.
> 
> Updates `scripts/preflight.sh` to run `serial`-group tests *outside* the parallel run (`--exclude-group=serial` then `--group=serial`) to avoid parallel `migrate:fresh` races during `PREFLIGHT_RUN_TESTS=1`.
> 
> Hardens the Postgres test DB bootstrap in `tests/TestCase.php` by validating `public` schema CREATE privileges/ownership for existing `testing_test_*` databases and failing fast with a targeted error; adds unit regression tests and documents the ownership expectations in `DEVELOPMENT.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1945aa9aaec555f62698b9804a81b83cf0848af5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->