### PR TITLE
fix(address-data,onboarding): CSV row diagnostics and residential lookback (#1053)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,10 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - forced the PHPUnit `DB_CONNECTION` and `DB_DATABASE` overrides so the early PostgreSQL test bootstrap always provisions `testing*_test_*` databases instead of inheriting runtime `secpal*` names from the shell environment during parallel runs
 - fixed address-street and address-locality `withValidator` callbacks to use `is_scalar` guards before casting, preventing a 500 error when an array is submitted for a filter field
 - fixed `AddressDataDownloader` to wrap the HTTP download and hash in a try/catch that removes the partial temp file on any exception, not just on a non-2xx response
-- fixed `AddressStreetCsvImporter` to include the data row number in the wrong-column-count error message
+- improved `AddressStreetCsvImporter` wrong-column-count errors with row number, expected versus observed counts, and a truncated row preview for large-file debugging
 - fixed `AddressSuggestionService` to pass `postalCodePrefix` into `orderStreetResults` and use it as an exact-match relevance tiebreaker
 - fixed `AddressDataImportService` pruning to expire stale `running` imports (older than 6 hours) before the delete pass, so crashed runs no longer accumulate indefinitely
-- fixed residential address history submission to require at least one previous address when the current address start date is within the last five years
+- aligned onboarding residential-address-history five-year previous-address enforcement with export address-history lookback (`startOfDay` boundary, shared five-year constant) and expanded Pest coverage for submit validation
 - fixed `ImportAddressDataCommand` to output failed results with `error()` and skipped results with `warn()` instead of always using `info()`
 - gated `OnboardingDemoUserSeeder` to non-production environments so production deployments cannot accidentally expose the demo onboarding account
 - fixed rollback of the residential address history onboarding step migration to only restore `onboarding_completed` for employees who previously completed onboarding (i.e., have `onboarding_completed_at` set), preventing false completion of in-progress dossiers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - improved `AddressStreetCsvImporter` wrong-column-count errors with row number, expected versus observed counts, and a truncated row preview for large-file debugging
 - fixed `AddressSuggestionService` to pass `postalCodePrefix` into `orderStreetResults` and use it as an exact-match relevance tiebreaker
 - fixed `AddressDataImportService` pruning to expire stale `running` imports (older than 6 hours) before the delete pass, so crashed runs no longer accumulate indefinitely
-- aligned onboarding residential-address-history five-year previous-address enforcement with export address-history lookback (`startOfDay` boundary, shared five-year constant) and expanded Pest coverage for submit validation
+- aligned onboarding residential-address-history five-year previous-address enforcement with export address-history lookback (`startOfDay` boundary) via shared `App\Support\AddressHistoryLookback::YEARS`, and expanded Pest coverage for submit validation
 - fixed `ImportAddressDataCommand` to output failed results with `error()` and skipped results with `warn()` instead of always using `info()`
 - gated `OnboardingDemoUserSeeder` to non-production environments so production deployments cannot accidentally expose the demo onboarding account
 - fixed rollback of the residential address history onboarding step migration to only restore `onboarding_completed` for employees who previously completed onboarding (i.e., have `onboarding_completed_at` set), preventing false completion of in-progress dossiers

--- a/app/Services/AddressData/AddressStreetCsvImporter.php
+++ b/app/Services/AddressData/AddressStreetCsvImporter.php
@@ -60,6 +60,7 @@ final class AddressStreetCsvImporter
             $chunkTarget = AddressDataConfig::int('address_data.chunk_rows', 2000);
             $countryCode = AddressDataConfig::string('address_data.country', 'DE');
             $now = now()->toDateTimeString();
+            $expectedColumnCount = count(self::EXPECTED_HEADER);
 
             $buffer = [];
             $total = 0;
@@ -106,11 +107,11 @@ final class AddressStreetCsvImporter
 
                 $rowNumber++;
 
-                if (count($row) !== 6) {
+                if (count($row) !== $expectedColumnCount) {
                     $got = count($row);
                     $preview = $this->csvRowPreviewForError($row);
                     throw new InvalidArgumentException(
-                        "CSV data row {$rowNumber} has wrong column count (expected 6, got {$got}). {$preview}",
+                        "CSV data row {$rowNumber} has wrong column count (expected {$expectedColumnCount}, got {$got}). {$preview}",
                     );
                 }
 

--- a/app/Services/AddressData/AddressStreetCsvImporter.php
+++ b/app/Services/AddressData/AddressStreetCsvImporter.php
@@ -107,7 +107,11 @@ final class AddressStreetCsvImporter
                 $rowNumber++;
 
                 if (count($row) !== 6) {
-                    throw new InvalidArgumentException("CSV data row {$rowNumber} has wrong column count (expected 6).");
+                    $got = count($row);
+                    $preview = $this->csvRowPreviewForError($row);
+                    throw new InvalidArgumentException(
+                        "CSV data row {$rowNumber} has wrong column count (expected 6, got {$got}). {$preview}",
+                    );
                 }
 
                 $name = (string) ($row[0] ?? '');
@@ -187,5 +191,25 @@ final class AddressStreetCsvImporter
         $trimmed = trim($postalCode);
 
         return preg_replace('/\s+/u', '', $trimmed) ?? $trimmed;
+    }
+
+    /**
+     * @param  array<int, string|null>  $row
+     */
+    private function csvRowPreviewForError(array $row): string
+    {
+        $cells = [];
+        foreach ($row as $cell) {
+            $value = str_replace(["\r", "\n"], ' ', (string) $cell);
+            $cells[] = str_contains($value, ',') ? '"'.str_replace('"', '""', $value).'"' : $value;
+        }
+
+        $joined = implode(',', $cells);
+        $max = 200;
+        if (mb_strlen($joined) > $max) {
+            $joined = mb_substr($joined, 0, $max).'…';
+        }
+
+        return 'Row preview: '.$joined;
     }
 }

--- a/app/Services/BewacherregisterExportService.php
+++ b/app/Services/BewacherregisterExportService.php
@@ -10,14 +10,13 @@ namespace App\Services;
 use App\Exceptions\BewacherregisterExportNotReadyException;
 use App\Models\Employee;
 use App\Models\EmployeeAddress;
+use App\Support\AddressHistoryLookback;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Storage;
 
 class BewacherregisterExportService
 {
-    private const EXPORT_ADDRESS_LOOKBACK_YEARS = 5;
-
     /**
      * @return array{disk: string, path: string, file_name: string, file_size_bytes: int}
      */
@@ -177,7 +176,7 @@ class BewacherregisterExportService
             }
         }
 
-        $windowStart = now()->startOfDay()->copy()->subYears(self::EXPORT_ADDRESS_LOOKBACK_YEARS);
+        $windowStart = now()->startOfDay()->copy()->subYears(AddressHistoryLookback::YEARS);
         $windowEnd = now()->startOfDay();
 
         /** @var array<int, array{start: Carbon, end: Carbon}> $segments */

--- a/app/Services/OnboardingFormDataSchemaValidationService.php
+++ b/app/Services/OnboardingFormDataSchemaValidationService.php
@@ -33,6 +33,11 @@ final class OnboardingFormDataSchemaValidationService
     private const RESIDENTIAL_ADDRESS_HISTORY_TEMPLATE_KEY = 'residential_address_history';
 
     /**
+     * Matches {@see BewacherregisterExportService} address-history lookback for onboarding parity.
+     */
+    private const RESIDENTIAL_ADDRESS_HISTORY_LOOKBACK_YEARS = 5;
+
+    /**
      * EEA + Switzerland (frontend parity for work-permit exemption).
      *
      * @var list<string>
@@ -622,12 +627,14 @@ final class OnboardingFormDataSchemaValidationService
             throw ValidationException::withMessages($messages);
         }
 
-        // Check five-year address history coverage for submissions.
+        // Require at least one prior residence when the current address alone does not cover the
+        // regulatory lookback window (aligned with export address-history validation).
         $residedFrom = $this->normalizedNonEmptyString($currentAddress['resided_from'] ?? null);
+        $windowStart = now()->startOfDay()->copy()->subYears(self::RESIDENTIAL_ADDRESS_HISTORY_LOOKBACK_YEARS)->toDateString();
         if (
             $residedFrom !== null
             && $this->isValidCalendarDate($residedFrom)
-            && $residedFrom > now()->subYears(5)->format('Y-m-d')
+            && $residedFrom > $windowStart
             && (! is_array($previousAddresses) || $previousAddresses === [])
         ) {
             throw ValidationException::withMessages([

--- a/app/Services/OnboardingFormDataSchemaValidationService.php
+++ b/app/Services/OnboardingFormDataSchemaValidationService.php
@@ -7,6 +7,7 @@ namespace App\Services;
 
 use App\Models\Employee;
 use App\Models\OnboardingFormTemplate;
+use App\Support\AddressHistoryLookback;
 use Illuminate\Support\Carbon;
 use Illuminate\Validation\ValidationException;
 use JsonException as JsonEncodeException;
@@ -31,11 +32,6 @@ final class OnboardingFormDataSchemaValidationService
     private const RESIDENCE_PERMIT_UNLIMITED_FIELD = 'residence_permit_unlimited';
 
     private const RESIDENTIAL_ADDRESS_HISTORY_TEMPLATE_KEY = 'residential_address_history';
-
-    /**
-     * Matches {@see BewacherregisterExportService} address-history lookback for onboarding parity.
-     */
-    private const RESIDENTIAL_ADDRESS_HISTORY_LOOKBACK_YEARS = 5;
 
     /**
      * EEA + Switzerland (frontend parity for work-permit exemption).
@@ -628,9 +624,9 @@ final class OnboardingFormDataSchemaValidationService
         }
 
         // Require at least one prior residence when the current address alone does not cover the
-        // regulatory lookback window (aligned with export address-history validation).
+        // regulatory lookback window (see {@see AddressHistoryLookback} and {@see BewacherregisterExportService}).
         $residedFrom = $this->normalizedNonEmptyString($currentAddress['resided_from'] ?? null);
-        $windowStart = now()->startOfDay()->copy()->subYears(self::RESIDENTIAL_ADDRESS_HISTORY_LOOKBACK_YEARS)->toDateString();
+        $windowStart = now()->startOfDay()->copy()->subYears(AddressHistoryLookback::YEARS)->toDateString();
         if (
             $residedFrom !== null
             && $this->isValidCalendarDate($residedFrom)

--- a/app/Support/AddressHistoryLookback.php
+++ b/app/Support/AddressHistoryLookback.php
@@ -1,0 +1,15 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+namespace App\Support;
+
+/**
+ * Rolling calendar lookback (years) shared by BWR export address-history validation
+ * and onboarding residential-address-history submit validation.
+ */
+final class AddressHistoryLookback
+{
+    public const YEARS = 5;
+}

--- a/tests/Unit/Services/AddressStreetCsvImporterTest.php
+++ b/tests/Unit/Services/AddressStreetCsvImporterTest.php
@@ -32,7 +32,7 @@ test('CSV importer error for wrong column count includes row number, expected an
         $threw = true;
         expect($e->getMessage())
             ->toContain('CSV data row 1')
-            ->and($e->getMessage())->toContain('expected 6, got 3')
+            ->and($e->getMessage())->toContain('expected '.count(AddressStreetCsvImporter::EXPECTED_HEADER).', got 3')
             ->and($e->getMessage())->toContain('Row preview:')
             ->and($e->getMessage())->toContain('Only,Two,Cols');
     } finally {

--- a/tests/Unit/Services/AddressStreetCsvImporterTest.php
+++ b/tests/Unit/Services/AddressStreetCsvImporterTest.php
@@ -15,3 +15,29 @@ test('CSV importer accepts exact header and preserves postal codes with leading 
 
     expect($count)->toBe(3);
 });
+
+test('CSV importer error for wrong column count includes row number, expected and actual counts, and a row preview', function (): void {
+    $path = tempnam(sys_get_temp_dir(), 'addr_street_csv_');
+    expect($path)->not->toBeFalse();
+    $header = implode(',', AddressStreetCsvImporter::EXPECTED_HEADER);
+    file_put_contents($path, $header."\n".'Only,Two,Cols'."\n");
+
+    $import = new AddressDataImport(['id' => 0]);
+    $importer = new AddressStreetCsvImporter;
+
+    $threw = false;
+    try {
+        $importer->importFile($path, $import, true);
+    } catch (InvalidArgumentException $e) {
+        $threw = true;
+        expect($e->getMessage())
+            ->toContain('CSV data row 1')
+            ->and($e->getMessage())->toContain('expected 6, got 3')
+            ->and($e->getMessage())->toContain('Row preview:')
+            ->and($e->getMessage())->toContain('Only,Two,Cols');
+    } finally {
+        unlink($path);
+    }
+
+    expect($threw)->toBeTrue();
+});

--- a/tests/Unit/Services/OnboardingFormDataSchemaValidationServiceDateTest.php
+++ b/tests/Unit/Services/OnboardingFormDataSchemaValidationServiceDateTest.php
@@ -5,6 +5,7 @@
 
 use App\Models\OnboardingFormTemplate;
 use App\Services\OnboardingFormDataSchemaValidationService;
+use Carbon\Carbon;
 use Illuminate\Validation\ValidationException;
 
 uses()->group('unit', 'services');
@@ -108,3 +109,35 @@ test('impossible day in resided_until is rejected', function () {
         forSubmittedStatus: true,
     );
 })->throws(ValidationException::class);
+
+test('residential history rejects empty previous_addresses when current resided_from is after the five-year lookback start', function () {
+    Carbon::setTestNow(Carbon::parse('2026-05-15 12:00:00', 'UTC'));
+    try {
+        $this->service->assertMatchesTemplate(
+            $this->template,
+            [
+                'current_address' => validCurrentAddress('2024-06-01'),
+                'previous_addresses' => [],
+            ],
+            forSubmittedStatus: true,
+        );
+    } finally {
+        Carbon::setTestNow();
+    }
+})->throws(ValidationException::class);
+
+test('residential history allows empty previous_addresses when current resided_from is on or before the five-year lookback start', function () {
+    Carbon::setTestNow(Carbon::parse('2026-05-15 12:00:00', 'UTC'));
+    try {
+        $this->service->assertMatchesTemplate(
+            $this->template,
+            [
+                'current_address' => validCurrentAddress('2021-05-15'),
+                'previous_addresses' => [],
+            ],
+            forSubmittedStatus: true,
+        );
+    } finally {
+        Carbon::setTestNow();
+    }
+})->throwsNoExceptions();


### PR DESCRIPTION
## Defect / gap (reproduced before this change)

- **CSV import:** Wrong-column-count failures were hard to triage in large files: the message did not state how many columns were parsed or show a safe row snippet (see `app/Services/AddressData/AddressStreetCsvImporter.php` around the non-blank data-row loop).
- **Residential address history:** Submit-time validation needed explicit parity with the five-year export window and regression coverage proving that an empty `previous_addresses` is rejected when `current_address.resided_from` falls after the lookback start (and allowed on the boundary). This is now covered in `tests/Unit/Services/OnboardingFormDataSchemaValidationServiceDateTest.php`.

## What changed

- `AddressStreetCsvImporter`: wrong-column-count errors now include expected vs observed counts and a truncated row preview (comma-safe quoting in the preview helper).
- `OnboardingFormDataSchemaValidationService`: five-year previous-address rule uses the same `startOfDay` + `subYears` lookback shape as `BewacherregisterExportService`, via `RESIDENTIAL_ADDRESS_HISTORY_LOOKBACK_YEARS`.
- `CHANGELOG.md` ([Unreleased] / Fixed): bullets updated to match the shipped behavior.
- Pest: `AddressStreetCsvImporterTest` and the residential-history date tests above.

## Validations already run (local)

- `vendor/bin/pint --dirty`
- `php artisan test tests/Unit/Services/AddressStreetCsvImporterTest.php tests/Unit/Services/OnboardingFormDataSchemaValidationServiceDateTest.php`

## Follow-up before marking ready

- Confirm GitHub Actions on this PR (full `php-ci` / required checks).
- Final self-review in the GitHub PR UI (draft stays until that review finds zero issues).

## Linked workspaces

- Polyscope clone for this agent: `47d112dd/swift-crow` (this branch). Other linked workspaces were not used for this change set.

Fixes #1053.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to validation/error messaging and sharing a 5-year lookback constant, with added unit tests to lock in behavior at the boundary.
> 
> **Overview**
> Improves `AddressStreetCsvImporter` diagnostics when a CSV row has the wrong column count by reporting *expected vs actual* counts plus a truncated, comma-safe row preview, and adds a unit test covering the new message.
> 
> Aligns onboarding residential-address-history submit validation with the BWR export lookback window by introducing a shared `AddressHistoryLookback::YEARS` constant (used in both services) and adds date-boundary tests to ensure empty `previous_addresses` is rejected/allowed at the correct cutoff; updates the changelog accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6103a9d08b8ce526a9ce6d5ef45097d2daa79529. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->