### PR TITLE
fix(onboarding): enforce additional properties schema checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- fixed optional onboarding template validation to keep `additionalProperties: false` authoritative even when all declared fields are empty, so payloads with undeclared keys now fail schema validation instead of bypassing it as “semantically empty”
+- fixed optional onboarding template validation to keep undeclared-key schema checks authoritative even when declared fields are empty, so payloads with undeclared keys now fail `additionalProperties` validation instead of bypassing it as “semantically empty”
 - enforced server-side residence-title requirements during onboarding submission for non-exempt nationalities (title + employment authorization, and expiry when not unlimited) so clients can no longer bypass the frontend-only checks by posting `nationalities` without required residence data
 - aligned passkey credential mapping with WebAuthn-lib 5.3 by using `PublicKeyCredentialSource` directly, fixing passkey challenge flows that were failing with a `TypeError` (return type mismatch)
 - forced the PHPUnit `DB_CONNECTION` and `DB_DATABASE` overrides so the early PostgreSQL test bootstrap always provisions `testing*_test_*` databases instead of inheriting runtime `secpal*` names from the shell environment during parallel runs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- fixed optional onboarding template validation to keep undeclared-key schema checks authoritative even when declared fields are empty, so payloads with undeclared keys now fail `additionalProperties` validation instead of bypassing it as “semantically empty”
+- fixed optional onboarding template validation to keep undeclared-key schema checks authoritative even when declared fields are empty, so payloads with undeclared keys now fail `additionalProperties` validation instead of bypassing it as `semantically empty`
 - enforced server-side residence-title requirements during onboarding submission for non-exempt nationalities (title + employment authorization, and expiry when not unlimited) so clients can no longer bypass the frontend-only checks by posting `nationalities` without required residence data
 - aligned passkey credential mapping with WebAuthn-lib 5.3 by using `PublicKeyCredentialSource` directly, fixing passkey challenge flows that were failing with a `TypeError` (return type mismatch)
 - forced the PHPUnit `DB_CONNECTION` and `DB_DATABASE` overrides so the early PostgreSQL test bootstrap always provisions `testing*_test_*` databases instead of inheriting runtime `secpal*` names from the shell environment during parallel runs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- fixed optional onboarding template validation to keep `additionalProperties: false` authoritative even when all declared fields are empty, so payloads with undeclared keys now fail schema validation instead of bypassing it as “semantically empty”
 - enforced server-side residence-title requirements during onboarding submission for non-exempt nationalities (title + employment authorization, and expiry when not unlimited) so clients can no longer bypass the frontend-only checks by posting `nationalities` without required residence data
 - aligned passkey credential mapping with WebAuthn-lib 5.3 by using `PublicKeyCredentialSource` directly, fixing passkey challenge flows that were failing with a `TypeError` (return type mismatch)
 - forced the PHPUnit `DB_CONNECTION` and `DB_DATABASE` overrides so the early PostgreSQL test bootstrap always provisions `testing*_test_*` databases instead of inheriting runtime `secpal*` names from the shell environment during parallel runs

--- a/app/Services/OnboardingFormDataSchemaValidationService.php
+++ b/app/Services/OnboardingFormDataSchemaValidationService.php
@@ -196,11 +196,9 @@ final class OnboardingFormDataSchemaValidationService
             return $formData === [];
         }
 
-        if (($schema['additionalProperties'] ?? true) === false) {
-            foreach (array_keys($formData) as $name) {
-                if (! array_key_exists($name, $properties)) {
-                    return false;
-                }
+        foreach (array_keys($formData) as $name) {
+            if (! array_key_exists($name, $properties)) {
+                return false;
             }
         }
 

--- a/app/Services/OnboardingFormDataSchemaValidationService.php
+++ b/app/Services/OnboardingFormDataSchemaValidationService.php
@@ -196,6 +196,14 @@ final class OnboardingFormDataSchemaValidationService
             return $formData === [];
         }
 
+        if (($schema['additionalProperties'] ?? true) === false) {
+            foreach (array_keys($formData) as $name) {
+                if (! array_key_exists($name, $properties)) {
+                    return false;
+                }
+            }
+        }
+
         foreach ($properties as $name => $property) {
             if (! is_array($property)) {
                 continue;

--- a/tests/Feature/Controllers/OnboardingControllerTest.php
+++ b/tests/Feature/Controllers/OnboardingControllerTest.php
@@ -933,6 +933,30 @@ describe('POST /v1/onboarding/submissions', function () {
         $response->assertStatus(404);
     });
 
+    test('does not skip schema validation for undeclared keys when additional properties are forbidden on optional templates', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.write');
+
+        $template = OnboardingFormTemplate::factory()->optional()->create([
+            'tenant_id' => $this->tenant->id,
+            'form_schema' => [
+                'type' => 'object',
+                'properties' => [
+                    'name' => ['type' => 'string'],
+                ],
+                'additionalProperties' => false,
+            ],
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->postJson('/v1/onboarding/submissions', [
+                'form_template_id' => $template->id,
+                'form_data' => ['unknown_key' => 'unexpected'],
+                'status' => 'submitted',
+            ]);
+
+        $response->assertStatus(422);
+    });
+
     test('rejects partial optional-template payload when required schema fields are missing on submit', function (): void {
         givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.write');
 

--- a/tests/Feature/Controllers/OnboardingControllerTest.php
+++ b/tests/Feature/Controllers/OnboardingControllerTest.php
@@ -957,6 +957,27 @@ describe('POST /v1/onboarding/submissions', function () {
         $response->assertStatus(422);
     });
 
+    test('does not skip schema validation for undeclared keys constrained by additional properties schemas on optional templates', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.write');
+
+        $template = OnboardingFormTemplate::factory()->optional()->create([
+            'tenant_id' => $this->tenant->id,
+            'form_schema' => [
+                'type' => 'object',
+                'additionalProperties' => ['type' => 'integer'],
+            ],
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->postJson('/v1/onboarding/submissions', [
+                'form_template_id' => $template->id,
+                'form_data' => ['dynamic_key' => 'unexpected'],
+                'status' => 'submitted',
+            ]);
+
+        $response->assertStatus(422);
+    });
+
     test('rejects partial optional-template payload when required schema fields are missing on submit', function (): void {
         givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.write');
 

--- a/tests/Feature/Controllers/OnboardingControllerTest.php
+++ b/tests/Feature/Controllers/OnboardingControllerTest.php
@@ -957,7 +957,7 @@ describe('POST /v1/onboarding/submissions', function () {
         $response->assertStatus(422);
     });
 
-    test('does not skip schema validation for undeclared keys constrained by additional properties schemas on optional templates', function (): void {
+    test('does not treat undeclared keys as semantically empty when additional properties define their schema on optional templates', function (): void {
         givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.write');
 
         $template = OnboardingFormTemplate::factory()->optional()->create([


### PR DESCRIPTION
## Summary
- keep `additionalProperties: false` authoritative for optional onboarding templates even when declared fields are empty
- add regression coverage proving undeclared keys now trigger schema validation instead of bypassing it as semantically empty
- document the validation fix in the changelog

## Testing
- php artisan test tests/Feature/Controllers/OnboardingControllerTest.php --filter="does not skip schema validation for undeclared keys when additional properties are forbidden on optional templates|skips full schema enforcement for optional templates with semantically empty payloads on submit"
- vendor/bin/pint --dirty

Fixes #1009

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes onboarding submission schema-validation behavior for optional templates, which may newly reject previously-accepted payloads containing undeclared keys. Risk is moderate and mitigated by added regression tests covering `additionalProperties` edge cases.
> 
> **Overview**
> Fixes optional onboarding-template validation so the “semantically empty” bypass no longer applies when the payload contains *undeclared* keys: `isSemanticallyEmpty()` now returns false if `form_data` includes keys not present in schema `properties`, keeping `additionalProperties` enforcement authoritative.
> 
> Adds feature-test coverage proving submissions with unknown keys now fail with `422` both when `additionalProperties: false` and when `additionalProperties` specifies a schema, and documents the fix in the changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 369041fe4270c788030e83a25e4b8c943f37bda7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->