### PR TITLE
fix(onboarding): reword current address resided_from label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- renamed the `resided_from` field label in the current-address block of the residential address history onboarding form from "Living There Since" to "Date You Started Living There" for clarity
 - fixed OpenPLZ address-import retention so pruning only removes superseded imports for the active country and keeps the prior successful dataset even when failed attempts exist between successful runs
 - made the `birth_state` and `employee_addresses.state` cleanup migrations intentionally irreversible in `0.x`, so rollbacks no longer recreate removed compatibility columns
 - fixed BWR address-history continuity check reporting false-positive gaps when an employee has a pre-window historical address followed by a current address that fully covers the 5-year export window; segments ending before the window start are now discarded before the merge pass

--- a/app/Services/OnboardingFormDataSchemaValidationService.php
+++ b/app/Services/OnboardingFormDataSchemaValidationService.php
@@ -657,7 +657,7 @@ final class OnboardingFormDataSchemaValidationService
             'country' => $this->validationMessageString('Country'),
             'resided_from' => $requireUntilDate
                 ? $this->validationMessageString('Resided From')
-                : $this->validationMessageString('Living There Since'),
+                : $this->validationMessageString('Date You Started Living There'),
         ] as $field => $fieldLabel) {
             if ($this->normalizedNonEmptyString($address[$field] ?? null) !== null) {
                 continue;

--- a/app/Support/ResidentialAddressHistorySchema.php
+++ b/app/Support/ResidentialAddressHistorySchema.php
@@ -29,7 +29,7 @@ final class ResidentialAddressHistorySchema
                         'country' => ['type' => 'string', 'title' => 'Country', 'pattern' => '^[A-Z]{2}$'],
                         'resided_from' => [
                             'type' => 'string',
-                            'title' => 'Living There Since',
+                            'title' => 'Date You Started Living There',
                             'pattern' => '^\d{4}-\d{2}-\d{2}$',
                         ],
                     ],

--- a/database/migrations/2026_05_15_120000_update_residential_address_history_resided_from_label.php
+++ b/database/migrations/2026_05_15_120000_update_residential_address_history_resided_from_label.php
@@ -3,7 +3,6 @@
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-use App\Support\ResidentialAddressHistorySchema;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
@@ -13,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         $now = Carbon::now();
-        $schema = json_encode(ResidentialAddressHistorySchema::definition(), JSON_THROW_ON_ERROR);
+        $schema = json_encode($this->updatedResidentialAddressHistorySchema(), JSON_THROW_ON_ERROR);
 
         DB::table('onboarding_form_templates')
             ->whereNull('tenant_id')
@@ -27,23 +26,7 @@ return new class extends Migration
     public function down(): void
     {
         $now = Carbon::now();
-        $schema = json_encode(
-            array_replace_recursive(
-                ResidentialAddressHistorySchema::definition(),
-                [
-                    'properties' => [
-                        'current_address' => [
-                            'properties' => [
-                                'resided_from' => [
-                                    'title' => 'Living There Since',
-                                ],
-                            ],
-                        ],
-                    ],
-                ],
-            ),
-            JSON_THROW_ON_ERROR,
-        );
+        $schema = json_encode($this->legacyResidentialAddressHistorySchema(), JSON_THROW_ON_ERROR);
 
         DB::table('onboarding_form_templates')
             ->whereNull('tenant_id')
@@ -52,5 +35,123 @@ return new class extends Migration
                 'form_schema' => $schema,
                 'updated_at' => $now,
             ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function updatedResidentialAddressHistorySchema(): array
+    {
+        return [
+            'title' => 'Residential Address History',
+            'description' => 'Provide your current residential address, the date since you have lived there, and earlier residences covering the last five years.',
+            'type' => 'object',
+            'properties' => [
+                'current_address' => [
+                    'type' => 'object',
+                    'title' => 'Current Residential Address',
+                    'properties' => [
+                        'street' => ['type' => 'string', 'title' => 'Street', 'maxLength' => 255],
+                        'house_number' => ['type' => 'string', 'title' => 'House Number', 'maxLength' => 50],
+                        'postal_code' => ['type' => 'string', 'title' => 'Postal Code', 'maxLength' => 20],
+                        'city' => ['type' => 'string', 'title' => 'City', 'maxLength' => 255],
+                        'supplement' => ['type' => 'string', 'title' => 'Address Supplement', 'maxLength' => 255],
+                        'country' => ['type' => 'string', 'title' => 'Country', 'pattern' => '^[A-Z]{2}$'],
+                        'resided_from' => [
+                            'type' => 'string',
+                            'title' => 'Date You Started Living There',
+                            'pattern' => '^\d{4}-\d{2}-\d{2}$',
+                        ],
+                    ],
+                    'required' => ['street', 'house_number', 'postal_code', 'city', 'country', 'resided_from'],
+                ],
+                'previous_addresses' => [
+                    'type' => 'array',
+                    'title' => 'Previous Residences',
+                    'items' => [
+                        'type' => 'object',
+                        'properties' => [
+                            'street' => ['type' => 'string', 'title' => 'Street', 'maxLength' => 255],
+                            'house_number' => ['type' => 'string', 'title' => 'House Number', 'maxLength' => 50],
+                            'postal_code' => ['type' => 'string', 'title' => 'Postal Code', 'maxLength' => 20],
+                            'city' => ['type' => 'string', 'title' => 'City', 'maxLength' => 255],
+                            'supplement' => ['type' => 'string', 'title' => 'Address Supplement', 'maxLength' => 255],
+                            'country' => ['type' => 'string', 'title' => 'Country', 'pattern' => '^[A-Z]{2}$'],
+                            'resided_from' => [
+                                'type' => 'string',
+                                'title' => 'Resided From',
+                                'pattern' => '^\d{4}-\d{2}-\d{2}$',
+                            ],
+                            'resided_until' => [
+                                'type' => 'string',
+                                'title' => 'Resided Until',
+                                'pattern' => '^\d{4}-\d{2}-\d{2}$',
+                            ],
+                        ],
+                        'required' => ['street', 'house_number', 'postal_code', 'city', 'country', 'resided_from', 'resided_until'],
+                    ],
+                ],
+            ],
+            'required' => ['current_address'],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function legacyResidentialAddressHistorySchema(): array
+    {
+        return [
+            'title' => 'Residential Address History',
+            'description' => 'Provide your current residential address, the date since you have lived there, and earlier residences covering the last five years.',
+            'type' => 'object',
+            'properties' => [
+                'current_address' => [
+                    'type' => 'object',
+                    'title' => 'Current Residential Address',
+                    'properties' => [
+                        'street' => ['type' => 'string', 'title' => 'Street', 'maxLength' => 255],
+                        'house_number' => ['type' => 'string', 'title' => 'House Number', 'maxLength' => 50],
+                        'postal_code' => ['type' => 'string', 'title' => 'Postal Code', 'maxLength' => 20],
+                        'city' => ['type' => 'string', 'title' => 'City', 'maxLength' => 255],
+                        'supplement' => ['type' => 'string', 'title' => 'Address Supplement', 'maxLength' => 255],
+                        'country' => ['type' => 'string', 'title' => 'Country', 'pattern' => '^[A-Z]{2}$'],
+                        'resided_from' => [
+                            'type' => 'string',
+                            'title' => 'Living There Since',
+                            'pattern' => '^\d{4}-\d{2}-\d{2}$',
+                        ],
+                    ],
+                    'required' => ['street', 'house_number', 'postal_code', 'city', 'country', 'resided_from'],
+                ],
+                'previous_addresses' => [
+                    'type' => 'array',
+                    'title' => 'Previous Residences',
+                    'items' => [
+                        'type' => 'object',
+                        'properties' => [
+                            'street' => ['type' => 'string', 'title' => 'Street', 'maxLength' => 255],
+                            'house_number' => ['type' => 'string', 'title' => 'House Number', 'maxLength' => 50],
+                            'postal_code' => ['type' => 'string', 'title' => 'Postal Code', 'maxLength' => 20],
+                            'city' => ['type' => 'string', 'title' => 'City', 'maxLength' => 255],
+                            'supplement' => ['type' => 'string', 'title' => 'Address Supplement', 'maxLength' => 255],
+                            'country' => ['type' => 'string', 'title' => 'Country', 'pattern' => '^[A-Z]{2}$'],
+                            'resided_from' => [
+                                'type' => 'string',
+                                'title' => 'Resided From',
+                                'pattern' => '^\d{4}-\d{2}-\d{2}$',
+                            ],
+                            'resided_until' => [
+                                'type' => 'string',
+                                'title' => 'Resided Until',
+                                'pattern' => '^\d{4}-\d{2}-\d{2}$',
+                            ],
+                        ],
+                        'required' => ['street', 'house_number', 'postal_code', 'city', 'country', 'resided_from', 'resided_until'],
+                    ],
+                ],
+            ],
+            'required' => ['current_address'],
+        ];
     }
 };

--- a/database/migrations/2026_05_15_120000_update_residential_address_history_resided_from_label.php
+++ b/database/migrations/2026_05_15_120000_update_residential_address_history_resided_from_label.php
@@ -1,0 +1,51 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use App\Support\ResidentialAddressHistorySchema;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $now = Carbon::now();
+        $schema = json_encode(ResidentialAddressHistorySchema::definition(), JSON_THROW_ON_ERROR);
+
+        DB::table('onboarding_form_templates')
+            ->whereNull('tenant_id')
+            ->where('template_key', 'residential_address_history')
+            ->update([
+                'form_schema' => $schema,
+                'updated_at' => $now,
+            ]);
+    }
+
+    public function down(): void
+    {
+        $now = Carbon::now();
+        $schema = json_encode($this->legacyResidentialAddressHistorySchema(), JSON_THROW_ON_ERROR);
+
+        DB::table('onboarding_form_templates')
+            ->whereNull('tenant_id')
+            ->where('template_key', 'residential_address_history')
+            ->update([
+                'form_schema' => $schema,
+                'updated_at' => $now,
+            ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function legacyResidentialAddressHistorySchema(): array
+    {
+        $schema = ResidentialAddressHistorySchema::definition();
+        $schema['properties']['current_address']['properties']['resided_from']['title'] = 'Living There Since';
+
+        return $schema;
+    }
+};

--- a/database/migrations/2026_05_15_120000_update_residential_address_history_resided_from_label.php
+++ b/database/migrations/2026_05_15_120000_update_residential_address_history_resided_from_label.php
@@ -27,7 +27,23 @@ return new class extends Migration
     public function down(): void
     {
         $now = Carbon::now();
-        $schema = json_encode($this->legacyResidentialAddressHistorySchema(), JSON_THROW_ON_ERROR);
+        $schema = json_encode(
+            array_replace_recursive(
+                ResidentialAddressHistorySchema::definition(),
+                [
+                    'properties' => [
+                        'current_address' => [
+                            'properties' => [
+                                'resided_from' => [
+                                    'title' => 'Living There Since',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ),
+            JSON_THROW_ON_ERROR,
+        );
 
         DB::table('onboarding_form_templates')
             ->whereNull('tenant_id')
@@ -36,16 +52,5 @@ return new class extends Migration
                 'form_schema' => $schema,
                 'updated_at' => $now,
             ]);
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    private function legacyResidentialAddressHistorySchema(): array
-    {
-        $schema = ResidentialAddressHistorySchema::definition();
-        $schema['properties']['current_address']['properties']['resided_from']['title'] = 'Living There Since';
-
-        return $schema;
     }
 };

--- a/lang/en/onboarding_schemas.php
+++ b/lang/en/onboarding_schemas.php
@@ -75,7 +75,7 @@ return [
                     'city' => ['title' => 'City'],
                     'supplement' => ['title' => 'Address Supplement'],
                     'country' => ['title' => 'Country'],
-                    'resided_from' => ['title' => 'Living There Since'],
+                    'resided_from' => ['title' => 'Date You Started Living There'],
                 ],
                 'previous_addresses' => [
                     'title' => 'Previous Residences',

--- a/tests/Feature/Migrations/UpdateResidentialAddressHistoryResidedFromLabelMigrationTest.php
+++ b/tests/Feature/Migrations/UpdateResidentialAddressHistoryResidedFromLabelMigrationTest.php
@@ -52,7 +52,9 @@ test('up() stores a schema equal to ResidentialAddressHistorySchema::definition(
 
     $template = globalResidentialTemplate();
 
-    expect($template->form_schema)->toBe(ResidentialAddressHistorySchema::definition());
+    expect($template->form_schema)->toBe(ResidentialAddressHistorySchema::definition())
+        ->and($template->form_schema['properties']['current_address']['properties']['resided_from']['title'])
+        ->toBe('Date You Started Living There');
 });
 
 test('down() restores global template schema to legacy resided_from label', function (): void {

--- a/tests/Feature/Migrations/UpdateResidentialAddressHistoryResidedFromLabelMigrationTest.php
+++ b/tests/Feature/Migrations/UpdateResidentialAddressHistoryResidedFromLabelMigrationTest.php
@@ -1,0 +1,95 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use App\Models\OnboardingFormTemplate;
+use App\Models\TenantKey;
+use App\Support\ResidentialAddressHistorySchema;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function (): void {
+    incrementTestKekCounter();
+    TenantKey::setKekPath(getTestKekPath());
+    TenantKey::generateKek();
+});
+
+afterEach(function (): void {
+    cleanupTestKekFile();
+    TenantKey::setKekPath(null);
+});
+
+function loadResidedFromLabelMigration(): object
+{
+    return require database_path('migrations/2026_05_15_120000_update_residential_address_history_resided_from_label.php');
+}
+
+function globalResidentialTemplate(): OnboardingFormTemplate
+{
+    return OnboardingFormTemplate::query()
+        ->whereNull('tenant_id')
+        ->where('template_key', 'residential_address_history')
+        ->firstOrFail();
+}
+
+test('up() updates global residential template schema to new resided_from label', function (): void {
+    $template = globalResidentialTemplate();
+
+    $migration = loadResidedFromLabelMigration();
+    $migration->up();
+
+    $template->refresh();
+
+    $currentAddressResidedFrom = $template->form_schema['properties']['current_address']['properties']['resided_from'];
+    expect($currentAddressResidedFrom['title'])->toBe('Date You Started Living There');
+});
+
+test('up() stores a schema equal to ResidentialAddressHistorySchema::definition()', function (): void {
+    $migration = loadResidedFromLabelMigration();
+    $migration->up();
+
+    $template = globalResidentialTemplate();
+
+    expect($template->form_schema)->toBe(ResidentialAddressHistorySchema::definition());
+});
+
+test('down() restores global template schema to legacy resided_from label', function (): void {
+    $migration = loadResidedFromLabelMigration();
+    $migration->up();
+    $migration->down();
+
+    $template = globalResidentialTemplate();
+
+    $currentAddressResidedFrom = $template->form_schema['properties']['current_address']['properties']['resided_from'];
+    expect($currentAddressResidedFrom['title'])->toBe('Living There Since');
+});
+
+test('down() leaves previous_addresses resided_from label unchanged', function (): void {
+    $migration = loadResidedFromLabelMigration();
+    $migration->up();
+    $migration->down();
+
+    $template = globalResidentialTemplate();
+
+    $previousAddressResidedFrom = $template->form_schema['properties']['previous_addresses']['items']['properties']['resided_from'];
+    expect($previousAddressResidedFrom['title'])->toBe('Resided From');
+});
+
+test('up() does not touch tenant-scoped residential templates', function (): void {
+    $tenant = TenantKey::factory()->create();
+
+    $tenantTemplate = OnboardingFormTemplate::factory()->create([
+        'tenant_id' => $tenant->id,
+        'template_key' => 'residential_address_history',
+        'form_schema' => ['type' => 'object', 'properties' => ['legacy_field' => ['type' => 'string']]],
+    ]);
+
+    $migration = loadResidedFromLabelMigration();
+    $migration->up();
+
+    $tenantTemplate->refresh();
+
+    expect($tenantTemplate->form_schema)->toBe(['type' => 'object', 'properties' => ['legacy_field' => ['type' => 'string']]]);
+});


### PR DESCRIPTION
## Summary
- Regression coverage for `UpdateResidentialAddressHistoryResidedFromLabelMigrationTest` shows existing global `residential_address_history` templates still stored the awkward current-address `resided_from` label `"Living There Since"`.
- Reword the current-address label to `"Date You Started Living There"` in the canonical schema, English onboarding translation, and current-address validation messaging.
- Add a migration to rewrite stored global residential address history template JSON so existing installs get the updated label without touching tenant-scoped templates.

## Visible impact
- User-visible: the current residential address field now uses clearer English wording in onboarding and related validation output.
- API/contract: the `form_schema` JSON for the global `residential_address_history` template changes only in that label text; no field keys or validation patterns change.
- Governance: `CHANGELOG.md` is updated for the wording fix.

## Validation
- `php artisan test --filter='UpdateResidentialAddressHistoryResidedFromLabelMigrationTest'`
- `php artisan test --filter='OnboardingFormTemplatesSeederTest|OnboardingFormDataSchemaValidationServiceDateTest|AddResidentialAddressHistoryOnboardingStepMigrationTest'`
- `vendor/bin/pint --dirty`
- `git diff --check`

## Linked repos
- None.

## Out-of-scope issues
- None filed.

## Ready status
- Open this as a draft first.
- Before marking ready: publish the signed commit, let required checks pass, and complete the final PR-view self-review with zero issues.

Closes #1052

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to user-facing label text plus a migration that rewrites only the global `residential_address_history` template JSON schema; no field keys or validation rules change.
> 
> **Overview**
> Rewords the current-address `resided_from` label from "Living There Since" to **"Date You Started Living There"** across the canonical residential address history schema, English onboarding schema localization, and validation error messaging.
> 
> Adds a migration to update existing **global** `residential_address_history` entries in `onboarding_form_templates.form_schema` to the updated schema (with a `down()` to restore the legacy label), plus a focused migration test ensuring tenant-scoped templates are untouched. Updates `CHANGELOG.md` to record the wording fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31e477b5b5803f9925b74774cd057e1693045e54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->