### PR TITLE
fix: remove ineffective RuntimeException migration imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - aligned onboarding completion email verification with the invited employee mailbox by syncing the user login email before verification and dispatching the `Verified` event in that path; auth payloads now also expose resolved onboarding workflow state via `Employee::resolveOnboardingWorkflowStatus()`, with regression tests for login, `/v1/me`, and onboarding completion
 - fixed residential-address onboarding step rollout to reopen already-completed pre-contract dossiers when the new mandatory step is inserted, preserve existing completed residential-address step state, reject blank employee address rows before they can wipe persisted history, and let address autocomplete match common ASCII fallback input such as `Muller`/`Koln` for umlauted source data
 - made the employee-address migrations preserve legacy flat/current-history data during forward rollout and rollback, and tightened the residential-address-history rollback so only migration-inserted empty steps are removed while pre-existing tenant/global templates, submissions, and completed employee state stay consistent
+- removed ineffective `use RuntimeException;` imports from the anonymous employee-address and residential-address-history migrations so PHP 8.4 no longer aborts Polyscope preview setup during migration discovery
 
 ### Added
 

--- a/database/migrations/2026_05_10_120001_drop_legacy_employee_address_columns_from_employees_table.php
+++ b/database/migrations/2026_05_10_120001_drop_legacy_employee_address_columns_from_employees_table.php
@@ -11,7 +11,6 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
-use RuntimeException;
 
 return new class extends Migration
 {

--- a/database/migrations/2026_05_12_120000_add_residential_address_history_onboarding_step.php
+++ b/database/migrations/2026_05_12_120000_add_residential_address_history_onboarding_step.php
@@ -8,7 +8,6 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
-use RuntimeException;
 
 return new class extends Migration
 {


### PR DESCRIPTION
## Summary
- remove ineffective `use RuntimeException;` imports from `database/migrations/2026_05_10_120001_drop_legacy_employee_address_columns_from_employees_table.php`
- remove the same ineffective import from `database/migrations/2026_05_12_120000_add_residential_address_history_onboarding_step.php`
- document the PHP 8.4 / Polyscope migration-discovery setup fix in `CHANGELOG.md`

## Validation
- `php artisan config:clear && php artisan migrate:status --no-interaction`
- `php artisan test tests/Feature/Migrations/AddResidentialAddressHistoryOnboardingStepMigrationTest.php`
- `php artisan test --filter="employee_addresses table exists with expected columns and partial unique index" tests/Feature/Migrations/EmployeeAddressesTableMigrationTest.php`

## Note
- the full `tests/Feature/Migrations/EmployeeAddressesTableMigrationTest.php` file still has an unrelated existing failing assertion about tenant key query reuse

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to removing unused `use RuntimeException;` imports and updating documentation; it should not affect migration behavior beyond avoiding PHP 8.4/Polyscope discovery failures.
> 
> **Overview**
> Removes ineffective `use RuntimeException;` imports from two anonymous migrations (`2026_05_10_120001_drop_legacy_employee_address_columns_from_employees_table.php` and `2026_05_12_120000_add_residential_address_history_onboarding_step.php`) to prevent PHP 8.4/Polyscope migration-discovery aborts.
> 
> Updates `CHANGELOG.md` to document the fix (and normalizes the `[unreleased]` link formatting).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59d1bdc3a57b23958ba47b02754df1c61aecc778. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->