### PR TITLE
fix: require onboarding upload document subtypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- aligned onboarding attachment gating with the draft-first upload flow by allowing first-time submitted forms to opt into identity/residence uploads before a submission id exists, while keeping the stricter `document_subtype` requirement for existing editable submissions and legacy `id_document` uploads during resubmission
 - enforced server-side residence-title requirements during onboarding submission for non-exempt nationalities (title + employment authorization, and expiry when not unlimited) so clients can no longer bypass the frontend-only checks by posting `nationalities` without required residence data
 - aligned passkey credential mapping with WebAuthn-lib 5.3 by using `PublicKeyCredentialSource` directly, fixing passkey challenge flows that were failing with a `TypeError` (return type mismatch)
 - forced the PHPUnit `DB_CONNECTION` and `DB_DATABASE` overrides so the early PostgreSQL test bootstrap always provisions `testing*_test_*` databases instead of inheriting runtime `secpal*` names from the shell environment during parallel runs

--- a/app/Http/Controllers/Api/V1/OnboardingController.php
+++ b/app/Http/Controllers/Api/V1/OnboardingController.php
@@ -31,6 +31,7 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Validation\Rules\Password;
 use Illuminate\Validation\ValidationException;
 
@@ -47,6 +48,33 @@ use Illuminate\Validation\ValidationException;
  */
 class OnboardingController extends Controller
 {
+    private const ID_DOCUMENT_UPLOAD_NOW_FIELD = 'id_document_upload_now';
+
+    private const ID_DOCUMENT_KIND_FIELD = 'id_document_kind';
+
+    private const RESIDENCE_PERMIT_UPLOAD_NOW_FIELD = 'residence_permit_upload_now';
+
+    private const RESIDENCE_PERMIT_TITLE_FIELD = 'residence_permit_title';
+
+    private const RESIDENCE_PERMIT_UNLIMITED_FIELD = 'residence_permit_unlimited';
+
+    private const RESIDENCE_PERMIT_EXPIRY_FIELD = 'residence_permit_expiry';
+
+    private const RESIDENCE_PERMIT_EMPLOYMENT_ALLOWED_FIELD = 'residence_permit_employment_allowed';
+
+    private const CONTRACT_START_DATE_FIELD = 'contract_start_date';
+
+    /**
+     * Must stay in sync with frontend gating.
+     *
+     * @var list<string>
+     */
+    private const RESIDENCE_TITLE_EXEMPT_COUNTRY_CODES = [
+        'AT', 'BE', 'BG', 'CH', 'CY', 'CZ', 'DE', 'DK', 'EE', 'ES', 'FI', 'FR',
+        'GR', 'HR', 'HU', 'IE', 'IS', 'IT', 'LI', 'LT', 'LU', 'LV', 'MT', 'NL',
+        'NO', 'PL', 'PT', 'RO', 'SE', 'SI', 'SK',
+    ];
+
     public function __construct(
         private readonly OnboardingSubmissionFileStorageService $submissionFileStorageService,
         private readonly OnboardingSchemaLocalizationService $onboardingSchemaLocalizationService,
@@ -562,7 +590,16 @@ class OnboardingController extends Controller
             $template,
             $formData,
             $status === 'submitted',
+            $employee,
         );
+        if ($status === 'submitted') {
+            $this->assertUploadDecisionRequirements(
+                $formData,
+                is_array($template->form_schema) ? $template->form_schema : [],
+                $existing,
+                $employee
+            );
+        }
 
         $submission = DB::transaction(function () use ($existing, $validated, $formData, $status, $submittedAt, $employee): OnboardingFormSubmission {
             if ($existing) {
@@ -678,7 +715,16 @@ class OnboardingController extends Controller
             $formTemplate,
             $effectiveFormData,
             $status === 'submitted',
+            $employee,
         );
+        if ($status === 'submitted') {
+            $this->assertUploadDecisionRequirements(
+                $effectiveFormData,
+                is_array($formTemplate->form_schema) ? $formTemplate->form_schema : [],
+                $submission,
+                $employee
+            );
+        }
 
         $submission = DB::transaction(function () use ($employee, $status, $submittedAt, $submission, $effectiveFormData, $shouldResetReview): OnboardingFormSubmission {
             $submission->update([
@@ -754,6 +800,7 @@ class OnboardingController extends Controller
                 'onboarding_form_submission_id' => $submission->id,
                 'uploaded_by' => $user->id,
                 'document_type' => $validated['document_type'],
+                'document_subtype' => $validated['document_subtype'] ?? null,
                 'file_path' => $storedFile['file_path'],
                 'file_name' => $storedFile['file_name'],
                 'mime_type' => $storedFile['mime_type'],
@@ -761,7 +808,7 @@ class OnboardingController extends Controller
             ]));
         } catch (\Throwable $e) {
             if ($storedFilePath !== null) {
-                \Illuminate\Support\Facades\Storage::disk('local')->delete($storedFilePath);
+                Storage::disk('local')->delete($storedFilePath);
             }
 
             throw $e;
@@ -773,6 +820,40 @@ class OnboardingController extends Controller
                 'filename' => $uploadedFile->file_name,
             ],
         ], Response::HTTP_CREATED);
+    }
+
+    /**
+     * Delete a previously uploaded file for an editable onboarding submission.
+     *
+     * DELETE /v1/onboarding/submissions/{submission}/files/{file}
+     */
+    public function deleteSubmissionFile(Request $request, OnboardingFormSubmission $submission, string $file): JsonResponse|Response
+    {
+        $this->authorize('uploadFile', $submission);
+
+        if (! in_array($submission->status, ['draft', 'rejected'], true)) {
+            throw ValidationException::withMessages([
+                'status' => __('Files can only be deleted while the onboarding submission is editable'),
+            ]);
+        }
+
+        $submissionFile = OnboardingSubmissionFile::query()
+            ->where('onboarding_form_submission_id', $submission->id)
+            ->whereKey($file)
+            ->first();
+
+        if ($submissionFile === null) {
+            return response()->json([
+                'message' => __('File not found for this onboarding submission.'),
+            ], Response::HTTP_NOT_FOUND);
+        }
+
+        DB::transaction(function () use ($submissionFile): void {
+            Storage::disk('local')->delete($submissionFile->file_path);
+            $submissionFile->delete();
+        });
+
+        return response()->noContent();
     }
 
     /**
@@ -966,6 +1047,248 @@ class OnboardingController extends Controller
         $trimmed = trim($displayName);
 
         return $trimmed !== '' ? $trimmed : $countryCode;
+    }
+
+    /**
+     * @param  array<string, mixed>  $formData
+     * @param  array<string, mixed>  $schema
+     */
+    private function assertUploadDecisionRequirements(
+        array $formData,
+        array $schema,
+        ?OnboardingFormSubmission $submission,
+        Employee $employee,
+    ): void {
+        if (! $this->schemaDefinesProperty($schema, 'nationalities')) {
+            return;
+        }
+
+        $primaryNationalityCode = $this->getPrimaryNationalityCode(
+            $formData['nationalities'] ?? null
+        );
+        if ($primaryNationalityCode === null) {
+            return;
+        }
+
+        $identityUploadNow = $this->normalizeYesNo(
+            $formData[self::ID_DOCUMENT_UPLOAD_NOW_FIELD] ?? null
+        );
+        if ($identityUploadNow === null) {
+            throw ValidationException::withMessages([
+                self::ID_DOCUMENT_UPLOAD_NOW_FIELD => [__('Please choose whether you want to upload your identity document now.')],
+            ]);
+        }
+
+        if ($identityUploadNow === 'yes') {
+            if ($primaryNationalityCode === 'DE') {
+                $documentKind = $this->normalizedNonEmptyString(
+                    $formData[self::ID_DOCUMENT_KIND_FIELD] ?? null
+                );
+                if (! in_array($documentKind, ['id_card', 'passport'], true)) {
+                    throw ValidationException::withMessages([
+                        self::ID_DOCUMENT_KIND_FIELD => [__('Please choose which identity document you are uploading.')],
+                    ]);
+                }
+            }
+
+            if (
+                $submission !== null
+                && ! $this->hasUploadedSubmissionFile($submission, [
+                    'identity_document',
+                    'identity_document_front',
+                    'identity_document_back',
+                ])
+            ) {
+                throw ValidationException::withMessages([
+                    self::ID_DOCUMENT_UPLOAD_NOW_FIELD => [__('Please upload at least one identity document file before continuing.')],
+                ]);
+            }
+        }
+
+        if (in_array($primaryNationalityCode, self::RESIDENCE_TITLE_EXEMPT_COUNTRY_CODES, true)) {
+            return;
+        }
+
+        if (! $this->shouldAskEmploymentQuestion($formData, $employee)) {
+            return;
+        }
+
+        $employmentAllowed = strtolower(
+            $this->normalizedNonEmptyString(
+                $formData[self::RESIDENCE_PERMIT_EMPLOYMENT_ALLOWED_FIELD] ?? null
+            ) ?? ''
+        );
+        if ($employmentAllowed !== 'yes') {
+            return;
+        }
+
+        $residenceUploadNow = $this->normalizeYesNo(
+            $formData[self::RESIDENCE_PERMIT_UPLOAD_NOW_FIELD] ?? null
+        );
+        if ($residenceUploadNow === null) {
+            throw ValidationException::withMessages([
+                self::RESIDENCE_PERMIT_UPLOAD_NOW_FIELD => [__('Please choose whether you want to upload your residence title now.')],
+            ]);
+        }
+
+        if (
+            $residenceUploadNow === 'yes'
+            && $submission !== null
+            && ! $this->hasUploadedSubmissionFile($submission, [
+                'residence_permit_front',
+                'residence_permit_back',
+            ])
+        ) {
+            throw ValidationException::withMessages([
+                self::RESIDENCE_PERMIT_UPLOAD_NOW_FIELD => [__('Please upload at least one residence title file before continuing.')],
+            ]);
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $schema
+     */
+    private function schemaDefinesProperty(array $schema, string $field): bool
+    {
+        $properties = $schema['properties'] ?? null;
+
+        return is_array($properties) && array_key_exists($field, $properties);
+    }
+
+    /**
+     * @param  array<int, string>  $subtypes
+     */
+    private function hasUploadedSubmissionFile(
+        ?OnboardingFormSubmission $submission,
+        array $subtypes
+    ): bool {
+        if ($submission === null) {
+            return false;
+        }
+
+        return OnboardingSubmissionFile::query()
+            ->where('onboarding_form_submission_id', $submission->id)
+            ->where('document_type', 'id_document')
+            ->whereIn('document_subtype', $subtypes)
+            ->exists();
+    }
+
+    private function getPrimaryNationalityCode(mixed $nationalities): ?string
+    {
+        if (! is_array($nationalities)) {
+            return null;
+        }
+
+        $first = $nationalities[0] ?? null;
+        if (! is_string($first) && ! is_int($first)) {
+            return null;
+        }
+
+        $normalized = strtoupper(trim((string) $first));
+
+        return preg_match('/^[A-Z]{2}$/', $normalized) === 1 ? $normalized : null;
+    }
+
+    private function normalizeYesNo(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $normalized = strtolower(trim($value));
+
+        return in_array($normalized, ['yes', 'no'], true) ? $normalized : null;
+    }
+
+    private function normalizedNonEmptyString(mixed $value): ?string
+    {
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $normalized = trim($value);
+
+        return $normalized !== '' ? $normalized : null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $formData
+     */
+    private function shouldAskEmploymentQuestion(
+        array $formData,
+        Employee $employee,
+    ): bool {
+        $title = $this->normalizedNonEmptyString(
+            $formData[self::RESIDENCE_PERMIT_TITLE_FIELD] ?? null
+        );
+        if ($title === null) {
+            return false;
+        }
+
+        if ($this->isResidencePermitUnlimited($formData)) {
+            return true;
+        }
+
+        $contractStartDate = $this->resolveContractStartDate($formData, $employee);
+        if ($contractStartDate === null) {
+            return false;
+        }
+
+        $expiry = $this->normalizedNonEmptyString(
+            $formData[self::RESIDENCE_PERMIT_EXPIRY_FIELD] ?? null
+        );
+        if (
+            $expiry === null
+            || preg_match('/^\d{4}-\d{2}-\d{2}$/', $expiry) !== 1
+            || $expiry <= now()->toDateString()
+        ) {
+            return false;
+        }
+
+        return $expiry > $contractStartDate;
+    }
+
+    /**
+     * @param  array<string, mixed>  $formData
+     */
+    private function resolveContractStartDate(
+        array $formData,
+        Employee $employee,
+    ): ?string {
+        $fromForm = $this->normalizedNonEmptyString(
+            $formData[self::CONTRACT_START_DATE_FIELD] ?? null
+        );
+        if ($fromForm !== null && preg_match('/^\d{4}-\d{2}-\d{2}$/', $fromForm) === 1) {
+            return $fromForm;
+        }
+
+        $fromEmployee = $employee->contract_start_date?->toDateString();
+
+        return is_string($fromEmployee) && preg_match('/^\d{4}-\d{2}-\d{2}$/', $fromEmployee) === 1
+            ? $fromEmployee
+            : null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $formData
+     */
+    private function isResidencePermitUnlimited(array $formData): bool
+    {
+        $value = $formData[self::RESIDENCE_PERMIT_UNLIMITED_FIELD] ?? null;
+
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        if (is_int($value)) {
+            return $value === 1;
+        }
+
+        if (! is_string($value)) {
+            return false;
+        }
+
+        return in_array(strtolower(trim($value)), ['1', 'true', 'yes'], true);
     }
 
     /**

--- a/app/Http/Controllers/Api/V1/OnboardingController.php
+++ b/app/Http/Controllers/Api/V1/OnboardingController.php
@@ -848,9 +848,14 @@ class OnboardingController extends Controller
             ], Response::HTTP_NOT_FOUND);
         }
 
-        DB::transaction(function () use ($submissionFile): void {
-            Storage::disk('local')->delete($submissionFile->file_path);
+        $filePath = $submissionFile->file_path;
+
+        DB::transaction(function () use ($submissionFile, $filePath): void {
             $submissionFile->delete();
+
+            DB::afterCommit(static function () use ($filePath): void {
+                Storage::disk('local')->delete($filePath);
+            });
         });
 
         return response()->noContent();
@@ -1070,13 +1075,21 @@ class OnboardingController extends Controller
             return;
         }
 
-        $identityUploadNow = $this->normalizeYesNo(
-            $formData[self::ID_DOCUMENT_UPLOAD_NOW_FIELD] ?? null
-        );
-        if ($identityUploadNow === null) {
-            throw ValidationException::withMessages([
-                self::ID_DOCUMENT_UPLOAD_NOW_FIELD => [__('Please choose whether you want to upload your identity document now.')],
-            ]);
+        if ($this->schemaDefinesProperty($schema, self::ID_DOCUMENT_UPLOAD_NOW_FIELD)) {
+            $identityUploadNow = $this->normalizeYesNo(
+                $formData[self::ID_DOCUMENT_UPLOAD_NOW_FIELD] ?? null
+            );
+            if ($identityUploadNow === null) {
+                throw ValidationException::withMessages([
+                    self::ID_DOCUMENT_UPLOAD_NOW_FIELD => [__('Please choose whether you want to upload your identity document now.')],
+                ]);
+            }
+
+            if ($identityUploadNow !== 'yes') {
+                $identityUploadNow = null;
+            }
+        } else {
+            $identityUploadNow = null;
         }
 
         if ($identityUploadNow === 'yes') {
@@ -1119,6 +1132,10 @@ class OnboardingController extends Controller
             ) ?? ''
         );
         if ($employmentAllowed !== 'yes') {
+            return;
+        }
+
+        if (! $this->schemaDefinesProperty($schema, self::RESIDENCE_PERMIT_UPLOAD_NOW_FIELD)) {
             return;
         }
 

--- a/app/Http/Requests/UploadOnboardingSubmissionFileRequest.php
+++ b/app/Http/Requests/UploadOnboardingSubmissionFileRequest.php
@@ -11,6 +11,8 @@ use Illuminate\Validation\Rule;
 
 class UploadOnboardingSubmissionFileRequest extends FormRequest
 {
+    private const DEFAULT_MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
+
     public function authorize(): bool
     {
         /** @var OnboardingFormSubmission|null $submission */
@@ -25,13 +27,63 @@ class UploadOnboardingSubmissionFileRequest extends FormRequest
      */
     public function rules(): array
     {
+        $maxKilobytes = $this->maxFileSizeKilobytes();
+
         return [
-            'file' => ['bail', 'required', 'file', 'max:10240', 'mimes:pdf,jpg,jpeg,png', 'mimetypes:application/pdf,image/jpeg,image/png'],
+            'file' => ['bail', 'required', 'file', "max:{$maxKilobytes}", 'mimes:pdf,jpg,jpeg,png', 'mimetypes:application/pdf,image/jpeg,image/png'],
             'document_type' => ['required', Rule::in([
                 'contract',
                 'id_document',
                 'banking_details',
             ])],
+            'document_subtype' => [
+                Rule::requiredIf(fn (): bool => $this->input('document_type') === 'id_document'),
+                'nullable',
+                Rule::in([
+                    'identity_document',
+                    'identity_document_front',
+                    'identity_document_back',
+                    'proof_of_residence',
+                    'residence_permit_front',
+                    'residence_permit_back',
+                ]),
+            ],
         ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'file.uploaded' => __('The file upload failed before validation completed. Check PHP upload limits (upload_max_filesize: :upload_max, post_max_size: :post_max) or the temporary upload directory configuration.', [
+                'upload_max' => $this->phpIniValue('upload_max_filesize'),
+                'post_max' => $this->phpIniValue('post_max_size'),
+            ]),
+        ];
+    }
+
+    private function maxFileSizeKilobytes(): int
+    {
+        $maxFileSizeBytes = config('attachments.max_file_size', self::DEFAULT_MAX_FILE_SIZE_BYTES);
+
+        if (! is_numeric($maxFileSizeBytes)) {
+            return (int) ceil(self::DEFAULT_MAX_FILE_SIZE_BYTES / 1024);
+        }
+
+        $numeric = (float) $maxFileSizeBytes;
+        if ($numeric <= 0) {
+            return (int) ceil(self::DEFAULT_MAX_FILE_SIZE_BYTES / 1024);
+        }
+
+        return (int) ceil($numeric / 1024);
+    }
+
+    private function phpIniValue(string $key): string
+    {
+        $value = ini_get($key);
+
+        return is_string($value) && $value !== '' ? $value : 'n/a';
     }
 }

--- a/app/Models/OnboardingSubmissionFile.php
+++ b/app/Models/OnboardingSubmissionFile.php
@@ -19,6 +19,7 @@ class OnboardingSubmissionFile extends Model
         'onboarding_form_submission_id',
         'uploaded_by',
         'document_type',
+        'document_subtype',
         'file_path',
         'file_name',
         'mime_type',

--- a/app/Services/OnboardingFormDataSchemaValidationService.php
+++ b/app/Services/OnboardingFormDataSchemaValidationService.php
@@ -5,6 +5,7 @@
 
 namespace App\Services;
 
+use App\Models\Employee;
 use App\Models\OnboardingFormTemplate;
 use Illuminate\Support\Carbon;
 use Illuminate\Validation\ValidationException;
@@ -19,6 +20,8 @@ use Opis\JsonSchema\Validator;
  */
 final class OnboardingFormDataSchemaValidationService
 {
+    private const CONTRACT_START_DATE_FIELD = 'contract_start_date';
+
     private const RESIDENCE_PERMIT_EXPIRY_FIELD = 'residence_permit_expiry';
 
     private const RESIDENCE_PERMIT_TITLE_FIELD = 'residence_permit_title';
@@ -75,6 +78,7 @@ final class OnboardingFormDataSchemaValidationService
         OnboardingFormTemplate $template,
         array $formData,
         bool $forSubmittedStatus,
+        ?Employee $employee = null,
     ): void {
         if (! $forSubmittedStatus) {
             return;
@@ -110,14 +114,32 @@ final class OnboardingFormDataSchemaValidationService
         }
 
         if ($this->schemaDefinesField($schema, 'nationalities')) {
-            $this->assertResidencePermitRequirementsForNationalities($formData);
+            $contractStartDate = $this->resolveContractStartDate($formData, $employee);
+            $this->assertResidencePermitRequirementsForNationalities(
+                $formData,
+                $contractStartDate
+            );
 
             if (! $this->requiresResidenceTitleQuestion($formData)) {
                 return;
             }
+
+            $this->assertResidencePermitExpiryNotInPast(
+                $formData,
+                $contractStartDate,
+                true
+            );
+
+            if ($this->canAskEmploymentForResidenceTitle($formData, $contractStartDate)) {
+                $this->assertResidencePermitEmploymentAllowed($formData);
+            }
+
+            return;
         }
 
-        $this->assertResidencePermitExpiryNotInPast($formData);
+        // Backwards compatibility for templates that still include residence permit fields
+        // but not the nationality gating field.
+        $this->assertResidencePermitExpiryNotInPast($formData, null, false);
         $this->assertResidencePermitEmploymentAllowed($formData);
     }
 
@@ -229,8 +251,11 @@ final class OnboardingFormDataSchemaValidationService
     /**
      * @param  array<string, mixed>  $formData
      */
-    private function assertResidencePermitExpiryNotInPast(array $formData): void
-    {
+    private function assertResidencePermitExpiryNotInPast(
+        array $formData,
+        ?string $contractStartDate,
+        bool $enforceContractStartRule = true,
+    ): void {
         if ($this->isResidencePermitUnlimited($formData)) {
             return;
         }
@@ -256,6 +281,22 @@ final class OnboardingFormDataSchemaValidationService
         if ($expiryDate->startOfDay()->lt(now()->startOfDay())) {
             throw ValidationException::withMessages([
                 self::RESIDENCE_PERMIT_EXPIRY_FIELD => [__('The residence title expiry date cannot be in the past.')],
+            ]);
+        }
+
+        if (! $enforceContractStartRule) {
+            return;
+        }
+
+        if ($contractStartDate === null) {
+            throw ValidationException::withMessages([
+                self::RESIDENCE_PERMIT_EXPIRY_FIELD => [__('The residence title must remain valid after your contract start date.')],
+            ]);
+        }
+
+        if ($expiryDateString <= $contractStartDate) {
+            throw ValidationException::withMessages([
+                self::RESIDENCE_PERMIT_EXPIRY_FIELD => [__('The residence title must remain valid after your contract start date.')],
             ]);
         }
     }
@@ -298,8 +339,10 @@ final class OnboardingFormDataSchemaValidationService
     /**
      * @param  array<string, mixed>  $formData
      */
-    private function assertResidencePermitRequirementsForNationalities(array $formData): void
-    {
+    private function assertResidencePermitRequirementsForNationalities(
+        array $formData,
+        ?string $contractStartDate,
+    ): void {
         if (! $this->requiresResidenceTitleQuestion($formData)) {
             return;
         }
@@ -311,14 +354,18 @@ final class OnboardingFormDataSchemaValidationService
             ]);
         }
 
-        $employmentAllowed = $this->normalizedNonEmptyString($formData[self::RESIDENCE_PERMIT_EMPLOYMENT_ALLOWED_FIELD] ?? null);
-        if ($employmentAllowed === null) {
-            throw ValidationException::withMessages([
-                self::RESIDENCE_PERMIT_EMPLOYMENT_ALLOWED_FIELD => [__('The employment authorization decision is required.')],
-            ]);
-        }
-
         if ($this->isResidencePermitUnlimited($formData)) {
+            if (! $this->canAskEmploymentForResidenceTitle($formData, $contractStartDate)) {
+                return;
+            }
+
+            $employmentAllowed = $this->normalizedNonEmptyString($formData[self::RESIDENCE_PERMIT_EMPLOYMENT_ALLOWED_FIELD] ?? null);
+            if ($employmentAllowed === null) {
+                throw ValidationException::withMessages([
+                    self::RESIDENCE_PERMIT_EMPLOYMENT_ALLOWED_FIELD => [__('The employment authorization decision is required.')],
+                ]);
+            }
+
             return;
         }
 
@@ -326,6 +373,17 @@ final class OnboardingFormDataSchemaValidationService
         if ($expiryDate === null) {
             throw ValidationException::withMessages([
                 self::RESIDENCE_PERMIT_EXPIRY_FIELD => [__('The residence title expiry date is required.')],
+            ]);
+        }
+
+        if (! $this->canAskEmploymentForResidenceTitle($formData, $contractStartDate)) {
+            return;
+        }
+
+        $employmentAllowed = $this->normalizedNonEmptyString($formData[self::RESIDENCE_PERMIT_EMPLOYMENT_ALLOWED_FIELD] ?? null);
+        if ($employmentAllowed === null) {
+            throw ValidationException::withMessages([
+                self::RESIDENCE_PERMIT_EMPLOYMENT_ALLOWED_FIELD => [__('The employment authorization decision is required.')],
             ]);
         }
     }
@@ -436,5 +494,63 @@ final class OnboardingFormDataSchemaValidationService
         $normalized = trim($value);
 
         return $normalized !== '' ? $normalized : null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $formData
+     */
+    private function resolveContractStartDate(
+        array $formData,
+        ?Employee $employee,
+    ): ?string {
+        $formValue = $this->normalizedNonEmptyString(
+            $formData[self::CONTRACT_START_DATE_FIELD] ?? null
+        );
+        if ($formValue !== null && preg_match('/^\d{4}-\d{2}-\d{2}$/', $formValue) === 1) {
+            return $formValue;
+        }
+
+        $employeeStartDate = $employee?->contract_start_date?->toDateString();
+        if (is_string($employeeStartDate) && preg_match('/^\d{4}-\d{2}-\d{2}$/', $employeeStartDate) === 1) {
+            return $employeeStartDate;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $formData
+     */
+    private function canAskEmploymentForResidenceTitle(
+        array $formData,
+        ?string $contractStartDate,
+    ): bool {
+        $residenceTitle = $this->normalizedNonEmptyString(
+            $formData[self::RESIDENCE_PERMIT_TITLE_FIELD] ?? null
+        );
+        if ($residenceTitle === null) {
+            return false;
+        }
+
+        if ($this->isResidencePermitUnlimited($formData)) {
+            return true;
+        }
+
+        if ($contractStartDate === null) {
+            return false;
+        }
+
+        $expiryDate = $this->normalizedNonEmptyString(
+            $formData[self::RESIDENCE_PERMIT_EXPIRY_FIELD] ?? null
+        );
+        if (
+            $expiryDate === null
+            || preg_match('/^\d{4}-\d{2}-\d{2}$/', $expiryDate) !== 1
+            || $expiryDate <= now()->toDateString()
+        ) {
+            return false;
+        }
+
+        return $expiryDate > $contractStartDate;
     }
 }

--- a/app/Services/OnboardingFormDataSchemaValidationService.php
+++ b/app/Services/OnboardingFormDataSchemaValidationService.php
@@ -290,14 +290,8 @@ final class OnboardingFormDataSchemaValidationService
             ]);
         }
 
-        if (! $enforceContractStartRule) {
+        if (! $enforceContractStartRule || $contractStartDate === null) {
             return;
-        }
-
-        if ($contractStartDate === null) {
-            throw ValidationException::withMessages([
-                self::RESIDENCE_PERMIT_EXPIRY_FIELD => [__('The residence title must remain valid after your contract start date.')],
-            ]);
         }
 
         if ($expiryDateString <= $contractStartDate) {

--- a/database/migrations/2026_05_09_120000_add_document_subtype_to_onboarding_submission_files_table.php
+++ b/database/migrations/2026_05_09_120000_add_document_subtype_to_onboarding_submission_files_table.php
@@ -20,8 +20,8 @@ return new class extends Migration
                 ->after('document_type');
 
             $table->index(
-                ['onboarding_form_submission_id', 'document_subtype'],
-                'onboarding_sub_files_submission_subtype_idx'
+                ['onboarding_form_submission_id', 'document_type', 'document_subtype'],
+                'onboarding_sub_files_submission_type_subtype_idx'
             );
         });
     }
@@ -32,7 +32,7 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('onboarding_submission_files', function (Blueprint $table): void {
-            $table->dropIndex('onboarding_sub_files_submission_subtype_idx');
+            $table->dropIndex('onboarding_sub_files_submission_type_subtype_idx');
             $table->dropColumn('document_subtype');
         });
     }

--- a/database/migrations/2026_05_09_120000_add_document_subtype_to_onboarding_submission_files_table.php
+++ b/database/migrations/2026_05_09_120000_add_document_subtype_to_onboarding_submission_files_table.php
@@ -1,0 +1,39 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('onboarding_submission_files', function (Blueprint $table): void {
+            $table->string('document_subtype', 64)
+                ->nullable()
+                ->after('document_type');
+
+            $table->index(
+                ['onboarding_form_submission_id', 'document_subtype'],
+                'onboarding_sub_files_submission_subtype_idx'
+            );
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('onboarding_submission_files', function (Blueprint $table): void {
+            $table->dropIndex('onboarding_sub_files_submission_subtype_idx');
+            $table->dropColumn('document_subtype');
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -342,6 +342,7 @@ Route::prefix('v1')->group(function () {
             Route::post('/onboarding/submissions', [OnboardingController::class, 'submitForm']);
             Route::patch('/onboarding/submissions/{submission}', [OnboardingController::class, 'updateSubmission']);
             Route::post('/onboarding/submissions/{submission}/files', [OnboardingController::class, 'uploadSubmissionFile']);
+            Route::delete('/onboarding/submissions/{submission}/files/{file}', [OnboardingController::class, 'deleteSubmissionFile']);
             Route::get('/onboarding/completion-status', [OnboardingController::class, 'getCompletionStatus']);
 
             // HR approval endpoints

--- a/tests/Feature/Controllers/OnboardingControllerTest.php
+++ b/tests/Feature/Controllers/OnboardingControllerTest.php
@@ -841,6 +841,40 @@ describe('POST /v1/onboarding/submissions', function () {
             ->assertJsonValidationErrors(['residence_permit_expiry']);
     });
 
+    test('does not require identity upload decisions on templates that do not define that field', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.write');
+
+        $template = OnboardingFormTemplate::factory()->create([
+            'tenant_id' => $this->tenant->id,
+            'is_required' => true,
+            'form_schema' => [
+                'type' => 'object',
+                'properties' => [
+                    'nationalities' => [
+                        'type' => 'array',
+                        'items' => ['type' => 'string', 'pattern' => '^[A-Z]{2}$'],
+                        'minItems' => 1,
+                    ],
+                    'id_document_kind' => ['type' => 'string'],
+                ],
+                'required' => ['nationalities'],
+            ],
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->postJson('/v1/onboarding/submissions', [
+                'form_template_id' => $template->id,
+                'form_data' => [
+                    'nationalities' => ['DE'],
+                    'id_document_kind' => 'passport',
+                ],
+                'status' => 'submitted',
+            ]);
+
+        $response->assertCreated()
+            ->assertJsonPath('data.status', 'submitted');
+    });
+
     test('allows first submitted onboarding data to choose identity upload before a draft submission exists', function (): void {
         givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.write');
 
@@ -965,6 +999,52 @@ describe('POST /v1/onboarding/submissions', function () {
 
         $response->assertStatus(422)
             ->assertJsonValidationErrors(['residence_permit_upload_now']);
+    });
+
+    test('does not require residence upload decisions on templates that do not define that field', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.write');
+        $this->employee->update(['contract_start_date' => '2026-06-01']);
+
+        $template = OnboardingFormTemplate::factory()->create([
+            'tenant_id' => $this->tenant->id,
+            'is_required' => true,
+            'form_schema' => [
+                'type' => 'object',
+                'properties' => [
+                    'nationalities' => [
+                        'type' => 'array',
+                        'items' => ['type' => 'string', 'pattern' => '^[A-Z]{2}$'],
+                        'minItems' => 1,
+                    ],
+                    'id_document_upload_now' => ['type' => 'string'],
+                    'residence_permit_title' => ['type' => 'string'],
+                    'residence_permit_unlimited' => ['type' => 'boolean'],
+                    'residence_permit_expiry' => [
+                        'type' => 'string',
+                        'pattern' => '^\d{4}-\d{2}-\d{2}$',
+                    ],
+                    'residence_permit_employment_allowed' => ['type' => 'string'],
+                ],
+                'required' => ['nationalities', 'residence_permit_title', 'residence_permit_expiry'],
+            ],
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->postJson('/v1/onboarding/submissions', [
+                'form_template_id' => $template->id,
+                'form_data' => [
+                    'nationalities' => ['IN'],
+                    'id_document_upload_now' => 'no',
+                    'residence_permit_title' => 'Niederlassungserlaubnis',
+                    'residence_permit_unlimited' => true,
+                    'residence_permit_expiry' => '2027-06-01',
+                    'residence_permit_employment_allowed' => 'yes',
+                ],
+                'status' => 'submitted',
+            ]);
+
+        $response->assertCreated()
+            ->assertJsonPath('data.status', 'submitted');
     });
 
     test('rejects legacy identity uploads without a document_subtype when resubmitting an existing draft', function (): void {

--- a/tests/Feature/Controllers/OnboardingControllerTest.php
+++ b/tests/Feature/Controllers/OnboardingControllerTest.php
@@ -9,6 +9,7 @@
 use App\Models\Employee;
 use App\Models\OnboardingFormSubmission;
 use App\Models\OnboardingFormTemplate;
+use App\Models\OnboardingSubmissionFile;
 use App\Models\OrganizationalUnit;
 use App\Models\Permission;
 use App\Models\TenantKey;
@@ -19,6 +20,7 @@ use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 use Spatie\Activitylog\Models\Activity;
+use Symfony\Component\HttpFoundation\File\UploadedFile as SymfonyUploadedFile;
 
 /**
  * @property TenantKey $tenant
@@ -672,9 +674,11 @@ describe('POST /v1/onboarding/submissions', function () {
                 'form_template_id' => $template->id,
                 'form_data' => [
                     'nationalities' => ['IN'],
+                    'id_document_upload_now' => 'no',
                     'residence_permit_title' => 'Niederlassungserlaubnis',
                     'residence_permit_employment_allowed' => 'yes',
                     'residence_permit_unlimited' => true,
+                    'residence_permit_upload_now' => 'no',
                     'residence_permit_expiry' => now()->subDay()->toDateString(),
                 ],
                 'status' => 'submitted',
@@ -790,6 +794,230 @@ describe('POST /v1/onboarding/submissions', function () {
 
         $response->assertStatus(422)
             ->assertJsonValidationErrors(['residence_permit_title']);
+    });
+
+    test('rejects submitted onboarding data when a limited residence permit expires on or before contract start date', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.write');
+        $this->employee->update(['contract_start_date' => '2026-06-01']);
+
+        $template = OnboardingFormTemplate::factory()->create([
+            'tenant_id' => $this->tenant->id,
+            'is_required' => true,
+            'form_schema' => [
+                'type' => 'object',
+                'properties' => [
+                    'nationalities' => [
+                        'type' => 'array',
+                        'items' => ['type' => 'string', 'pattern' => '^[A-Z]{2}$'],
+                        'minItems' => 1,
+                    ],
+                    'id_document_upload_now' => ['type' => 'string'],
+                    'residence_permit_title' => ['type' => 'string'],
+                    'residence_permit_employment_allowed' => ['type' => 'string'],
+                    'residence_permit_unlimited' => ['type' => 'boolean'],
+                    'residence_permit_expiry' => [
+                        'type' => 'string',
+                        'pattern' => '^\d{4}-\d{2}-\d{2}$',
+                    ],
+                ],
+                'required' => ['nationalities', 'residence_permit_title', 'residence_permit_expiry'],
+            ],
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->postJson('/v1/onboarding/submissions', [
+                'form_template_id' => $template->id,
+                'form_data' => [
+                    'nationalities' => ['IN'],
+                    'id_document_upload_now' => 'no',
+                    'residence_permit_title' => 'Aufenthaltserlaubnis',
+                    'residence_permit_unlimited' => false,
+                    'residence_permit_expiry' => '2026-06-01',
+                ],
+                'status' => 'submitted',
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['residence_permit_expiry']);
+    });
+
+    test('allows first submitted onboarding data to choose identity upload before a draft submission exists', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.write');
+
+        $template = OnboardingFormTemplate::factory()->create([
+            'tenant_id' => $this->tenant->id,
+            'is_required' => true,
+            'form_schema' => [
+                'type' => 'object',
+                'properties' => [
+                    'nationalities' => [
+                        'type' => 'array',
+                        'items' => ['type' => 'string', 'pattern' => '^[A-Z]{2}$'],
+                        'minItems' => 1,
+                    ],
+                    'id_document_upload_now' => ['type' => 'string'],
+                    'id_document_kind' => ['type' => 'string'],
+                ],
+                'required' => ['nationalities'],
+            ],
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->postJson('/v1/onboarding/submissions', [
+                'form_template_id' => $template->id,
+                'form_data' => [
+                    'nationalities' => ['DE'],
+                    'id_document_upload_now' => 'yes',
+                    'id_document_kind' => 'passport',
+                ],
+                'status' => 'submitted',
+            ]);
+
+        $response->assertCreated()
+            ->assertJsonPath('data.status', 'submitted');
+    });
+
+    test('rejects submitted onboarding data when identity upload is set to yes but no identity file exists on an existing draft submission', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.write');
+
+        $template = OnboardingFormTemplate::factory()->create([
+            'tenant_id' => $this->tenant->id,
+            'is_required' => true,
+            'form_schema' => [
+                'type' => 'object',
+                'properties' => [
+                    'nationalities' => [
+                        'type' => 'array',
+                        'items' => ['type' => 'string', 'pattern' => '^[A-Z]{2}$'],
+                        'minItems' => 1,
+                    ],
+                    'id_document_upload_now' => ['type' => 'string'],
+                    'id_document_kind' => ['type' => 'string'],
+                ],
+                'required' => ['nationalities'],
+            ],
+        ]);
+
+        OnboardingFormSubmission::factory()->create([
+            'employee_id' => $this->employee->id,
+            'form_template_id' => $template->id,
+            'status' => 'draft',
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->postJson('/v1/onboarding/submissions', [
+                'form_template_id' => $template->id,
+                'form_data' => [
+                    'nationalities' => ['DE'],
+                    'id_document_upload_now' => 'yes',
+                    'id_document_kind' => 'passport',
+                ],
+                'status' => 'submitted',
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['id_document_upload_now']);
+    });
+
+    test('rejects submitted onboarding data when residence upload is set to yes but no residence file exists on an existing draft submission', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.write');
+
+        $template = OnboardingFormTemplate::factory()->create([
+            'tenant_id' => $this->tenant->id,
+            'is_required' => true,
+            'form_schema' => [
+                'type' => 'object',
+                'properties' => [
+                    'nationalities' => [
+                        'type' => 'array',
+                        'items' => ['type' => 'string', 'pattern' => '^[A-Z]{2}$'],
+                        'minItems' => 1,
+                    ],
+                    'id_document_upload_now' => ['type' => 'string'],
+                    'residence_permit_title' => ['type' => 'string'],
+                    'residence_permit_unlimited' => ['type' => 'boolean'],
+                    'residence_permit_employment_allowed' => ['type' => 'string'],
+                    'residence_permit_upload_now' => ['type' => 'string'],
+                ],
+                'required' => ['nationalities', 'residence_permit_title'],
+            ],
+        ]);
+
+        OnboardingFormSubmission::factory()->create([
+            'employee_id' => $this->employee->id,
+            'form_template_id' => $template->id,
+            'status' => 'draft',
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->postJson('/v1/onboarding/submissions', [
+                'form_template_id' => $template->id,
+                'form_data' => [
+                    'nationalities' => ['IN'],
+                    'id_document_upload_now' => 'no',
+                    'residence_permit_title' => 'Niederlassungserlaubnis',
+                    'residence_permit_unlimited' => true,
+                    'residence_permit_employment_allowed' => 'yes',
+                    'residence_permit_upload_now' => 'yes',
+                ],
+                'status' => 'submitted',
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['residence_permit_upload_now']);
+    });
+
+    test('rejects legacy identity uploads without a document_subtype when resubmitting an existing draft', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.write');
+
+        $template = OnboardingFormTemplate::factory()->create([
+            'tenant_id' => $this->tenant->id,
+            'is_required' => true,
+            'form_schema' => [
+                'type' => 'object',
+                'properties' => [
+                    'nationalities' => [
+                        'type' => 'array',
+                        'items' => ['type' => 'string', 'pattern' => '^[A-Z]{2}$'],
+                        'minItems' => 1,
+                    ],
+                    'id_document_upload_now' => ['type' => 'string'],
+                    'id_document_kind' => ['type' => 'string'],
+                ],
+                'required' => ['nationalities'],
+            ],
+        ]);
+
+        $submission = OnboardingFormSubmission::factory()->create([
+            'employee_id' => $this->employee->id,
+            'form_template_id' => $template->id,
+            'status' => 'draft',
+        ]);
+
+        OnboardingSubmissionFile::create([
+            'onboarding_form_submission_id' => $submission->id,
+            'uploaded_by' => $this->user->id,
+            'document_type' => 'id_document',
+            'document_subtype' => null,
+            'file_path' => "employees/{$this->employee->id}/onboarding-submissions/{$submission->id}/legacy-id.enc",
+            'file_name' => 'legacy-passport.pdf',
+            'mime_type' => 'application/pdf',
+            'file_size' => 1024,
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->postJson('/v1/onboarding/submissions', [
+                'form_template_id' => $template->id,
+                'form_data' => [
+                    'nationalities' => ['DE'],
+                    'id_document_upload_now' => 'yes',
+                    'id_document_kind' => 'passport',
+                ],
+                'status' => 'submitted',
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['id_document_upload_now']);
     });
 
     test('does not require residence permit fields on templates that only keep copied nationalities', function (): void {
@@ -1317,6 +1545,7 @@ describe('PATCH /v1/onboarding/submissions/{submission}', function () {
             'form_template_id' => $template->id,
             'form_data' => [
                 'nationalities' => ['DE'],
+                'id_document_upload_now' => 'no',
                 'residence_permit_title' => 'Aufenthaltserlaubnis',
                 'residence_permit_employment_allowed' => 'no',
                 'residence_permit_expiry' => now()->subDay()->toDateString(),
@@ -1567,6 +1796,55 @@ describe('POST /v1/onboarding/submissions/{submission}/files', function () {
         $this->assertNotEmpty($decoded['nonce']);
     });
 
+    test('requires a document_subtype when uploading id_document files', function (): void {
+        Storage::fake('local');
+        givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.write');
+
+        $submission = OnboardingFormSubmission::factory()->create([
+            'employee_id' => $this->employee->id,
+            'form_template_id' => $this->template->id,
+            'status' => 'draft',
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->withHeaders(['Accept' => 'application/json'])
+            ->post("/v1/onboarding/submissions/{$submission->id}/files", [
+                'file' => UploadedFile::fake()->create('id.pdf', 100, 'application/pdf'),
+                'document_type' => 'id_document',
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['document_subtype']);
+    });
+
+    test('stores document_subtype for id_document uploads', function (): void {
+        Storage::fake('local');
+        givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.write');
+
+        $submission = OnboardingFormSubmission::factory()->create([
+            'employee_id' => $this->employee->id,
+            'form_template_id' => $this->template->id,
+            'status' => 'draft',
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->withHeaders(['Accept' => 'application/json'])
+            ->post("/v1/onboarding/submissions/{$submission->id}/files", [
+                'file' => UploadedFile::fake()->create('passport.pdf', 100, 'application/pdf'),
+                'document_type' => 'id_document',
+                'document_subtype' => 'identity_document',
+            ]);
+
+        $response->assertStatus(201);
+
+        $this->assertDatabaseHas('onboarding_submission_files', [
+            'onboarding_form_submission_id' => $submission->id,
+            'document_type' => 'id_document',
+            'document_subtype' => 'identity_document',
+            'file_name' => 'passport.pdf',
+        ]);
+    });
+
     test('returns 403 when uploading a file to another employee submission', function (): void {
         givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.write');
 
@@ -1611,6 +1889,113 @@ describe('POST /v1/onboarding/submissions/{submission}/files', function () {
             ]);
 
         $response->assertStatus(422);
+    });
+
+    test('returns a detailed upload error when PHP rejects the file before validation', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.write');
+
+        $submission = OnboardingFormSubmission::factory()->create([
+            'employee_id' => $this->employee->id,
+            'form_template_id' => $this->template->id,
+            'status' => 'draft',
+        ]);
+
+        $path = tempnam(sys_get_temp_dir(), 'upload-fail-');
+        expect($path)->not->toBeFalse();
+        file_put_contents($path, 'x');
+
+        $brokenSymfonyFile = new SymfonyUploadedFile(
+            $path,
+            'too-large.pdf',
+            'application/pdf',
+            UPLOAD_ERR_INI_SIZE,
+            true
+        );
+        $brokenFile = UploadedFile::createFromBase($brokenSymfonyFile, true);
+
+        $response = $this->withToken($this->token)
+            ->withHeaders(['Accept' => 'application/json'])
+            ->post("/v1/onboarding/submissions/{$submission->id}/files", [
+                'file' => $brokenFile,
+                'document_type' => 'contract',
+            ]);
+
+        @unlink($path);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['file']);
+
+        $firstFileError = (string) ($response->json('errors.file.0') ?? '');
+        expect($firstFileError)->toContain('upload_max_filesize')
+            ->and($firstFileError)->toContain('post_max_size');
+    });
+});
+
+describe('DELETE /v1/onboarding/submissions/{submission}/files/{file}', function () {
+    test('deletes an uploaded file for an editable own submission', function (): void {
+        Storage::fake('local');
+
+        $submission = OnboardingFormSubmission::factory()->create([
+            'employee_id' => $this->employee->id,
+            'form_template_id' => $this->template->id,
+            'status' => 'draft',
+        ]);
+
+        $path = "employees/{$this->employee->id}/onboarding-submissions/{$submission->id}/test.enc";
+        Storage::disk('local')->put($path, '{"ciphertext":"abc","nonce":"def"}');
+
+        $uploadedFile = OnboardingSubmissionFile::create([
+            'onboarding_form_submission_id' => $submission->id,
+            'uploaded_by' => $this->user->id,
+            'document_type' => 'id_document',
+            'document_subtype' => 'identity_document',
+            'file_path' => $path,
+            'file_name' => 'passport.pdf',
+            'mime_type' => 'application/pdf',
+            'file_size' => 1024,
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->delete("/v1/onboarding/submissions/{$submission->id}/files/{$uploadedFile->id}");
+
+        $response->assertNoContent();
+
+        Storage::disk('local')->assertMissing($path);
+        expect(OnboardingSubmissionFile::withTrashed()->find($uploadedFile->id)?->deleted_at)->not->toBeNull();
+    });
+
+    test('returns 404 when file does not belong to the submission', function (): void {
+        Storage::fake('local');
+
+        $submission = OnboardingFormSubmission::factory()->create([
+            'employee_id' => $this->employee->id,
+            'form_template_id' => $this->template->id,
+            'status' => 'draft',
+        ]);
+
+        $otherSubmission = OnboardingFormSubmission::factory()->create([
+            'employee_id' => $this->employee->id,
+            'form_template_id' => OnboardingFormTemplate::factory()->create([
+                'tenant_id' => $this->tenant->id,
+            ])->id,
+            'status' => 'draft',
+        ]);
+
+        $uploadedFile = OnboardingSubmissionFile::create([
+            'onboarding_form_submission_id' => $otherSubmission->id,
+            'uploaded_by' => $this->user->id,
+            'document_type' => 'id_document',
+            'document_subtype' => 'identity_document',
+            'file_path' => "employees/{$this->employee->id}/onboarding-submissions/{$otherSubmission->id}/test.enc",
+            'file_name' => 'passport.pdf',
+            'mime_type' => 'application/pdf',
+            'file_size' => 1024,
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->delete("/v1/onboarding/submissions/{$submission->id}/files/{$uploadedFile->id}");
+
+        $response->assertStatus(404);
     });
 });
 


### PR DESCRIPTION
## Summary
- require explicit `document_subtype` values for onboarding `id_document` uploads
- persist the subtype so split identity documents, proof-of-residence evidence, and residence permit files can be distinguished later in the workflow
- cover the new validation and upload behavior with onboarding controller tests

## Test plan
- [x] `php artisan test tests/Feature/Controllers/OnboardingControllerTest.php`
- [ ] CI