### PR TITLE
fix(employee-qualifications): remove public document_path field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- stopped exposing `employee_qualifications.document_path` through the public qualification attach/update API and `EmployeeQualificationResource`; the storage path remains internal and regression coverage now proves requests ignore it while list/show responses omit it
 - renamed the `resided_from` field label in the current-address block of the residential address history onboarding form from "Living There Since" to "Date You Started Living There" for clarity
 - fixed OpenPLZ address-import retention so pruning only removes superseded imports for the active country and keeps the prior successful dataset even when failed attempts exist between successful runs
 - made the `birth_state` and `employee_addresses.state` cleanup migrations intentionally irreversible in `0.x`, so rollbacks no longer recreate removed compatibility columns

--- a/app/Http/Controllers/Api/V1/EmployeeQualificationController.php
+++ b/app/Http/Controllers/Api/V1/EmployeeQualificationController.php
@@ -83,7 +83,6 @@ class EmployeeQualificationController extends Controller
             'certificate_number' => $validated['certificate_number'] ?? null,
             'issuing_authority' => $validated['issuing_authority'] ?? null,
             'notes' => $validated['notes'] ?? null,
-            'document_path' => $validated['document_path'] ?? null,
             'status' => $validated['status'] ?? 'valid',
         ]);
 

--- a/app/Http/Requests/AttachQualificationRequest.php
+++ b/app/Http/Requests/AttachQualificationRequest.php
@@ -59,7 +59,6 @@ class AttachQualificationRequest extends FormRequest
             'certificate_number' => ['nullable', 'string', 'max:255'],
             'issuing_authority' => ['nullable', 'string', 'max:255'],
             'notes' => ['nullable', 'string', 'max:1000'],
-            'document_path' => ['nullable', 'string', 'max:255'],
             'status' => ['nullable', Rule::in(['valid', 'expiring_soon', 'expired'])],
         ];
     }

--- a/app/Http/Requests/UpdateEmployeeQualificationRequest.php
+++ b/app/Http/Requests/UpdateEmployeeQualificationRequest.php
@@ -38,7 +38,6 @@ class UpdateEmployeeQualificationRequest extends FormRequest
             'certificate_number' => ['sometimes', 'nullable', 'string', 'max:255'],
             'issuing_authority' => ['sometimes', 'nullable', 'string', 'max:255'],
             'notes' => ['sometimes', 'nullable', 'string', 'max:1000'],
-            'document_path' => ['sometimes', 'nullable', 'string', 'max:255'],
             'status' => ['sometimes', 'nullable', Rule::in(['valid', 'expiring_soon', 'expired'])],
         ];
     }

--- a/app/Http/Resources/EmployeeQualificationResource.php
+++ b/app/Http/Resources/EmployeeQualificationResource.php
@@ -40,7 +40,6 @@ class EmployeeQualificationResource extends JsonResource
             'certificate_number' => $this->certificate_number,
             'issuing_authority' => $this->issuing_authority,
             'notes' => $this->notes,
-            'document_path' => $this->document_path,
             'status' => $this->status,
 
             // Relationships (optional)

--- a/app/Models/Employee.php
+++ b/app/Models/Employee.php
@@ -741,7 +741,6 @@ class Employee extends Model
             'certificate_number',
             'issuing_authority',
             'notes',
-            'document_path',
             'status',
         ])->withTimestamps();
     }

--- a/app/Models/EmployeeQualification.php
+++ b/app/Models/EmployeeQualification.php
@@ -24,7 +24,6 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property string|null $certificate_number
  * @property string|null $issuing_authority
  * @property string|null $notes
- * @property string|null $document_path
  * @property string $status
  */
 class EmployeeQualification extends Model
@@ -59,7 +58,6 @@ class EmployeeQualification extends Model
         'certificate_number',
         'issuing_authority',
         'notes',
-        'document_path',
         'status',
     ];
 

--- a/database/factories/EmployeeQualificationFactory.php
+++ b/database/factories/EmployeeQualificationFactory.php
@@ -30,7 +30,6 @@ class EmployeeQualificationFactory extends Factory
             'certificate_number' => fake()->optional()->bothify('CERT-####-????'),
             'issuing_authority' => fake()->optional()->company(),
             'notes' => fake()->optional()->sentence(),
-            'document_path' => fake()->optional()->filePath(),
             'status' => EmployeeQualification::STATUS_ACTIVE,
         ];
     }

--- a/tests/Feature/Controllers/EmployeeQualificationControllerTest.php
+++ b/tests/Feature/Controllers/EmployeeQualificationControllerTest.php
@@ -414,6 +414,71 @@ describe('PATCH /v1/employee-qualifications/{employeeQualification}', function (
     });
 });
 
+describe('document_path is not exposed via the public API', function () {
+    test('attach ignores document_path in request and omits it from response', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'employee_qualification.write');
+
+        $response = $this->withToken($this->token)
+            ->postJson("/v1/employees/{$this->employee->id}/qualifications", [
+                'qualification_id' => $this->qualification->id,
+                'obtained_date' => now()->subMonth()->toDateString(),
+                'status' => 'valid',
+                'document_path' => 'employees/1/qualifications/leaked.pdf',
+            ]);
+
+        $response->assertStatus(201);
+        expect(array_key_exists('document_path', $response->json('data')))->toBeFalse();
+
+        $employeeQualification = EmployeeQualification::query()->findOrFail($response->json('data.id'));
+        expect($employeeQualification->document_path)->toBeNull();
+    });
+
+    test('update ignores document_path in request and omits it from response', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'employee_qualification.write');
+
+        $pivot = EmployeeQualification::factory()->create([
+            'employee_id' => $this->employee->id,
+            'qualification_id' => $this->qualification->id,
+            'status' => 'valid',
+        ]);
+        $pivot->forceFill(['document_path' => 'employees/1/qualifications/internal.enc'])->save();
+
+        $response = $this->withToken($this->token)
+            ->patchJson("/v1/employee-qualifications/{$pivot->id}", [
+                'notes' => 'Updated notes',
+                'document_path' => 'employees/1/qualifications/leaked.pdf',
+            ]);
+
+        $response->assertStatus(200);
+        expect(array_key_exists('document_path', $response->json('data')))->toBeFalse();
+        expect($response->json('data.notes'))->toBe('Updated notes');
+
+        $pivot->refresh();
+        expect($pivot->document_path)->toBe('employees/1/qualifications/internal.enc');
+    });
+
+    test('read endpoints omit document_path even when stored internally', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'employee_qualification.read');
+
+        $pivot = EmployeeQualification::factory()->create([
+            'employee_id' => $this->employee->id,
+            'qualification_id' => $this->qualification->id,
+            'status' => 'valid',
+        ]);
+        $pivot->forceFill(['document_path' => 'employees/1/qualifications/internal.enc'])->save();
+
+        $showResponse = $this->withToken($this->token)
+            ->getJson("/v1/employee-qualifications/{$pivot->id}");
+        $showResponse->assertStatus(200);
+        expect(array_key_exists('document_path', $showResponse->json('data')))->toBeFalse();
+
+        $listResponse = $this->withToken($this->token)
+            ->getJson("/v1/employees/{$this->employee->id}/qualifications");
+        $listResponse->assertStatus(200);
+        expect(array_key_exists('document_path', $listResponse->json('data.0')))->toBeFalse();
+    });
+});
+
 describe('DELETE /v1/employee-qualifications/{employeeQualification}', function () {
     test('returns 401 when not authenticated', function (): void {
         $pivot = EmployeeQualification::factory()->create([


### PR DESCRIPTION
## Reproduced defect
The employee qualification API still accepted and returned `document_path` even though it represents the internal storage path on `employee_qualifications`, so the public contract leaked storage implementation details.

Closes #1055.

## Current change
- remove public `document_path` validation from qualification attach and update requests
- stop returning `document_path` from `EmployeeQualificationResource`
- stop mass-assigning or exposing the field through the controller, model, and employee qualification pivot relationship
- add regression coverage proving attach and update ignore client-sent `document_path` values and list/show responses omit the stored internal path
- update `CHANGELOG.md`

## Validation run
- `php artisan test tests/Feature/Controllers/EmployeeQualificationControllerTest.php`
- `vendor/bin/pint --dirty`

## Linked workspace context
- `SecPal/contracts` workspace `fix-qualification-document-path` contains the matching contracts/OpenAPI change from `SecPal/contracts#233`

## Still needed before marking ready
- final self-review in the PR view must still find zero issues
- GitHub Actions checks for this draft PR still need to complete successfully

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the public `employee qualification` API contract by rejecting/ignoring `document_path` on attach/update and omitting it from all responses, which could break clients relying on that field but reduces leakage of internal storage details.
> 
> **Overview**
> **Removes the internal `employee_qualifications.document_path` field from the public API surface.** The attach/update requests no longer validate or mass-assign `document_path`, and `EmployeeQualificationResource` (plus the `Employee::qualifications()` pivot mapping) no longer returns it.
> 
> Adds feature tests proving `document_path` is ignored on write and omitted from list/show responses, and documents the fix in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cf31e1d4bca4e37900588925832812c55fc5922. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->