### PR TITLE
fix: expose contract start date in auth bootstrap payload

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -975,7 +975,7 @@ class AuthController extends Controller
      * viewable rank ranges (0-255), granting access to all leadership
      * levels and non-leadership employees.
      *
-     * @return array{id: string, name: string, email: string, emailVerified: bool, roles: list<string>, permissions: list<string>, hasOrganizationalScopes: bool, hasCustomerAccess: bool, hasSiteAccess: bool, employeeStatus: string|null, onboardingWorkflowStatus: string|null}
+     * @return array{id: string, name: string, email: string, emailVerified: bool, roles: list<string>, permissions: list<string>, hasOrganizationalScopes: bool, hasCustomerAccess: bool, hasSiteAccess: bool, employeeStatus: string|null, onboardingWorkflowStatus: string|null, employee: array{id: string, contract_start_date: string|null}|null}
      */
     private function buildUserAuthorizationData(User $user): array
     {
@@ -1016,6 +1016,12 @@ class AuthController extends Controller
             'hasSiteAccess' => $hasSiteAccess,
             'employeeStatus' => $employee?->status,
             'onboardingWorkflowStatus' => $employee?->resolveOnboardingWorkflowStatus(),
+            'employee' => $employee
+                ? [
+                    'id' => (string) $employee->id,
+                    'contract_start_date' => $employee->contract_start_date?->toDateString(),
+                ]
+                : null,
         ];
     }
 

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -975,7 +975,7 @@ class AuthController extends Controller
      * viewable rank ranges (0-255), granting access to all leadership
      * levels and non-leadership employees.
      *
-     * @return array{id: string, name: string, email: string, emailVerified: bool, roles: list<string>, permissions: list<string>, hasOrganizationalScopes: bool, hasCustomerAccess: bool, hasSiteAccess: bool, employeeStatus: string|null, onboardingWorkflowStatus: string|null, employee: array{id: string, contract_start_date: string|null}|null}
+     * @return array{id: string, name: string, email: string, emailVerified: bool, roles: list<string>, permissions: list<string>, hasOrganizationalScopes: bool, hasCustomerAccess: bool, hasSiteAccess: bool, employeeStatus: string|null, onboardingWorkflowStatus: string|null, employee: array{id: string, contractStartDate: string|null}|null}
      */
     private function buildUserAuthorizationData(User $user): array
     {
@@ -1019,7 +1019,7 @@ class AuthController extends Controller
             'employee' => $employee
                 ? [
                     'id' => (string) $employee->id,
-                    'contract_start_date' => $employee->contract_start_date?->toDateString(),
+                    'contractStartDate' => $employee->contract_start_date?->toDateString(),
                 ]
                 : null,
         ];

--- a/tests/Feature/AuthTest.php
+++ b/tests/Feature/AuthTest.php
@@ -107,7 +107,7 @@ describe('SPA Session Login', function () {
             ]);
     });
 
-    test('spa login and me payloads include employee status and resolved onboarding workflow state', function () {
+    test('spa login and me payloads include employee status, workflow state, and canonical employee fields', function () {
         $email = 'employee-auth-payload@secpal.dev';
 
         $user = User::factory()->create([
@@ -116,7 +116,7 @@ describe('SPA Session Login', function () {
             'password' => bcrypt('password123'),
         ]);
 
-        Employee::factory()->create([
+        $employee = Employee::factory()->create([
             'user_id' => $user->id,
             'email' => $email,
             'status' => Employee::STATUS_PRE_CONTRACT,
@@ -132,6 +132,7 @@ describe('SPA Session Login', function () {
         ])->assertOk()
             ->assertJsonPath('user.employeeStatus', Employee::STATUS_PRE_CONTRACT)
             ->assertJsonPath('user.onboardingWorkflowStatus', Employee::WORKFLOW_STATUS_INVITED)
+            ->assertJsonPath('user.employee.id', (string) $employee->id)
             ->assertJsonPath('user.employee.contract_start_date', '2026-06-01');
 
         $this->withHeaders(spaHeaders())
@@ -139,6 +140,7 @@ describe('SPA Session Login', function () {
             ->assertOk()
             ->assertJsonPath('employeeStatus', Employee::STATUS_PRE_CONTRACT)
             ->assertJsonPath('onboardingWorkflowStatus', Employee::WORKFLOW_STATUS_INVITED)
+            ->assertJsonPath('employee.id', (string) $employee->id)
             ->assertJsonPath('employee.contract_start_date', '2026-06-01');
     });
 

--- a/tests/Feature/AuthTest.php
+++ b/tests/Feature/AuthTest.php
@@ -133,7 +133,7 @@ describe('SPA Session Login', function () {
             ->assertJsonPath('user.employeeStatus', Employee::STATUS_PRE_CONTRACT)
             ->assertJsonPath('user.onboardingWorkflowStatus', Employee::WORKFLOW_STATUS_INVITED)
             ->assertJsonPath('user.employee.id', (string) $employee->id)
-            ->assertJsonPath('user.employee.contract_start_date', '2026-06-01');
+            ->assertJsonPath('user.employee.contractStartDate', '2026-06-01');
 
         $this->withHeaders(spaHeaders())
             ->getJson('/v1/me')
@@ -141,7 +141,7 @@ describe('SPA Session Login', function () {
             ->assertJsonPath('employeeStatus', Employee::STATUS_PRE_CONTRACT)
             ->assertJsonPath('onboardingWorkflowStatus', Employee::WORKFLOW_STATUS_INVITED)
             ->assertJsonPath('employee.id', (string) $employee->id)
-            ->assertJsonPath('employee.contract_start_date', '2026-06-01');
+            ->assertJsonPath('employee.contractStartDate', '2026-06-01');
     });
 
     test('spa login fails with invalid credentials', function () {

--- a/tests/Feature/AuthTest.php
+++ b/tests/Feature/AuthTest.php
@@ -121,6 +121,7 @@ describe('SPA Session Login', function () {
             'email' => $email,
             'status' => Employee::STATUS_PRE_CONTRACT,
             'onboarding_workflow_status' => null,
+            'contract_start_date' => '2026-06-01',
         ]);
 
         $this->withHeaders(spaHeaders([
@@ -130,13 +131,15 @@ describe('SPA Session Login', function () {
             'password' => 'password123',
         ])->assertOk()
             ->assertJsonPath('user.employeeStatus', Employee::STATUS_PRE_CONTRACT)
-            ->assertJsonPath('user.onboardingWorkflowStatus', Employee::WORKFLOW_STATUS_INVITED);
+            ->assertJsonPath('user.onboardingWorkflowStatus', Employee::WORKFLOW_STATUS_INVITED)
+            ->assertJsonPath('user.employee.contract_start_date', '2026-06-01');
 
         $this->withHeaders(spaHeaders())
             ->getJson('/v1/me')
             ->assertOk()
             ->assertJsonPath('employeeStatus', Employee::STATUS_PRE_CONTRACT)
-            ->assertJsonPath('onboardingWorkflowStatus', Employee::WORKFLOW_STATUS_INVITED);
+            ->assertJsonPath('onboardingWorkflowStatus', Employee::WORKFLOW_STATUS_INVITED)
+            ->assertJsonPath('employee.contract_start_date', '2026-06-01');
     });
 
     test('spa login fails with invalid credentials', function () {


### PR DESCRIPTION
## Summary
- extend the auth bootstrap payload returned by login and `/v1/me` with a minimal `employee` object
- expose the canonical `contract_start_date` so onboarding clients can validate residence-title expiry against a stable backend source
- cover the new payload contract in the auth feature tests

## Test plan
- [x] `php artisan test tests/Feature/AuthTest.php`
- [ ] CI