### PR TITLE
Add employee emergency contacts to API and persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - wrapped onboarding submission approval state updates and completion checks in one transaction, and restricted tax-identifier employee sync to the canonical `tax_identification_number` template key so approval can no longer commit partial state or mutate PII from name-matched custom templates
 - aligned onboarding completion email verification with the invited employee mailbox by syncing the user login email before verification and dispatching the `Verified` event in that path; auth payloads now also expose resolved onboarding workflow state via `Employee::resolveOnboardingWorkflowStatus()`, with regression tests for login, `/v1/me`, and onboarding completion
 
+### Added
+
+- added optional employee `emergency_contacts` support across request validation, persistence (new nullable JSON column on `employees`), and API resource serialization, with targeted regression tests for validation, model casting, resource output, and schema presence
+
 ### Changed
 
 - removed duplicate assertion in `OnboardingControllerTest` consent-field test

--- a/app/Http/Requests/StoreEmployeeRequest.php
+++ b/app/Http/Requests/StoreEmployeeRequest.php
@@ -124,6 +124,14 @@ class StoreEmployeeRequest extends FormRequest
             'address_history.*.postal_code' => ['required', 'string', 'max:20'],
             'address_history.*.country' => ['required', 'string', 'size:2', 'regex:/^[A-Z]{2}$/'],
 
+            // Emergency contacts
+            'emergency_contacts' => ['nullable', 'array'],
+            'emergency_contacts.*.name' => ['required', 'string', 'max:255'],
+            'emergency_contacts.*.relationship' => ['nullable', 'string', 'max:100'],
+            'emergency_contacts.*.phone' => ['required', 'string', 'max:255'],
+            'emergency_contacts.*.email' => ['nullable', 'email', 'max:255'],
+            'emergency_contacts.*.notes' => ['nullable', 'string', 'max:500'],
+
             // BewachV § 16 Abs. 2 Nr. 7: Intended Activities
             'intended_activities' => ['nullable', 'array'], // JSON array of activity codes
             'intended_activities.*' => ['string', 'max:100'],
@@ -305,6 +313,11 @@ class StoreEmployeeRequest extends FormRequest
             'address_history.*.city.required' => 'Stadt für Adresshistorie erforderlich.',
             'address_history.*.postal_code.required' => 'PLZ für Adresshistorie erforderlich.',
             'address_history.*.country.required' => 'Land für Adresshistorie erforderlich.',
+
+            // Emergency contacts
+            'emergency_contacts.*.name.required' => 'Name für Notfallkontakt ist erforderlich.',
+            'emergency_contacts.*.phone.required' => 'Telefonnummer für Notfallkontakt ist erforderlich.',
+            'emergency_contacts.*.email.email' => 'E-Mail für Notfallkontakt muss gültig sein.',
 
             // Work permits
             'work_permit_type.required' => 'Arbeitserlaubnis-Typ ist für nicht freizügigkeitsberechtigte Staatsangehörigkeiten verpflichtend.',

--- a/app/Http/Requests/UpdateEmployeeRequest.php
+++ b/app/Http/Requests/UpdateEmployeeRequest.php
@@ -106,6 +106,14 @@ class UpdateEmployeeRequest extends FormRequest
             'address_history.*.postal_code' => ['required', 'string', 'max:20'],
             'address_history.*.country' => ['required', 'string', 'size:2', 'regex:/^[A-Z]{2}$/'],
 
+            // Emergency contacts
+            'emergency_contacts' => ['sometimes', 'nullable', 'array'],
+            'emergency_contacts.*.name' => ['required', 'string', 'max:255'],
+            'emergency_contacts.*.relationship' => ['nullable', 'string', 'max:100'],
+            'emergency_contacts.*.phone' => ['required', 'string', 'max:255'],
+            'emergency_contacts.*.email' => ['nullable', 'email', 'max:255'],
+            'emergency_contacts.*.notes' => ['nullable', 'string', 'max:500'],
+
             // BewachV § 16 Abs. 2 Nr. 7: Intended Activities
             'intended_activities' => ['sometimes', 'nullable', 'array'],
             'intended_activities.*' => ['string', 'max:100'],
@@ -244,6 +252,11 @@ class UpdateEmployeeRequest extends FormRequest
 
             // Address history
             'address_history.*.to.after_or_equal' => 'End-Datum muss nach Start-Datum liegen.',
+
+            // Emergency contacts
+            'emergency_contacts.*.name.required' => 'Name für Notfallkontakt ist erforderlich.',
+            'emergency_contacts.*.phone.required' => 'Telefonnummer für Notfallkontakt ist erforderlich.',
+            'emergency_contacts.*.email.email' => 'E-Mail für Notfallkontakt muss gültig sein.',
 
             // Work permits
             'work_permit_type.required' => 'Arbeitserlaubnis-Typ ist für nicht freizügigkeitsberechtigte Staatsangehörigkeiten verpflichtend.',

--- a/app/Http/Resources/EmployeeResource.php
+++ b/app/Http/Resources/EmployeeResource.php
@@ -82,6 +82,9 @@ class EmployeeResource extends JsonResource
             // BewachV § 16 Abs. 2 Nr. 6: Address History (Last 5 Years)
             'address_history' => $this->address_history, // JSON array
 
+            // Additional contact data
+            'emergency_contacts' => $this->emergency_contacts, // JSON array
+
             // BewachV § 16 Abs. 2 Nr. 7: Intended Activities (§34a work types)
             'intended_activities' => $this->intended_activities, // JSON array
 

--- a/app/Models/Employee.php
+++ b/app/Models/Employee.php
@@ -57,6 +57,7 @@ use Spatie\Activitylog\Support\LogOptions;
  * @property string|null $address_country ISO 3166-1 alpha-2
  * @property string|null $address_state
  * @property array<int, array{from: string, to: string, street: string, house_number: string, postal_code: string, city: string, country: string, state: ?string}>|null $address_history Array of address objects (5 years)
+ * @property array<int, array{name: string, relationship?: ?string, phone: string, email?: ?string, notes?: ?string}>|null $emergency_contacts Optional emergency contacts
  * @property array<int, string>|null $intended_activities Array of activity codes
  * @property string|null $id_document_type id_card|passport|residence_permit
  * @property string|null $id_document_number_enc Encrypted document number
@@ -350,6 +351,7 @@ class Employee extends Model
         'address_country',
         'address_state',
         'address_history',
+        'emergency_contacts',
         // Intended Activities
         'intended_activities',
         // ID Document
@@ -489,6 +491,7 @@ class Employee extends Model
             'previous_names' => 'array',
             'nationalities' => 'array',
             'address_history' => 'array',
+            'emergency_contacts' => 'array',
             'intended_activities' => 'array',
             'additional_certifications' => 'array',
             'runtime_access_snapshot' => 'array',

--- a/database/migrations/2026_05_05_000100_add_emergency_contacts_to_employees_table.php
+++ b/database/migrations/2026_05_05_000100_add_emergency_contacts_to_employees_table.php
@@ -1,0 +1,32 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('employees', function (Blueprint $table) {
+            $table->json('emergency_contacts')->nullable()->after('address_history')
+                ->comment('Optional emergency contacts for the employee');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('employees', function (Blueprint $table) {
+            $table->dropColumn('emergency_contacts');
+        });
+    }
+};

--- a/tests/Feature/BewachvEmployeeFieldsValidationTest.php
+++ b/tests/Feature/BewachvEmployeeFieldsValidationTest.php
@@ -407,6 +407,70 @@ test('update request validates additional certifications and firearms expiry fie
         ->and($validator->errors()->has('additional_certifications.0.expiry_date'))->toBeTrue();
 });
 
+test('emergency contacts require name and phone and validate optional email format', function () {
+    $invalidStoreValidator = makeStoreEmployeeValidator($this, validStoreEmployeeData($this, [
+        'email' => 'emergency-contacts-invalid@example.com',
+        'emergency_contacts' => [
+            [
+                'relationship' => 'Partner',
+                'email' => 'invalid-email-format',
+            ],
+        ],
+    ]));
+
+    expect($invalidStoreValidator->fails())->toBeTrue()
+        ->and($invalidStoreValidator->errors()->has('emergency_contacts.0.name'))->toBeTrue()
+        ->and($invalidStoreValidator->errors()->has('emergency_contacts.0.phone'))->toBeTrue()
+        ->and($invalidStoreValidator->errors()->has('emergency_contacts.0.email'))->toBeTrue();
+
+    $validStoreValidator = makeStoreEmployeeValidator($this, validStoreEmployeeData($this, [
+        'email' => 'emergency-contacts-valid@example.com',
+        'emergency_contacts' => [
+            [
+                'name' => 'Max Mustermann',
+                'relationship' => 'Partner',
+                'phone' => '+49 151 1234567',
+                'email' => 'max.mustermann@secpal.dev',
+                'notes' => 'Nur in dringenden Fällen kontaktieren.',
+            ],
+        ],
+    ]));
+
+    expect($validStoreValidator->passes())->toBeTrue();
+});
+
+test('UpdateEmployeeRequest validates emergency contacts on partial updates', function () {
+    $employee = Employee::factory()->create([
+        'tenant_id' => $this->tenant->id,
+        'organizational_unit_id' => $this->organizationalUnit->id,
+    ]);
+
+    $invalidUpdateValidator = makeUpdateEmployeeValidator($this, $employee, [
+        'emergency_contacts' => [
+            [
+                'name' => 'Kontaktperson',
+                'phone' => '+49 30 000000',
+                'email' => 'not-an-email',
+            ],
+        ],
+    ]);
+
+    expect($invalidUpdateValidator->fails())->toBeTrue()
+        ->and($invalidUpdateValidator->errors()->has('emergency_contacts.0.email'))->toBeTrue();
+
+    $validUpdateValidator = makeUpdateEmployeeValidator($this, $employee, [
+        'emergency_contacts' => [
+            [
+                'name' => 'Kontaktperson',
+                'phone' => '+49 30 000000',
+                'email' => 'kontakt@secpal.dev',
+            ],
+        ],
+    ]);
+
+    expect($validUpdateValidator->passes())->toBeTrue();
+});
+
 test('validation messages are in German', function () {
     $request = new StoreEmployeeRequest;
 

--- a/tests/Feature/Migrations/EmployeeNumberTenantUniquenessTest.php
+++ b/tests/Feature/Migrations/EmployeeNumberTenantUniquenessTest.php
@@ -110,6 +110,10 @@ test('employees table rejects duplicate employee numbers within the same tenant'
 });
 
 test('employees table includes nullable emergency contacts json column', function (): void {
-    expect(Schema::hasColumn('employees', 'emergency_contacts'))->toBeTrue()
-        ->and(Schema::getColumnType('employees', 'emergency_contacts'))->toBe('json');
+    $column = collect(Schema::getColumns('employees'))
+        ->firstWhere('name', 'emergency_contacts');
+
+    expect($column)->not->toBeNull()
+        ->and($column['type'] ?? null)->toBe('json')
+        ->and($column['nullable'] ?? null)->toBeTrue();
 });

--- a/tests/Feature/Migrations/EmployeeNumberTenantUniquenessTest.php
+++ b/tests/Feature/Migrations/EmployeeNumberTenantUniquenessTest.php
@@ -108,3 +108,8 @@ test('employees table rejects duplicate employee numbers within the same tenant'
 
     expect()->fail('Expected a tenant-scoped employee number unique constraint violation.');
 });
+
+test('employees table includes nullable emergency contacts json column', function (): void {
+    expect(Schema::hasColumn('employees', 'emergency_contacts'))->toBeTrue()
+        ->and(Schema::getColumnType('employees', 'emergency_contacts'))->toBe('json');
+});

--- a/tests/Unit/Models/EmployeeModelBewachvFieldsTest.php
+++ b/tests/Unit/Models/EmployeeModelBewachvFieldsTest.php
@@ -207,6 +207,25 @@ test('it casts address history to array', function () {
     expect($this->employee->address_history)->toBeArray()->and($this->employee->address_history)->toEqual($addressHistory);
 });
 
+test('it casts emergency contacts to array', function () {
+    $emergencyContacts = [
+        [
+            'name' => 'Max Mustermann',
+            'relationship' => 'Partner',
+            'phone' => '+49 151 1234567',
+            'email' => 'max.mustermann@secpal.dev',
+            'notes' => 'Primärer Notfallkontakt',
+        ],
+    ];
+
+    $this->employee->emergency_contacts = $emergencyContacts;
+    $this->employee->save();
+
+    $this->employee->refresh();
+    expect($this->employee->emergency_contacts)->toBeArray()
+        ->and($this->employee->emergency_contacts)->toEqual($emergencyContacts);
+});
+
 test('it stores bwr id as string with leading zeros', function () {
     $bwrId = '0123456';
     $this->employee->bwr_id = $bwrId;

--- a/tests/Unit/Resources/EmployeeResourceBewachvTest.php
+++ b/tests/Unit/Resources/EmployeeResourceBewachvTest.php
@@ -67,7 +67,8 @@ test('EmployeeResource includes all BewachV fields', function () {
         ->and($array)->toHaveKey('structured_address');
 
     // Address history
-    expect($array)->toHaveKey('address_history');
+    expect($array)->toHaveKey('address_history')
+        ->and($array)->toHaveKey('emergency_contacts');
 
     // Intended activities
     expect($array)->toHaveKey('intended_activities');
@@ -107,6 +108,28 @@ test('EmployeeResource includes all BewachV fields', function () {
         ->and($array)->toHaveKey('evacuation_cert_date')
         ->and($array)->toHaveKey('evacuation_cert_expiry')
         ->and($array)->toHaveKey('additional_certifications');
+});
+
+test('EmployeeResource serializes emergency contacts', function () {
+    $emergencyContacts = [
+        [
+            'name' => 'Max Mustermann',
+            'relationship' => 'Partner',
+            'phone' => '+49 151 1234567',
+            'email' => 'max.mustermann@secpal.dev',
+            'notes' => 'Primärer Notfallkontakt',
+        ],
+    ];
+
+    $employee = Employee::factory()->create([
+        'emergency_contacts' => $emergencyContacts,
+    ]);
+
+    $resource = new EmployeeResource($employee);
+    $array = $resource->toArray(employeeResourceRequest(true));
+
+    expect($array['emergency_contacts'])->toBeArray()
+        ->and($array['emergency_contacts'])->toEqual($emergencyContacts);
 });
 
 test('EmployeeResource formats dates consistently', function () {


### PR DESCRIPTION
## Summary
- add nullable `emergency_contacts` JSON column to `employees`
- allow `emergency_contacts` in store/update validation with German validation messages
- expose `emergency_contacts` via `EmployeeResource`
- add model fillable/cast/phpdoc support
- add regression tests for validation, migration schema, model casting, and resource serialization

## Testing
- php -l app/Models/Employee.php
- php -l app/Http/Requests/StoreEmployeeRequest.php
- php -l app/Http/Requests/UpdateEmployeeRequest.php
- php -l app/Http/Resources/EmployeeResource.php
- php -l database/migrations/2026_05_05_000100_add_emergency_contacts_to_employees_table.php
- php artisan test tests/Feature/BewachvEmployeeFieldsValidationTest.php tests/Feature/Migrations/EmployeeNumberTenantUniquenessTest.php tests/Unit/Models/EmployeeModelBewachvFieldsTest.php tests/Unit/Resources/EmployeeResourceBewachvTest.php

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new persisted employee field and exposes it via create/update and API responses, which can impact API consumers and database migrations but is otherwise localized and covered by tests.
> 
> **Overview**
> Adds optional employee `emergency_contacts` support end-to-end: request validation for `POST /v1/employees` and `PATCH /v1/employees/{employee}` (including German messages), persistence via a new nullable JSON `employees.emergency_contacts` column, and serialization through `EmployeeResource`.
> 
> Updates the `Employee` model to accept and cast `emergency_contacts` as an array and adds regression coverage for validation, schema/migration presence, model casting, and resource output; also notes the addition in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de2f9750f1947741d9f960026554aef8090be34c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->