### PR TITLE
Mark onboarding users as email verified on completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - made the PostgreSQL test bootstrap fail fast with an explicit owner/`public`-schema permission error when an existing `testing_test_*` database is not writable by the configured app user, so local ownership drift no longer degrades into late migration failures across large parallel test runs
 - fixed `OnboardingFormDataSchemaValidationService::isPropertySemanticallyEmpty` treating non-string values (e.g. integers) for `string`-type fields as empty, which previously allowed malformed payloads to bypass JSON Schema validation for optional templates; proved with a new regression test
 - wrapped onboarding submission approval state updates and completion checks in one transaction, and restricted tax-identifier employee sync to the canonical `tax_identification_number` template key so approval can no longer commit partial state or mutate PII from name-matched custom templates
+- aligned onboarding completion email verification with the invited employee mailbox by syncing the user login email before verification and dispatching the `Verified` event in that path; auth payloads now also expose resolved onboarding workflow state via `Employee::resolveOnboardingWorkflowStatus()`, with regression tests for login, `/v1/me`, and onboarding completion
 
 ### Changed
 

--- a/app/Http/Controllers/Api/V1/OnboardingController.php
+++ b/app/Http/Controllers/Api/V1/OnboardingController.php
@@ -23,6 +23,7 @@ use App\Services\OnboardingFormDataSchemaValidationService;
 use App\Services\OnboardingSchemaLocalizationService;
 use App\Services\OnboardingSubmissionFileStorageService;
 use App\Services\OnboardingTaxIdentificationSyncService;
+use Illuminate\Auth\Events\Verified;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
@@ -167,6 +168,8 @@ class OnboardingController extends Controller
         $lastName = $validated['last_name'];
         /** @var string $password */
         $password = $validated['password'];
+        /** @var string $onboardingEmail */
+        $onboardingEmail = $validated['email'];
 
         // Validate name changes (Hybrid approach: similarity check + HR notification)
         $firstNameValidation = null;
@@ -203,7 +206,7 @@ class OnboardingController extends Controller
         }
 
         // Wrap all operations in a transaction to ensure atomicity
-        DB::transaction(function () use ($employee, $firstName, $lastName, $password, $oldFirstName, $oldLastName, $firstNameValidation, $lastNameValidation, $shouldNotifyHR, $tokenModel, $request) {
+        DB::transaction(function () use ($employee, $firstName, $lastName, $password, $onboardingEmail, $oldFirstName, $oldLastName, $firstNameValidation, $lastNameValidation, $shouldNotifyHR, $tokenModel, $request) {
 
             // Update employee name (allow corrections/updates)
             $employee->first_name = $firstName;
@@ -258,9 +261,16 @@ class OnboardingController extends Controller
             $user->password = Hash::make($password);
             // Sync user name with employee name so it displays correctly after login
             $user->name = $firstName.' '.$lastName;
+            // The onboarding invite proves control over employee.email; keep the user login email aligned.
+            if ($user->email !== $onboardingEmail) {
+                $user->email = $onboardingEmail;
+                $user->email_verified_at = null;
+            }
             $user->save();
             // Consuming a valid onboarding magic link proves mailbox control.
-            $user->markEmailAsVerified();
+            if ($user->markEmailAsVerified()) {
+                event(new Verified($user));
+            }
 
             // Mark token as completed (only after all operations succeed)
             $ip = $request->ip() ?? 'unknown';

--- a/app/Http/Controllers/Api/V1/OnboardingController.php
+++ b/app/Http/Controllers/Api/V1/OnboardingController.php
@@ -259,6 +259,8 @@ class OnboardingController extends Controller
             // Sync user name with employee name so it displays correctly after login
             $user->name = $firstName.' '.$lastName;
             $user->save();
+            // Consuming a valid onboarding magic link proves mailbox control.
+            $user->markEmailAsVerified();
 
             // Mark token as completed (only after all operations succeed)
             $ip = $request->ip() ?? 'unknown';
@@ -276,14 +278,6 @@ class OnboardingController extends Controller
 
         // Refresh user to get updated name
         $user->refresh();
-
-        if (! $user->hasVerifiedEmail()) {
-            try {
-                $user->sendEmailVerificationNotification();
-            } catch (\Throwable $throwable) {
-                report($throwable);
-            }
-        }
 
         // Automatically log the user in (create session with cookie, like regular login)
         // This uses session-based auth (Sanctum SPA mode) instead of token-based auth
@@ -309,6 +303,7 @@ class OnboardingController extends Controller
                     'id' => $user->id,
                     'email' => $user->email,
                     'name' => $user->name,
+                    'email_verified' => $user->hasVerifiedEmail(),
                 ],
                 'employee' => [
                     'id' => $employee->id,

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -975,7 +975,7 @@ class AuthController extends Controller
      * viewable rank ranges (0-255), granting access to all leadership
      * levels and non-leadership employees.
      *
-     * @return array{id: string, name: string, email: string, emailVerified: bool, roles: list<string>, permissions: list<string>, hasOrganizationalScopes: bool, hasCustomerAccess: bool, hasSiteAccess: bool}
+     * @return array{id: string, name: string, email: string, emailVerified: bool, roles: list<string>, permissions: list<string>, hasOrganizationalScopes: bool, hasCustomerAccess: bool, hasSiteAccess: bool, employeeStatus: string|null, onboardingWorkflowStatus: string|null}
      */
     private function buildUserAuthorizationData(User $user): array
     {
@@ -992,7 +992,7 @@ class AuthController extends Controller
         }
 
         // Eager load relationships to reduce database queries
-        $user->load(['roles', 'permissions', 'organizationalScopes']);
+        $user->load(['roles', 'permissions', 'organizationalScopes', 'employee']);
 
         /** @var list<string> $roles */
         $roles = $user->getRoleNames()->toArray();
@@ -1002,6 +1002,7 @@ class AuthController extends Controller
 
         $hasCustomerAccess = $user->can('customers.read') || $user->hasAccessibleCustomers();
         $hasSiteAccess = $user->can('sites.read') || $user->hasAccessibleSites();
+        $employee = $user->employee;
 
         return [
             'id' => $user->id,
@@ -1013,6 +1014,8 @@ class AuthController extends Controller
             'hasOrganizationalScopes' => $user->organizationalScopes->isNotEmpty(),
             'hasCustomerAccess' => $hasCustomerAccess,
             'hasSiteAccess' => $hasSiteAccess,
+            'employeeStatus' => $employee?->status,
+            'onboardingWorkflowStatus' => $employee?->onboarding_workflow_status,
         ];
     }
 

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -1015,7 +1015,7 @@ class AuthController extends Controller
             'hasCustomerAccess' => $hasCustomerAccess,
             'hasSiteAccess' => $hasSiteAccess,
             'employeeStatus' => $employee?->status,
-            'onboardingWorkflowStatus' => $employee?->onboarding_workflow_status,
+            'onboardingWorkflowStatus' => $employee?->resolveOnboardingWorkflowStatus(),
         ];
     }
 

--- a/tests/Feature/AuthTest.php
+++ b/tests/Feature/AuthTest.php
@@ -5,6 +5,7 @@
 
 use App\Models\Customer;
 use App\Models\CustomerAssignment;
+use App\Models\Employee;
 use App\Models\OrganizationalUnit;
 use App\Models\Site;
 use App\Models\User;
@@ -104,6 +105,38 @@ describe('SPA Session Login', function () {
                     'emailVerified' => true,
                 ],
             ]);
+    });
+
+    test('spa login and me payloads include employee status and resolved onboarding workflow state', function () {
+        $email = 'employee-auth-payload@secpal.dev';
+
+        $user = User::factory()->create([
+            'name' => 'Employee Payload User',
+            'email' => $email,
+            'password' => bcrypt('password123'),
+        ]);
+
+        Employee::factory()->create([
+            'user_id' => $user->id,
+            'email' => $email,
+            'status' => Employee::STATUS_PRE_CONTRACT,
+            'onboarding_workflow_status' => null,
+        ]);
+
+        $this->withHeaders(spaHeaders([
+            'X-XSRF-TOKEN' => issueSpaCsrfToken($this),
+        ]))->postJson('/v1/auth/login', [
+            'email' => $email,
+            'password' => 'password123',
+        ])->assertOk()
+            ->assertJsonPath('user.employeeStatus', Employee::STATUS_PRE_CONTRACT)
+            ->assertJsonPath('user.onboardingWorkflowStatus', Employee::WORKFLOW_STATUS_INVITED);
+
+        $this->withHeaders(spaHeaders())
+            ->getJson('/v1/me')
+            ->assertOk()
+            ->assertJsonPath('employeeStatus', Employee::STATUS_PRE_CONTRACT)
+            ->assertJsonPath('onboardingWorkflowStatus', Employee::WORKFLOW_STATUS_INVITED);
     });
 
     test('spa login fails with invalid credentials', function () {

--- a/tests/Feature/OnboardingCompletionTest.php
+++ b/tests/Feature/OnboardingCompletionTest.php
@@ -9,7 +9,6 @@ use App\Models\Employee;
 use App\Models\EmployeeOnboardingToken;
 use App\Models\TenantKey;
 use App\Models\User;
-use Illuminate\Auth\Notifications\VerifyEmail;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Notification;
@@ -64,7 +63,7 @@ test('completes onboarding with valid token', function () {
         ->assertJsonStructure([
             'message',
             'data' => [
-                'user' => ['id', 'email', 'name'],
+                'user' => ['id', 'email', 'name', 'email_verified'],
                 'employee' => ['id', 'first_name', 'last_name', 'status'],
             ],
         ])
@@ -80,8 +79,9 @@ test('completes onboarding with valid token', function () {
     // Assert: Password set on user
     $user = $employee->user;
     expect($user)->not->toBeNull();
-    expect(Hash::check('SecurePassword123!', $user->password))->toBeTrue();
-    Notification::assertSentTo($user, VerifyEmail::class);
+    expect(Hash::check('SecurePassword123!', $user->password))->toBeTrue()
+        ->and($user->hasVerifiedEmail())->toBeTrue();
+    Notification::assertNothingSent();
 
     // Assert: Token marked as completed
     $tokenModel = $tokenData['model'];

--- a/tests/Feature/OnboardingCompletionTest.php
+++ b/tests/Feature/OnboardingCompletionTest.php
@@ -9,7 +9,9 @@ use App\Models\Employee;
 use App\Models\EmployeeOnboardingToken;
 use App\Models\TenantKey;
 use App\Models\User;
+use Illuminate\Auth\Events\Verified;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Notification;
 
@@ -89,6 +91,71 @@ test('completes onboarding with valid token', function () {
     expect($tokenModel->completed_at)->not->toBeNull()
         ->and($tokenModel->completed_from_ip)->not->toBeNull()
         ->and($tokenModel->completed_user_agent)->not->toBeNull();
+});
+
+test('completes onboarding by syncing and verifying the invited employee email on the linked user account', function () {
+    Notification::fake();
+
+    /** @var User $user */
+    $user = User::factory()->unverified()->create([
+        'email' => 'stale-user@secpal.dev',
+        'password' => Hash::make('temporary-password'),
+    ]);
+
+    /** @var Employee $employee */
+    $employee = Employee::factory()->preContract()->create([
+        'first_name' => 'Email',
+        'last_name' => 'Mismatch',
+        'email' => 'invited-employee@secpal.dev',
+        'user_id' => $user->id,
+    ]);
+
+    $tokenData = EmployeeOnboardingToken::generate($employee);
+
+    $this->withSession([])->postJson('/v1/onboarding/complete', [
+        'token' => $tokenData['plain'],
+        'email' => $employee->email,
+        'password' => 'SecurePassword123!',
+        'first_name' => 'Email',
+        'last_name' => 'Mismatch',
+    ])->assertOk()
+        ->assertJsonPath('data.user.email', $employee->email)
+        ->assertJsonPath('data.user.email_verified', true);
+
+    $user->refresh();
+    expect($user->email)->toBe($employee->email)
+        ->and($user->hasVerifiedEmail())->toBeTrue();
+    Notification::assertNothingSent();
+});
+
+test('dispatches verified event when onboarding completion verifies the user email', function () {
+    Event::fake([Verified::class]);
+
+    /** @var User $user */
+    $user = User::factory()->unverified()->create([
+        'password' => Hash::make('temporary-password'),
+    ]);
+
+    /** @var Employee $employee */
+    $employee = Employee::factory()->preContract()->create([
+        'first_name' => 'Event',
+        'last_name' => 'Dispatch',
+        'email' => $user->email,
+        'user_id' => $user->id,
+    ]);
+
+    $tokenData = EmployeeOnboardingToken::generate($employee);
+
+    $this->withSession([])->postJson('/v1/onboarding/complete', [
+        'token' => $tokenData['plain'],
+        'email' => $employee->email,
+        'password' => 'SecurePassword123!',
+        'first_name' => 'Event',
+        'last_name' => 'Dispatch',
+    ])->assertOk();
+
+    $user->refresh();
+    Event::assertDispatched(Verified::class, fn (Verified $event): bool => $event->user->is($user));
 });
 
 test('rejects invalid token', function () {


### PR DESCRIPTION
## Summary
- treat successful onboarding-link completion as proof of mailbox ownership
- mark onboarding users as email-verified during onboarding completion
- stop sending a separate verification email after onboarding completion
- expose employee onboarding state in auth payload to support frontend route-guard logic

## Key Changes
- `OnboardingController@complete`
  - calls `markEmailAsVerified()` once onboarding completes successfully
  - removes `sendEmailVerificationNotification()` fallback send
  - includes `email_verified` in completion response payload
- `AuthController::buildUserAuthorizationData`
  - adds `employeeStatus` and `onboardingWorkflowStatus`
  - eager-loads `employee` relation for payload construction
- updates onboarding completion feature test expectations accordingly

## Validation
- `php artisan test tests/Feature/OnboardingCompletionTest.php tests/Feature/AuthTest.php tests/Feature/Auth/SanctumCookieAuthTest.php`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes account email/verification state during onboarding completion and expands auth payloads, which can affect authentication/authorization flows and downstream frontend assumptions. Behavior is covered by new/updated feature tests but should be reviewed for edge cases around mismatched emails and verification state resets.
> 
> **Overview**
> Treats successful `POST /v1/onboarding/complete` as proof of mailbox ownership by **syncing the user login email to the invited employee email, marking it verified, and dispatching the `Verified` event**, instead of sending a separate verification notification; the completion response now includes `email_verified`.
> 
> Extends SPA auth responses (`/v1/auth/login` and `/v1/me`) to include `employeeStatus` and resolved `onboardingWorkflowStatus` via `Employee::resolveOnboardingWorkflowStatus()`, with updated regression coverage in `AuthTest` and `OnboardingCompletionTest`, plus a changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e43fbbc65f31b3edef862e2af678a9d5396f9dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->