### PR TITLE
test(onboarding): cover patch schema rejection paths

### DIFF
--- a/tests/Feature/Controllers/OnboardingControllerTest.php
+++ b/tests/Feature/Controllers/OnboardingControllerTest.php
@@ -1586,6 +1586,77 @@ describe('PATCH /v1/onboarding/submissions/{submission}', function () {
             ->and($response->json('data.status'))->toBe('draft');
     });
 
+    test('returns 422 when patch submit provides form data that violates the template schema', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.write');
+
+        $template = OnboardingFormTemplate::factory()->create([
+            'tenant_id' => $this->tenant->id,
+            'is_required' => true,
+            'form_schema' => [
+                'type' => 'object',
+                'properties' => [
+                    'iban' => [
+                        'type' => 'string',
+                        'pattern' => '^[A-Z]{2}\d{2}[A-Z0-9]+$',
+                    ],
+                ],
+                'required' => ['iban'],
+            ],
+        ]);
+
+        $submission = OnboardingFormSubmission::factory()->create([
+            'employee_id' => $this->employee->id,
+            'form_template_id' => $template->id,
+            'status' => 'draft',
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->patchJson("/v1/onboarding/submissions/{$submission->id}", [
+                'form_data' => ['iban' => 'not-an-iban'],
+                'status' => 'submitted',
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['iban']);
+    });
+
+    test('returns 422 when a rejected submission is resubmitted with schema-invalid form data', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.write');
+
+        $template = OnboardingFormTemplate::factory()->create([
+            'tenant_id' => $this->tenant->id,
+            'is_required' => true,
+            'form_schema' => [
+                'type' => 'object',
+                'properties' => [
+                    'iban' => [
+                        'type' => 'string',
+                        'pattern' => '^[A-Z]{2}\d{2}[A-Z0-9]+$',
+                    ],
+                ],
+                'required' => ['iban'],
+            ],
+        ]);
+
+        $submission = OnboardingFormSubmission::factory()->create([
+            'employee_id' => $this->employee->id,
+            'form_template_id' => $template->id,
+            'status' => 'rejected',
+            'review_notes' => 'Please correct the banking data.',
+            'reviewed_at' => now(),
+            'reviewed_by' => $this->user->id,
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->patchJson("/v1/onboarding/submissions/{$submission->id}", [
+                'form_data' => ['iban' => 'not-an-iban'],
+                'status' => 'submitted',
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['iban']);
+    });
+
     test('allows a rejected submission to be corrected and resubmitted', function (): void {
         givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.write');
 


### PR DESCRIPTION
## Summary
- add direct PATCH submit coverage for schema-invalid `form_data`
- add rejected-resubmission coverage for the same schema rejection path
- keep the full onboarding controller feature suite green on the unchanged runtime behavior

## Testing
- `php artisan test tests/Feature/Controllers/OnboardingControllerTest.php`
- `vendor/bin/pint --dirty`

Fixes #1008

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only changes that add coverage for 422 schema-validation behavior on PATCH submit and rejected resubmissions without modifying runtime code.
> 
> **Overview**
> Adds new feature tests for `PATCH /v1/onboarding/submissions/{submission}` to assert **422 validation** when a submission is moved to `submitted` with `form_data` that violates the template JSON schema.
> 
> Also covers the same rejection behavior when **resubmitting a previously `rejected` submission** via PATCH with schema-invalid data (e.g., invalid IBAN), ensuring consistent error reporting via `assertJsonValidationErrors`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bd72f2ad5ecffb444360964d644a43413449202. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->