### PR TITLE
test: apply phpunit environment overrides before bootstrap

### DIFF
--- a/artisan
+++ b/artisan
@@ -10,6 +10,37 @@ use Symfony\Component\Console\Input\ArgvInput;
 
 define('LARAVEL_START', microtime(true));
 
+if (($argv[1] ?? null) === 'test') {
+    $configuration = @simplexml_load_file(__DIR__.'/phpunit.xml');
+
+    if ($configuration instanceof SimpleXMLElement) {
+        /** @var SimpleXMLElement[]|false $envNodes */
+        $envNodes = $configuration->xpath('/phpunit/php/env');
+
+        if ($envNodes !== false) {
+            foreach ($envNodes as $envNode) {
+                $name = (string) ($envNode['name'] ?? '');
+                $value = (string) ($envNode['value'] ?? '');
+                $force = strtolower((string) ($envNode['force'] ?? 'false'));
+
+                if ($name === '' || ! in_array($force, ['1', 'true', 'yes'], true)) {
+                    continue;
+                }
+
+                putenv($name.'='.$value);
+                $_ENV[$name] = $value;
+                $_SERVER[$name] = $value;
+
+                if ($name === 'DB_DATABASE') {
+                    putenv('SECPAL_TEST_DATABASE='.$value);
+                    $_ENV['SECPAL_TEST_DATABASE'] = $value;
+                    $_SERVER['SECPAL_TEST_DATABASE'] = $value;
+                }
+            }
+        }
+    }
+}
+
 // Register the Composer autoloader...
 require __DIR__.'/vendor/autoload.php';
 

--- a/artisan
+++ b/artisan
@@ -10,7 +10,19 @@ use Symfony\Component\Console\Input\ArgvInput;
 
 define('LARAVEL_START', microtime(true));
 
-if (($argv[1] ?? null) === 'test') {
+$artisanCommand = null;
+
+foreach (array_slice($argv, 1) as $argument) {
+    if ($argument === '' || str_starts_with($argument, '-')) {
+        continue;
+    }
+
+    $artisanCommand = $argument;
+
+    break;
+}
+
+if ($artisanCommand === 'test') {
     $configuration = @simplexml_load_file(__DIR__.'/phpunit.xml');
 
     if ($configuration instanceof SimpleXMLElement) {

--- a/config/database.php
+++ b/config/database.php
@@ -5,6 +5,12 @@
 
 use Illuminate\Support\Str;
 
+$forcedTestDatabase = getenv('SECPAL_TEST_DATABASE');
+
+if (! is_string($forcedTestDatabase) || $forcedTestDatabase === '') {
+    $forcedTestDatabase = $_ENV['SECPAL_TEST_DATABASE'] ?? $_SERVER['SECPAL_TEST_DATABASE'] ?? null;
+}
+
 return [
 
     /*
@@ -91,7 +97,9 @@ return [
             'url' => env('DB_URL'),
             'host' => env('DB_HOST', '127.0.0.1'),
             'port' => env('DB_PORT', '5432'),
-            'database' => env('DB_DATABASE', 'laravel'),
+            'database' => is_string($forcedTestDatabase) && $forcedTestDatabase !== ''
+                ? $forcedTestDatabase
+                : env('DB_DATABASE', 'laravel'),
             'username' => env('DB_USERNAME', 'root'),
             'password' => env('DB_PASSWORD', ''),
             'charset' => env('DB_CHARSET', 'utf8'),

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,7 +8,7 @@ SPDX-License-Identifier: CC0-1.0
 
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
+         bootstrap="tests/bootstrap.php"
          colors="true"
 >
     <testsuites>

--- a/tests/Support/TestCaseBootstrapEnvironmentProbe.php
+++ b/tests/Support/TestCaseBootstrapEnvironmentProbe.php
@@ -31,6 +31,11 @@ final class TestCaseBootstrapEnvironmentProbe extends TestCase
         parent::ensureBootstrapEnvironmentFileExists();
     }
 
+    public static function applyPhpUnitEnvironmentOverrides(): void
+    {
+        parent::applyPhpUnitEnvironmentOverrides();
+    }
+
     public static function removeBootstrapEnvironmentStub(): void
     {
         parent::cleanupBootstrapEnvironmentFile();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -18,6 +18,11 @@ abstract class TestCase extends BaseTestCase
 {
     private static bool $postgresTestDatabasesEnsured = false;
 
+    /**
+     * @var array<string, string>|null
+     */
+    private static ?array $phpUnitEnvironmentOverrides = null;
+
     private static ?string $temporaryBootstrapEnvironmentFile = null;
 
     /**
@@ -27,6 +32,7 @@ abstract class TestCase extends BaseTestCase
 
     public static function setUpBeforeClass(): void
     {
+        self::applyPhpUnitEnvironmentOverrides();
         self::ensurePostgresTestDatabasesExist();
 
         parent::setUpBeforeClass();
@@ -34,10 +40,12 @@ abstract class TestCase extends BaseTestCase
 
     public function createApplication(): Application
     {
+        self::applyPhpUnitEnvironmentOverrides();
         self::ensureBootstrapEnvironmentFileExists();
 
         /** @var Application $app */
         $app = parent::createApplication();
+        self::normalizeApplicationConfiguration($app);
 
         return $app;
     }
@@ -248,6 +256,43 @@ abstract class TestCase extends BaseTestCase
         return $default;
     }
 
+    protected static function applyPhpUnitEnvironmentOverrides(): void
+    {
+        foreach (self::phpUnitEnvironmentOverrides() as $name => $value) {
+            putenv($name.'='.$value);
+            $_ENV[$name] = $value;
+            $_SERVER[$name] = $value;
+
+            if ($name === 'DB_DATABASE') {
+                putenv('SECPAL_TEST_DATABASE='.$value);
+                $_ENV['SECPAL_TEST_DATABASE'] = $value;
+                $_SERVER['SECPAL_TEST_DATABASE'] = $value;
+            }
+        }
+    }
+
+    protected static function normalizeApplicationConfiguration(Application $app): void
+    {
+        $databaseConnection = self::phpUnitEnvironmentOverrides()['DB_CONNECTION'] ?? null;
+        $databaseName = self::phpUnitEnvironmentOverrides()['DB_DATABASE'] ?? null;
+
+        if (is_string($databaseConnection) && $databaseConnection !== '') {
+            $app['config']->set('database.default', $databaseConnection);
+        }
+
+        if (
+            is_string($databaseConnection) && $databaseConnection !== ''
+            && is_string($databaseName) && $databaseName !== ''
+        ) {
+            $app['config']->set("database.connections.{$databaseConnection}.database", $databaseName);
+            $app['config']->set("database.connections.{$databaseConnection}.url", null);
+        }
+
+        if (isset($app['db'])) {
+            $app['db']->purge();
+        }
+    }
+
     protected static function bootstrapEnvironmentPath(): string
     {
         return dirname(__DIR__);
@@ -329,5 +374,54 @@ abstract class TestCase extends BaseTestCase
         self::$localEnvironmentValues = $values;
 
         return self::$localEnvironmentValues;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private static function phpUnitEnvironmentOverrides(): array
+    {
+        if (self::$phpUnitEnvironmentOverrides !== null) {
+            return self::$phpUnitEnvironmentOverrides;
+        }
+
+        $configurationPath = dirname(__DIR__).'/phpunit.xml';
+
+        if (! is_file($configurationPath)) {
+            self::$phpUnitEnvironmentOverrides = [];
+
+            return self::$phpUnitEnvironmentOverrides;
+        }
+
+        $configuration = simplexml_load_file($configurationPath);
+
+        if (! $configuration instanceof \SimpleXMLElement) {
+            self::$phpUnitEnvironmentOverrides = [];
+
+            return self::$phpUnitEnvironmentOverrides;
+        }
+
+        $overrides = [];
+
+        /** @var \SimpleXMLElement[]|false $envNodes */
+        $envNodes = $configuration->xpath('/phpunit/php/env');
+
+        if ($envNodes !== false) {
+            foreach ($envNodes as $envNode) {
+                $name = (string) ($envNode['name'] ?? '');
+                $value = (string) ($envNode['value'] ?? '');
+                $force = strtolower((string) ($envNode['force'] ?? 'false'));
+
+                if ($name === '' || ! in_array($force, ['1', 'true', 'yes'], true)) {
+                    continue;
+                }
+
+                $overrides[$name] = $value;
+            }
+        }
+
+        self::$phpUnitEnvironmentOverrides = $overrides;
+
+        return self::$phpUnitEnvironmentOverrides;
     }
 }

--- a/tests/Unit/TestCasePhpUnitEnvironmentOverridesTest.php
+++ b/tests/Unit/TestCasePhpUnitEnvironmentOverridesTest.php
@@ -13,40 +13,42 @@ test('phpunit environment overrides are applied before bootstrap-sensitive test 
     $originalDbDatabase = getenv('DB_DATABASE');
     $originalForcedTestDatabase = getenv('SECPAL_TEST_DATABASE');
 
-    putenv('APP_ENV=staging');
-    putenv('DB_CONNECTION=mysql');
-    putenv('DB_DATABASE=secpal');
+    try {
+        putenv('APP_ENV=staging');
+        putenv('DB_CONNECTION=mysql');
+        putenv('DB_DATABASE=secpal');
 
-    $_ENV['APP_ENV'] = 'staging';
-    $_ENV['DB_CONNECTION'] = 'mysql';
-    $_ENV['DB_DATABASE'] = 'secpal';
+        $_ENV['APP_ENV'] = 'staging';
+        $_ENV['DB_CONNECTION'] = 'mysql';
+        $_ENV['DB_DATABASE'] = 'secpal';
 
-    $_SERVER['APP_ENV'] = 'staging';
-    $_SERVER['DB_CONNECTION'] = 'mysql';
-    $_SERVER['DB_DATABASE'] = 'secpal';
+        $_SERVER['APP_ENV'] = 'staging';
+        $_SERVER['DB_CONNECTION'] = 'mysql';
+        $_SERVER['DB_DATABASE'] = 'secpal';
 
-    TestCaseBootstrapEnvironmentProbe::applyPhpUnitEnvironmentOverrides();
+        TestCaseBootstrapEnvironmentProbe::applyPhpUnitEnvironmentOverrides();
 
-    expect(getenv('APP_ENV'))->toBe('testing')
-        ->and(getenv('DB_CONNECTION'))->toBe('pgsql')
-        ->and(getenv('DB_DATABASE'))->toBe('testing')
-        ->and(getenv('SECPAL_TEST_DATABASE'))->toBe('testing');
+        expect(getenv('APP_ENV'))->toBe('testing')
+            ->and(getenv('DB_CONNECTION'))->toBe('pgsql')
+            ->and(getenv('DB_DATABASE'))->toBe('testing')
+            ->and(getenv('SECPAL_TEST_DATABASE'))->toBe('testing');
+    } finally {
+        foreach ([
+            'APP_ENV' => $originalAppEnv,
+            'DB_CONNECTION' => $originalDbConnection,
+            'DB_DATABASE' => $originalDbDatabase,
+            'SECPAL_TEST_DATABASE' => $originalForcedTestDatabase,
+        ] as $key => $value) {
+            if ($value === false) {
+                putenv($key);
+                unset($_ENV[$key], $_SERVER[$key]);
 
-    foreach ([
-        'APP_ENV' => $originalAppEnv,
-        'DB_CONNECTION' => $originalDbConnection,
-        'DB_DATABASE' => $originalDbDatabase,
-        'SECPAL_TEST_DATABASE' => $originalForcedTestDatabase,
-    ] as $key => $value) {
-        if ($value === false) {
-            putenv($key);
-            unset($_ENV[$key], $_SERVER[$key]);
+                continue;
+            }
 
-            continue;
+            putenv($key.'='.$value);
+            $_ENV[$key] = $value;
+            $_SERVER[$key] = $value;
         }
-
-        putenv($key.'='.$value);
-        $_ENV[$key] = $value;
-        $_SERVER[$key] = $value;
     }
 });

--- a/tests/Unit/TestCasePhpUnitEnvironmentOverridesTest.php
+++ b/tests/Unit/TestCasePhpUnitEnvironmentOverridesTest.php
@@ -1,0 +1,52 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+use Tests\Support\TestCaseBootstrapEnvironmentProbe;
+
+test('phpunit environment overrides are applied before bootstrap-sensitive test setup', function (): void {
+    $originalAppEnv = getenv('APP_ENV');
+    $originalDbConnection = getenv('DB_CONNECTION');
+    $originalDbDatabase = getenv('DB_DATABASE');
+    $originalForcedTestDatabase = getenv('SECPAL_TEST_DATABASE');
+
+    putenv('APP_ENV=staging');
+    putenv('DB_CONNECTION=mysql');
+    putenv('DB_DATABASE=secpal');
+
+    $_ENV['APP_ENV'] = 'staging';
+    $_ENV['DB_CONNECTION'] = 'mysql';
+    $_ENV['DB_DATABASE'] = 'secpal';
+
+    $_SERVER['APP_ENV'] = 'staging';
+    $_SERVER['DB_CONNECTION'] = 'mysql';
+    $_SERVER['DB_DATABASE'] = 'secpal';
+
+    TestCaseBootstrapEnvironmentProbe::applyPhpUnitEnvironmentOverrides();
+
+    expect(getenv('APP_ENV'))->toBe('testing')
+        ->and(getenv('DB_CONNECTION'))->toBe('pgsql')
+        ->and(getenv('DB_DATABASE'))->toBe('testing')
+        ->and(getenv('SECPAL_TEST_DATABASE'))->toBe('testing');
+
+    foreach ([
+        'APP_ENV' => $originalAppEnv,
+        'DB_CONNECTION' => $originalDbConnection,
+        'DB_DATABASE' => $originalDbDatabase,
+        'SECPAL_TEST_DATABASE' => $originalForcedTestDatabase,
+    ] as $key => $value) {
+        if ($value === false) {
+            putenv($key);
+            unset($_ENV[$key], $_SERVER[$key]);
+
+            continue;
+        }
+
+        putenv($key.'='.$value);
+        $_ENV[$key] = $value;
+        $_SERVER[$key] = $value;
+    }
+});

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,67 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+$configuration = @simplexml_load_file(__DIR__.'/../phpunit.xml');
+
+if ($configuration instanceof SimpleXMLElement) {
+    /** @var SimpleXMLElement[]|false $envNodes */
+    $envNodes = $configuration->xpath('/phpunit/php/env');
+
+    if ($envNodes !== false) {
+        foreach ($envNodes as $envNode) {
+            $name = (string) ($envNode['name'] ?? '');
+            $value = (string) ($envNode['value'] ?? '');
+            $force = strtolower((string) ($envNode['force'] ?? 'false'));
+
+            if ($name === '' || ! in_array($force, ['1', 'true', 'yes'], true)) {
+                continue;
+            }
+
+            putenv($name.'='.$value);
+            $_ENV[$name] = $value;
+            $_SERVER[$name] = $value;
+
+            if ($name === 'DB_DATABASE') {
+                putenv('SECPAL_TEST_DATABASE='.$value);
+                $_ENV['SECPAL_TEST_DATABASE'] = $value;
+                $_SERVER['SECPAL_TEST_DATABASE'] = $value;
+            }
+        }
+    }
+}
+
+require __DIR__.'/../vendor/autoload.php';
+
+if (class_exists(Illuminate\Testing\ParallelRunner::class)) {
+    Illuminate\Testing\ParallelRunner::resolveApplicationUsing(static function (): Illuminate\Foundation\Application {
+        /** @var Illuminate\Foundation\Application $app */
+        $app = require __DIR__.'/../bootstrap/app.php';
+
+        $app->make(Illuminate\Contracts\Console\Kernel::class)->bootstrap();
+
+        $databaseConnection = getenv('DB_CONNECTION') ?: ($_ENV['DB_CONNECTION'] ?? $_SERVER['DB_CONNECTION'] ?? null);
+        $databaseName = getenv('DB_DATABASE') ?: ($_ENV['DB_DATABASE'] ?? $_SERVER['DB_DATABASE'] ?? null);
+
+        if (is_string($databaseConnection) && $databaseConnection !== '') {
+            $app['config']->set('database.default', $databaseConnection);
+        }
+
+        if (
+            is_string($databaseConnection) && $databaseConnection !== ''
+            && is_string($databaseName) && $databaseName !== ''
+        ) {
+            $app['config']->set("database.connections.{$databaseConnection}.database", $databaseName);
+            $app['config']->set("database.connections.{$databaseConnection}.url", null);
+        }
+
+        if (isset($app['db'])) {
+            $app['db']->purge();
+        }
+
+        return $app;
+    });
+}


### PR DESCRIPTION
## Summary
- load forced PHPUnit env values before bootstrap-sensitive test setup runs
- normalize the application database configuration so test processes use the intended database consistently
- add focused coverage for the override plumbing and bootstrap entrypoint

## Test plan
- [x] `php artisan test tests/Unit/TestCasePhpUnitEnvironmentOverridesTest.php`
- [ ] CI