### PR TITLE
test(onboarding): cover factory json schema defaults

### DIFF
--- a/tests/Unit/Models/OnboardingFormTemplateTest.php
+++ b/tests/Unit/Models/OnboardingFormTemplateTest.php
@@ -91,22 +91,17 @@ test('onboarding form template casts booleans correctly', function () {
         ->and($template->is_system_template)->toBeTrue();
 });
 
-test('onboarding form template casts form schema as array', function () {
-    $schema = [
-        'fields' => [
-            ['name' => 'test_field', 'type' => 'text', 'required' => true],
-        ],
-    ];
-
+test('onboarding form template factory provides a JSON schema object by default', function () {
     $template = OnboardingFormTemplate::factory()->create([
         'tenant_id' => $this->tenant->id,
-        'form_schema' => $schema,
     ]);
 
     expect($template->form_schema)->toBeArray()
-        ->toBe($schema)
-        ->and($template->form_schema['fields'])->toBeArray()
-        ->and($template->form_schema['fields'][0]['name'])->toBe('test_field');
+        ->and($template->form_schema['type'])->toBe('object')
+        ->and($template->form_schema['properties'])->toBeArray()
+        ->and(array_keys($template->form_schema['properties']))->toBe(['name', 'email', 'field'])
+        ->and($template->form_schema['properties']['name'])->toBe(['type' => 'string'])
+        ->and($template->form_schema['additionalProperties'])->toBeTrue();
 });
 
 test('onboarding form template factory states work correctly', function () {

--- a/tests/Unit/Models/OnboardingFormTemplateTest.php
+++ b/tests/Unit/Models/OnboardingFormTemplateTest.php
@@ -104,6 +104,29 @@ test('onboarding form template factory provides a JSON schema object by default'
         ->and($template->form_schema['additionalProperties'])->toBeTrue();
 });
 
+test('onboarding form template preserves a custom form schema array', function () {
+    $schema = [
+        'type' => 'object',
+        'properties' => [
+            'custom_field' => ['type' => 'string'],
+        ],
+        'required' => ['custom_field'],
+        'additionalProperties' => false,
+    ];
+
+    $template = OnboardingFormTemplate::factory()->create([
+        'tenant_id' => $this->tenant->id,
+        'form_schema' => $schema,
+    ]);
+
+    expect($template->form_schema)->toBeArray()
+        ->toBe($schema)
+        ->and($template->form_schema['properties'])->toBeArray()
+        ->and($template->form_schema['properties']['custom_field'])->toBe(['type' => 'string'])
+        ->and($template->form_schema['required'])->toBe(['custom_field'])
+        ->and($template->form_schema['additionalProperties'])->toBeFalse();
+});
+
 test('onboarding form template factory states work correctly', function () {
     $required = OnboardingFormTemplate::factory()->required()->create([
         'tenant_id' => $this->tenant->id,


### PR DESCRIPTION
## Summary
- update the stale onboarding form template unit test that still asserted the legacy `fields` schema shape
- verify the factory now produces the current JSON Schema object defaults, including declared properties and `additionalProperties`
- keep the rest of the model coverage unchanged

## Testing
- php artisan test tests/Unit/Models/OnboardingFormTemplateTest.php
- vendor/bin/pint --dirty

Fixes #1019
Related #1015
