### PR TITLE
Fix address autocomplete missing table fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- fixed address autocomplete availability checks to return `503 address_data_unavailable` when address data tables are missing, instead of leaking a database exception as a 500
 - stopped exposing `employee_qualifications.document_path` through the public qualification attach/update API and `EmployeeQualificationResource`; the storage path remains internal and regression coverage now proves requests ignore it while list/show responses omit it
 - renamed the `resided_from` field label in the current-address block of the residential address history onboarding form from "Living There Since" to "Date You Started Living There" for clarity
 - fixed OpenPLZ address-import retention so pruning only removes superseded imports for the active country and keeps the prior successful dataset even when failed attempts exist between successful runs

--- a/app/Services/AddressData/AddressSuggestionService.php
+++ b/app/Services/AddressData/AddressSuggestionService.php
@@ -10,6 +10,7 @@ use App\Models\AddressStreet;
 use App\Support\AddressSearchNormalizer;
 use App\Support\LikePattern;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\QueryException;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 
@@ -30,6 +31,19 @@ final class AddressSuggestionService
     }
 
     public function activeImport(string $countryCode = 'DE'): ?AddressDataImport
+    {
+        try {
+            return $this->resolveActiveImport($countryCode);
+        } catch (QueryException $exception) {
+            if ($this->isMissingAddressDataImportsTable($exception)) {
+                return null;
+            }
+
+            throw $exception;
+        }
+    }
+
+    private function resolveActiveImport(string $countryCode): ?AddressDataImport
     {
         // Cache the primary key only. Serializing Eloquent models in Cache::remember()
         // can yield __PHP_Incomplete_Class on unserialize (500 TypeError) in production.
@@ -55,6 +69,21 @@ final class AddressSuggestionService
 
         /** @var AddressDataImport|null */
         return $this->activeImportQuery($countryCode)->first();
+    }
+
+    private function isMissingAddressDataImportsTable(QueryException $exception): bool
+    {
+        $message = $exception->getMessage();
+        $code = (string) $exception->getCode();
+
+        if (! str_contains($message, 'address_data_imports')) {
+            return false;
+        }
+
+        return in_array($code, ['42P01', '42S02'], true)
+            || str_contains($message, 'Undefined table')
+            || str_contains($message, 'Base table or view not found')
+            || str_contains($message, 'no such table');
     }
 
     /**

--- a/tests/Feature/Api/V1/AddressApiTest.php
+++ b/tests/Feature/Api/V1/AddressApiTest.php
@@ -7,6 +7,7 @@ use App\Models\AddressDataImport;
 use App\Models\AddressStreet;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
 use Laravel\Sanctum\Sanctum;
 
 uses(RefreshDatabase::class);
@@ -101,6 +102,20 @@ test('address endpoints return 503 without active import', function (): void {
     Sanctum::actingAs($user, [User::API_ACCESS_ABILITY]);
 
     $this->getJson('/v1/addresses/de/streets?name=gr')
+        ->assertStatus(503)
+        ->assertJsonPath('code', 'address_data_unavailable');
+});
+
+test('address endpoints return 503 when address data tables are missing', function (): void {
+    // PostgreSQL DDL is transactional; both renames are rolled back with the test transaction.
+    DB::statement('ALTER TABLE address_streets RENAME TO address_streets_hidden');
+    DB::statement('ALTER TABLE address_data_imports RENAME TO address_data_imports_hidden');
+
+    /** @var User $user */
+    $user = User::factory()->create();
+    Sanctum::actingAs($user, [User::API_ACCESS_ABILITY]);
+
+    $this->getJson('/v1/addresses/de/localities?postal_code=101')
         ->assertStatus(503)
         ->assertJsonPath('code', 'address_data_unavailable');
 });
@@ -288,11 +303,29 @@ test('street search returns 422 and no 500 when name param is an array', functio
         ->assertUnprocessable();
 });
 
+test('street search returns 422 and no 500 when postal code param is an array', function () {
+    /** @var User $user */
+    $user = User::factory()->create();
+    Sanctum::actingAs($user, [User::API_ACCESS_ABILITY]);
+
+    $this->getJson('/v1/addresses/de/streets?name=foo&postal_code[]=10115&postal_code[]=10117&locality=Berlin')
+        ->assertUnprocessable();
+});
+
 test('locality search returns 422 and no 500 when locality param is an array', function () {
     /** @var User $user */
     $user = User::factory()->create();
     Sanctum::actingAs($user, [User::API_ACCESS_ABILITY]);
 
     $this->getJson('/v1/addresses/de/localities?locality[]=Berlin&locality[]=Hamburg')
+        ->assertUnprocessable();
+});
+
+test('locality search returns 422 and no 500 when postal code param is an array', function () {
+    /** @var User $user */
+    $user = User::factory()->create();
+    Sanctum::actingAs($user, [User::API_ACCESS_ABILITY]);
+
+    $this->getJson('/v1/addresses/de/localities?postal_code[]=10115&postal_code[]=10117&locality=Berlin')
         ->assertUnprocessable();
 });

--- a/tests/Unit/Services/AddressSuggestionServiceTest.php
+++ b/tests/Unit/Services/AddressSuggestionServiceTest.php
@@ -8,6 +8,7 @@ use App\Models\AddressStreet;
 use App\Services\AddressData\AddressSuggestionService;
 use App\Support\AddressSearchNormalizer;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
 
 uses(RefreshDatabase::class)->group('unit', 'services', 'address-data');
 
@@ -22,6 +23,13 @@ beforeEach(function (): void {
         'status' => AddressDataImport::STATUS_SUCCEEDED,
         'activated_at' => now(),
     ]);
+});
+
+test('active import returns null instead of throwing when address_data_imports table is missing', function (): void {
+    // PostgreSQL DDL is transactional; the rename is rolled back with the test transaction.
+    DB::statement('ALTER TABLE address_data_imports RENAME TO address_data_imports_hidden');
+
+    expect((new AddressSuggestionService)->activeImport('DE'))->toBeNull();
 });
 
 test('active import ignores stale cached ids for deactivated imports', function (): void {


### PR DESCRIPTION
## Defect / Validation Lead

Regression coverage now proves that address autocomplete returns `503 address_data_unavailable` when the `address_data_imports` table is unavailable instead of surfacing a database exception as a 500. The affected Pest coverage also verifies street/locality query validation keeps array-valued `postal_code` filters at `422` rather than allowing a server error path.

## Changes

- Catch missing-table `QueryException`s while resolving the active address import and treat them as no active address data.
- Add feature and unit regression coverage for missing address data tables.
- Add feature regression coverage for array-valued street/locality `postal_code` filters.
- Update `CHANGELOG.md` for the address availability fix.

## Validation

- `php artisan test tests/Unit/Services/AddressSuggestionServiceTest.php tests/Feature/Api/V1/AddressApiTest.php`
- `vendor/bin/pint --dirty`
- `git diff --check`
- `reuse lint`
- Signed commit verified with `git log --show-signature --oneline -1`.

## Linked Workspaces

- SecPal/frontend (`diagnose-postleitzahl-500`)
- SecPal/contracts (`diagnose-postleitzahl-500-link-1`)
- SecPal/android (`diagnose-postleitzahl-500-link-3`)

No linked workspace files were changed from this API workspace.

## Before Ready

- Wait for GitHub CI on this draft PR.
- Perform the final PR-view self-review and only mark ready if it still finds zero issues.

## Out-of-Scope Findings

None found; no follow-up GitHub issues were needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change only alters address-autocomplete availability detection by treating missing address-data tables as "no active import" instead of surfacing a 500, with added regression tests to lock in the behavior.
> 
> **Overview**
> Address autocomplete endpoints now **fail gracefully** when address reference tables are missing: `AddressSuggestionService::activeImport()` catches missing-table `QueryException`s for `address_data_imports` and returns `null`, causing `/v1/addresses/de/*` to respond with `503` and `code: address_data_unavailable` instead of a 500.
> 
> Adds feature + unit regression coverage for the missing-table scenario (via transactional table renames in tests) and expands query-validation regressions to ensure array-valued `postal_code` filters still return `422`. The `CHANGELOG.md` is updated to document the 503 fallback fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef0beca3b1a4a4ccdd70ac3d6cdddaf8cf046741. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->