### PR TITLE
test(addresses): cover import failure exit

### DIFF
--- a/tests/Feature/AddressDataImportCommandTest.php
+++ b/tests/Feature/AddressDataImportCommandTest.php
@@ -48,6 +48,12 @@ function createAddressStreet(AddressDataImport $import, string $postalCode, stri
     ]);
 }
 
+test('addresses:import exits with failure and error output when import fails', function (): void {
+    $this->artisan('addresses:import', ['--source' => '/nonexistent/csv/path.csv'])
+        ->assertFailed()
+        ->expectsOutputToContain('Address data source file is not readable');
+});
+
 test('addresses:import imports fixture and activates dataset', function (): void {
     $fixture = base_path('tests/fixtures/address_data/sample_streets.csv');
 

--- a/tests/Feature/AddressDataImportCommandTest.php
+++ b/tests/Feature/AddressDataImportCommandTest.php
@@ -50,8 +50,8 @@ function createAddressStreet(AddressDataImport $import, string $postalCode, stri
 
 test('addresses:import exits with failure and error output when import fails', function (): void {
     $this->artisan('addresses:import', ['--source' => '/nonexistent/csv/path.csv'])
-        ->assertFailed()
-        ->expectsOutputToContain('Address data source file is not readable');
+        ->expectsOutputToContain('Address data source file is not readable')
+        ->assertFailed();
 });
 
 test('addresses:import imports fixture and activates dataset', function (): void {


### PR DESCRIPTION
Validation/reproduced defect:
- Added regression coverage for `addresses:import --source=/nonexistent/csv/path.csv` so the command is asserted to fail and emit `Address data source file is not readable`.

Change summary:
- Covers the address data import failure path in `tests/Feature/AddressDataImportCommandTest.php`.
- Keeps the PR scoped to import failure exit behavior.

Validation already run:
- `php artisan test tests/Feature/AddressDataImportCommandTest.php --filter='addresses:import exits with failure and error output when import fails'`
- `php artisan test tests/Feature/AddressDataImportCommandTest.php`
- `vendor/bin/pint --dirty`
- `git diff --check`

Governance notes:
- Test-only change; `CHANGELOG.md` was not updated because there is no observable product behavior change.
- No out-of-scope findings were identified, so no new GitHub issue was created.
- No linked workspace changes were used or required.
- Commit is GPG-signed.

Before marking ready:
- Wait for remote CI to finish.
- Complete the final self-review in the PR view and mark ready only if it still finds zero issues.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that adds coverage for an existing failure path without modifying production code.
> 
> **Overview**
> Adds a new feature test asserting `addresses:import` **fails and prints a clear error** when the provided `--source` CSV path is unreadable (e.g., nonexistent file).
> 
> This extends `AddressDataImportCommandTest` to cover the import command’s failure exit behavior alongside the existing success-path tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 663cffff85e70a8543e2a1c7d033c8ba702913ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->