### PR TITLE
test(mail): cover onboarding invitation copy

### DIFF
--- a/tests/Feature/Mail/EmployeeLifecycleMailTest.php
+++ b/tests/Feature/Mail/EmployeeLifecycleMailTest.php
@@ -73,6 +73,8 @@ test('onboarding invitation mail has correct content', function () {
 });
 
 test('onboarding invitation mail renders key onboarding copy sections', function () {
+    app()->setLocale('en');
+
     $contractStartDate = now()->addDays(14);
 
     $employee = Employee::factory()->create([

--- a/tests/Feature/Mail/EmployeeLifecycleMailTest.php
+++ b/tests/Feature/Mail/EmployeeLifecycleMailTest.php
@@ -72,6 +72,40 @@ test('onboarding invitation mail has correct content', function () {
     expect($content->markdown)->toBe('emails.employees.onboarding-invitation');
 });
 
+test('onboarding invitation mail renders key onboarding copy sections', function () {
+    $contractStartDate = now()->addDays(14);
+
+    $employee = Employee::factory()->create([
+        'tenant_id' => $this->tenant->id,
+        'organizational_unit_id' => $this->orgUnit->id,
+        'first_name' => 'John',
+        'last_name' => 'Doe',
+        'email' => 'john.doe.onboarding.copy@secpal.dev',
+        'contract_start_date' => $contractStartDate,
+        'status' => Employee::STATUS_ACTIVE,
+    ]);
+
+    $user = User::factory()->create([
+        'name' => 'John Doe',
+        'email' => 'john.doe.onboarding.copy@secpal.dev',
+        'password' => bcrypt('password'),
+    ]);
+
+    $mail = new OnboardingInvitationMail($employee, $user, 'fixed-onboarding-token');
+    $rendered = $mail->render();
+
+    expect($rendered)
+        ->toContain('Hello John,')
+        ->toContain('Your contract starts on')
+        ->toContain($contractStartDate->format('d.m.Y'))
+        ->toContain('Start Onboarding')
+        ->toContain('What to expect:')
+        ->toContain('Personal information for onboarding (including gender and nationalities)')
+        ->toContain('Emergency contacts')
+        ->toContain($contractStartDate->copy()->subDays(3)->format('d.m.Y'))
+        ->toContain('Please do not reply directly to this email.');
+});
+
 test('onboarding invitation URL includes token and email parameters', function () {
     $employee = Employee::factory()->create([
         'tenant_id' => $this->tenant->id,


### PR DESCRIPTION
## Summary
- render the onboarding invitation mailable in tests instead of only asserting the template name and link URL
- lock key invitation copy sections in place, including the greeting, expected sections, onboarding button label, and deadline text
- keep the rest of the lifecycle mail coverage unchanged

## Testing
- php artisan test tests/Feature/Mail/EmployeeLifecycleMailTest.php
- vendor/bin/pint --dirty

Fixes #1020
Related #1014

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only changes that render the onboarding invitation email and assert specific copy/date strings, with no production logic modifications.
> 
> **Overview**
> Adds a new feature test that **renders** `OnboardingInvitationMail` and asserts key onboarding invitation copy is present (greeting, contract start date formatting, CTA label, expected sections, deadline text, and no-reply footer), instead of only validating the template name/URL parameters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65ea6429d8e14398006731a580765849ea7aca6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->