### PR TITLE
test(addresses): assert import failure error output

### DIFF
--- a/tests/Feature/AddressDataImportCommandTest.php
+++ b/tests/Feature/AddressDataImportCommandTest.php
@@ -5,6 +5,7 @@
 
 use App\Models\AddressDataImport;
 use App\Models\AddressStreet;
+use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 uses(RefreshDatabase::class);
@@ -49,9 +50,15 @@ function createAddressStreet(AddressDataImport $import, string $postalCode, stri
 }
 
 test('addresses:import exits with failure and error output when import fails', function (): void {
-    $this->artisan('addresses:import', ['--source' => '/nonexistent/csv/path.csv'])
-        ->expectsOutputToContain('Address data source file is not readable')
-        ->assertFailed();
+    $this->withoutMockingConsoleOutput();
+
+    $exitCode = $this->artisan('addresses:import', ['--source' => '/nonexistent/csv/path.csv']);
+    $output = $this->app->make(Kernel::class)->output();
+
+    expect($exitCode)->toBe(1);
+    expect($output)
+        ->toContain('ERROR')
+        ->toContain('Address data source file is not readable');
 });
 
 test('addresses:import imports fixture and activates dataset', function (): void {


### PR DESCRIPTION
## Reproduced Gap

Issue #1051 is already fixed in the command implementation on `main`, but the regression coverage still stopped short of the full acceptance criteria: the existing Pest test only asserted the failure message and non-zero exit path. It did not prove that failed imports render the console `error` output component instead of a normal info line.

## Summary

- disable mocked console output in `tests/Feature/AddressDataImportCommandTest.php` for the failure-path test
- capture the rendered Artisan output buffer through the console kernel
- assert both exit code `1` and the rendered `ERROR` label for failed imports

## Validation

- `vendor/bin/pint --dirty`
- `php artisan test tests/Feature/AddressDataImportCommandTest.php`

## Readiness Notes

- linked workspaces used: none
- unresolved local issues found during review: none
- follow-up before marking ready: final self-review in the PR view and full CI signal

Closes #1051

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that tightens assertions around Artisan console output and exit codes for the `addresses:import` failure path.
> 
> **Overview**
> Strengthens the `addresses:import` failure-path feature test to verify the command renders an **error-styled** console message, not just a non-zero exit.
> 
> The test now disables mocked console output, captures the real Artisan output via the console `Kernel`, and asserts exit code `1` plus the rendered `ERROR` label and expected message when the source file is unreadable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f43cc943a67507ee034f1ddf97c3a39b275bc114. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->