### PR TITLE
fix(onboarding): scope template validation by tenant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- scoped onboarding submission `form_template_id` existence validation to the authenticated tenant plus global templates, so cross-tenant template UUID probes now fail with `422` validation errors instead of leaking into later tenant-scoped `404` responses
 - enforced server-side residence-title requirements during onboarding submission for non-exempt nationalities (title + employment authorization, and expiry when not unlimited) so clients can no longer bypass the frontend-only checks by posting `nationalities` without required residence data
 - aligned passkey credential mapping with WebAuthn-lib 5.3 by using `PublicKeyCredentialSource` directly, fixing passkey challenge flows that were failing with a `TypeError` (return type mismatch)
 - forced the PHPUnit `DB_CONNECTION` and `DB_DATABASE` overrides so the early PostgreSQL test bootstrap always provisions `testing*_test_*` databases instead of inheriting runtime `secpal*` names from the shell environment during parallel runs

--- a/app/Http/Requests/SubmitOnboardingFormRequest.php
+++ b/app/Http/Requests/SubmitOnboardingFormRequest.php
@@ -38,6 +38,8 @@ class SubmitOnboardingFormRequest extends FormRequest
             'form_template_id' => [
                 'required',
                 Rule::exists('onboarding_form_templates', 'id')->where(function (\Illuminate\Database\Query\Builder $query) use ($tenantId): void {
+                    $query->whereNull('deleted_at');
+
                     if ($tenantId === null) {
                         $query->whereNull('tenant_id');
 

--- a/app/Http/Requests/SubmitOnboardingFormRequest.php
+++ b/app/Http/Requests/SubmitOnboardingFormRequest.php
@@ -6,6 +6,7 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 /**
  * SubmitOnboardingFormRequest validates onboarding form submission requests.
@@ -30,8 +31,25 @@ class SubmitOnboardingFormRequest extends FormRequest
      */
     public function rules(): array
     {
+        /** @var int|null $tenantId */
+        $tenantId = $this->user()?->tenant_id;
+
         return [
-            'form_template_id' => ['required', 'exists:onboarding_form_templates,id'],
+            'form_template_id' => [
+                'required',
+                Rule::exists('onboarding_form_templates', 'id')->where(function (\Illuminate\Database\Query\Builder $query) use ($tenantId): void {
+                    if ($tenantId === null) {
+                        $query->whereNull('tenant_id');
+
+                        return;
+                    }
+
+                    $query->where(function (\Illuminate\Database\Query\Builder $templateQuery) use ($tenantId): void {
+                        $templateQuery->whereNull('tenant_id')
+                            ->orWhere('tenant_id', $tenantId);
+                    });
+                }),
+            ],
             'form_data' => ['present', 'array'],
             'status' => ['required', 'in:draft,submitted'],
         ];

--- a/tests/Feature/Controllers/OnboardingControllerTest.php
+++ b/tests/Feature/Controllers/OnboardingControllerTest.php
@@ -909,7 +909,7 @@ describe('POST /v1/onboarding/submissions', function () {
             ->assertJsonPath('data.status', 'submitted');
     });
 
-    test('returns 404 when employee submits a template from a different tenant', function (): void {
+    test('returns 422 when employee submits a template from a different tenant', function (): void {
         givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.write');
 
         // Create a template belonging to a different tenant
@@ -930,7 +930,8 @@ describe('POST /v1/onboarding/submissions', function () {
                 'status' => 'draft',
             ]);
 
-        $response->assertStatus(404);
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['form_template_id']);
     });
 
     test('rejects partial optional-template payload when required schema fields are missing on submit', function (): void {

--- a/tests/Feature/Controllers/OnboardingControllerTest.php
+++ b/tests/Feature/Controllers/OnboardingControllerTest.php
@@ -934,6 +934,44 @@ describe('POST /v1/onboarding/submissions', function () {
             ->assertJsonValidationErrors(['form_template_id']);
     });
 
+    test('returns 422 when employee submits a deleted template', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.write');
+
+        $deletedTemplate = OnboardingFormTemplate::factory()->create([
+            'tenant_id' => $this->tenant->id,
+            'form_schema' => [
+                'type' => 'object',
+                'properties' => ['name' => ['type' => 'string']],
+                'required' => ['name'],
+            ],
+        ]);
+        $deletedTemplate->delete();
+
+        $response = $this->withToken($this->token)
+            ->postJson('/v1/onboarding/submissions', [
+                'form_template_id' => $deletedTemplate->id,
+                'form_data' => ['name' => 'test'],
+                'status' => 'draft',
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['form_template_id']);
+    });
+
+    test('returns 422 when employee submits a nonexistent template identifier', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.write');
+
+        $response = $this->withToken($this->token)
+            ->postJson('/v1/onboarding/submissions', [
+                'form_template_id' => (string) Illuminate\Support\Str::uuid(),
+                'form_data' => ['name' => 'test'],
+                'status' => 'draft',
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['form_template_id']);
+    });
+
     test('rejects partial optional-template payload when required schema fields are missing on submit', function (): void {
         givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.write');
 


### PR DESCRIPTION
## Summary
- scope onboarding submission `form_template_id` validation to global plus authenticated-tenant templates
- change the cross-tenant submission regression test from a later 404 to an immediate 422 validation failure
- document the security fix in the API changelog

## Testing
- php artisan test tests/Feature/Controllers/OnboardingControllerTest.php --filter="returns 422 when employee submits a template from a different tenant"
- php artisan test tests/Feature/Controllers/OnboardingControllerTest.php --filter="creates submission with submitted status and timestamp|returns 422 when employee submits a template from a different tenant"
- vendor/bin/pint --dirty

Fixes #1021
Related #1012

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request validation and response semantics for onboarding submission template IDs (now `422` instead of tenant-scoped `404`), which could affect client error handling while closing a cross-tenant enumeration vector.
> 
> **Overview**
> **Tightens onboarding submission validation** by scoping `form_template_id` existence checks to *global templates + the authenticated tenant* and excluding soft-deleted templates, so cross-tenant/deleted/nonexistent IDs fail fast with a `422` validation error.
> 
> Updates onboarding submission feature coverage to expect the new `422` behavior (including new cases for deleted and nonexistent template IDs) and records the security fix in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09009ea8b7594d83bf1d100f2a1e59ffc7ad29ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->