### PR TITLE
fix(locale): avoid redundant global auth resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- avoided unnecessary locale user-resolution work in the global middleware pass when no bearer token is present, while still allowing the later API pass to honor session-authenticated `preferred_locale` overrides
 - enforced server-side residence-title requirements during onboarding submission for non-exempt nationalities (title + employment authorization, and expiry when not unlimited) so clients can no longer bypass the frontend-only checks by posting `nationalities` without required residence data
 - aligned passkey credential mapping with WebAuthn-lib 5.3 by using `PublicKeyCredentialSource` directly, fixing passkey challenge flows that were failing with a `TypeError` (return type mismatch)
 - forced the PHPUnit `DB_CONNECTION` and `DB_DATABASE` overrides so the early PostgreSQL test bootstrap always provisions `testing*_test_*` databases instead of inheriting runtime `secpal*` names from the shell environment during parallel runs

--- a/app/Http/Middleware/SetLocaleFromHeader.php
+++ b/app/Http/Middleware/SetLocaleFromHeader.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpFoundation\Response;
 
 class SetLocaleFromHeader
 {
-    private const ALLOW_USER_LOOKUP_ATTRIBUTE = 'secpal.locale.allow_user_lookup';
+    private const ALLOW_USER_LOOKUP_ATTRIBUTE = 'locale.allow_user_lookup';
 
     /**
      * Handle an incoming request and set the application locale.

--- a/app/Http/Middleware/SetLocaleFromHeader.php
+++ b/app/Http/Middleware/SetLocaleFromHeader.php
@@ -14,6 +14,10 @@ class SetLocaleFromHeader
 {
     private const ALLOW_USER_LOOKUP_ATTRIBUTE = 'locale.allow_user_lookup';
 
+    private const USER_LOOKUP_COMPLETED_ATTRIBUTE = 'locale.user_lookup_completed';
+
+    private const USER_LOCALE_APPLIED_ATTRIBUTE = 'locale.user_locale_applied';
+
     /**
      * Handle an incoming request and set the application locale.
      *
@@ -31,17 +35,25 @@ class SetLocaleFromHeader
     {
         $supportedLocales = ['en', 'de'];
 
-        $canResolveUserLocale = $request->attributes->getBoolean(self::ALLOW_USER_LOOKUP_ATTRIBUTE)
-            || $request->bearerToken() !== null;
+        if ($request->attributes->getBoolean(self::USER_LOCALE_APPLIED_ATTRIBUTE)) {
+            return $next($request);
+        }
 
-        // The global pass sets the marker so the later API-group pass can resolve
-        // session-authenticated users without forcing auth resolution twice.
+        $canResolveUserLocale = ! $request->attributes->getBoolean(self::USER_LOOKUP_COMPLETED_ATTRIBUTE)
+            && (
+                $request->attributes->getBoolean(self::ALLOW_USER_LOOKUP_ATTRIBUTE)
+                || $request->bearerToken() !== null
+            );
+
         $request->attributes->set(self::ALLOW_USER_LOOKUP_ATTRIBUTE, true);
 
         if ($canResolveUserLocale) {
+            $request->attributes->set(self::USER_LOOKUP_COMPLETED_ATTRIBUTE, true);
+
             $preferredLocale = $request->user()?->preferred_locale;
             if (is_string($preferredLocale) && in_array($preferredLocale, $supportedLocales, true)) {
                 App::setLocale($preferredLocale);
+                $request->attributes->set(self::USER_LOCALE_APPLIED_ATTRIBUTE, true);
 
                 return $next($request);
             }

--- a/app/Http/Middleware/SetLocaleFromHeader.php
+++ b/app/Http/Middleware/SetLocaleFromHeader.php
@@ -12,6 +12,8 @@ use Symfony\Component\HttpFoundation\Response;
 
 class SetLocaleFromHeader
 {
+    private const ALLOW_USER_LOOKUP_ATTRIBUTE = 'secpal.locale.allow_user_lookup';
+
     /**
      * Handle an incoming request and set the application locale.
      *
@@ -29,11 +31,20 @@ class SetLocaleFromHeader
     {
         $supportedLocales = ['en', 'de'];
 
-        $preferredLocale = $request->user()?->preferred_locale;
-        if (is_string($preferredLocale) && in_array($preferredLocale, $supportedLocales, true)) {
-            App::setLocale($preferredLocale);
+        $canResolveUserLocale = $request->attributes->getBoolean(self::ALLOW_USER_LOOKUP_ATTRIBUTE)
+            || $request->bearerToken() !== null;
 
-            return $next($request);
+        // The global pass sets the marker so the later API-group pass can resolve
+        // session-authenticated users without forcing auth resolution twice.
+        $request->attributes->set(self::ALLOW_USER_LOOKUP_ATTRIBUTE, true);
+
+        if ($canResolveUserLocale) {
+            $preferredLocale = $request->user()?->preferred_locale;
+            if (is_string($preferredLocale) && in_array($preferredLocale, $supportedLocales, true)) {
+                App::setLocale($preferredLocale);
+
+                return $next($request);
+            }
         }
 
         // Get preferred language from Accept-Language header

--- a/tests/Feature/LocaleMiddlewareTest.php
+++ b/tests/Feature/LocaleMiddlewareTest.php
@@ -3,7 +3,9 @@
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+use App\Http\Middleware\SetLocaleFromHeader;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Route;
 
@@ -59,6 +61,24 @@ test('middleware prefers higher quality language from Accept-Language header', f
 
     expect(App::getLocale())->toBe('de');
     $response->assertOk();
+});
+
+test('middleware does not resolve user when request has no bearer token', function (): void {
+    $request = Request::create('/health', 'GET', [], [], [], [
+        'HTTP_ACCEPT_LANGUAGE' => 'de',
+    ]);
+
+    $request->setUserResolver(static function (): never {
+        throw new RuntimeException('user resolver should not run without a bearer token');
+    });
+
+    $response = app(SetLocaleFromHeader::class)->handle(
+        $request,
+        static fn (): Illuminate\Http\Response => response()->noContent(),
+    );
+
+    expect(App::getLocale())->toBe('de')
+        ->and($response->getStatusCode())->toBe(204);
 });
 
 test('middleware prefers authenticated user preferred locale over Accept-Language header', function (): void {

--- a/tests/Feature/LocaleMiddlewareTest.php
+++ b/tests/Feature/LocaleMiddlewareTest.php
@@ -63,7 +63,7 @@ test('middleware prefers higher quality language from Accept-Language header', f
     $response->assertOk();
 });
 
-test('middleware does not resolve user when request has no bearer token', function (): void {
+test('middleware does not resolve user during the global pass when request has no bearer token or lookup marker', function (): void {
     $request = Request::create('/health', 'GET', [], [], [], [
         'HTTP_ACCEPT_LANGUAGE' => 'de',
     ]);
@@ -74,10 +74,40 @@ test('middleware does not resolve user when request has no bearer token', functi
 
     $response = app(SetLocaleFromHeader::class)->handle(
         $request,
-        static fn (): Illuminate\Http\Response => response()->noContent(),
+        static fn (Request $request): Illuminate\Http\Response => response()->noContent(),
     );
 
     expect(App::getLocale())->toBe('de')
+        ->and($response->getStatusCode())->toBe(204);
+});
+
+test('middleware resolves bearer-token user locale at most once across both middleware passes', function (): void {
+    $request = Request::create('/v1/example', 'GET', [], [], [], [
+        'HTTP_ACCEPT_LANGUAGE' => 'en',
+        'HTTP_AUTHORIZATION' => 'Bearer token',
+    ]);
+
+    $lookupCount = 0;
+    $request->setUserResolver(static function () use (&$lookupCount): object {
+        $lookupCount++;
+
+        return (object) ['preferred_locale' => 'de'];
+    });
+
+    $middleware = app(SetLocaleFromHeader::class);
+
+    $middleware->handle(
+        $request,
+        static fn (Request $request): Illuminate\Http\Response => response()->noContent(),
+    );
+
+    $response = $middleware->handle(
+        $request,
+        static fn (Request $request): Illuminate\Http\Response => response()->noContent(),
+    );
+
+    expect($lookupCount)->toBe(1)
+        ->and(App::getLocale())->toBe('de')
         ->and($response->getStatusCode())->toBe(204);
 });
 


### PR DESCRIPTION
## Summary
- avoid resolving the user locale during the first global middleware pass when no bearer token is present
- preserve the later API-group pass so session-authenticated requests still honor `preferred_locale`
- add direct regression coverage for the no-token middleware path and record the fix in the changelog

## Testing
- php artisan test tests/Feature/LocaleMiddlewareTest.php
- vendor/bin/pint --dirty

Fixes #1022
Related #1016

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk behavior/perf tweak to locale middleware; it only changes when the request user is resolved (skipping it in the global pass without a bearer token) and is covered by new regression tests.
> 
> **Overview**
> **Reduces unnecessary auth/user resolution in `SetLocaleFromHeader`.** The middleware now skips calling `$request->user()` during the global middleware pass unless a bearer token (or an explicit lookup marker) is present, while ensuring the API-group pass can still apply an authenticated user’s `preferred_locale`.
> 
> Adds regression tests to prove the user resolver is not invoked without a bearer token and that bearer-token locale resolution happens at most once across both middleware passes, and records the fix in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed9953fe5b7b24aec3990719522fe867bd4b5537. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->