### PR TITLE
fix(address-data): skip setup import when tables missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- skipped `AddressDataSeeder` gracefully when `address_data_imports` or `address_streets` is unavailable during setup seeding, so fresh workspace provisioning no longer aborts the full `db:seed` run on partial or drifted address-data schemas
 - normalized BWR export readiness `errors` responses to stable field codes independent of request locale, and exposed translated human messages separately via `error_messages`
 - fixed address autocomplete availability checks to return `503 address_data_unavailable` when address data tables are missing, instead of leaking a database exception as a 500
 - stopped exposing `employee_qualifications.document_path` through the public qualification attach/update API and `EmployeeQualificationResource`; the storage path remains internal and regression coverage now proves requests ignore it while list/show responses omit it

--- a/database/seeders/AddressDataSeeder.php
+++ b/database/seeders/AddressDataSeeder.php
@@ -18,7 +18,7 @@ class AddressDataSeeder extends Seeder
     public function run(): void
     {
         if (! Schema::hasTable('address_data_imports') || ! Schema::hasTable('address_streets')) {
-            $this->command?->warn('Skipped: address data tables are missing; run migrations before setup import.');
+            $this->command->warn('Skipped: address data tables are missing; run migrations before setup import.');
 
             return;
         }

--- a/database/seeders/AddressDataSeeder.php
+++ b/database/seeders/AddressDataSeeder.php
@@ -7,6 +7,7 @@ namespace Database\Seeders;
 
 use App\Services\AddressData\AddressDataImportService;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Schema;
 use RuntimeException;
 
 class AddressDataSeeder extends Seeder
@@ -16,6 +17,12 @@ class AddressDataSeeder extends Seeder
      */
     public function run(): void
     {
+        if (! Schema::hasTable('address_data_imports') || ! Schema::hasTable('address_streets')) {
+            $this->command?->warn('Skipped: address data tables are missing; run migrations before setup import.');
+
+            return;
+        }
+
         /** @var AddressDataImportService $importService */
         $importService = app(AddressDataImportService::class);
 

--- a/tests/Feature/Seeders/AddressDataSeederTest.php
+++ b/tests/Feature/Seeders/AddressDataSeederTest.php
@@ -7,6 +7,7 @@ use App\Models\AddressDataImport;
 use App\Models\AddressStreet;
 use Database\Seeders\AddressDataSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
 
 use function Pest\Laravel\artisan;
 
@@ -37,4 +38,17 @@ test('address data seeder respects disabled setup import flag', function (): voi
 
     expect(AddressDataImport::query()->count())->toBe(0)
         ->and(AddressStreet::query()->count())->toBe(0);
+});
+
+test('address data seeder skips gracefully when address data tables are missing', function (): void {
+    config([
+        'address_data.import_on_setup' => true,
+        'address_data.setup_source_path' => base_path('tests/fixtures/address_data/sample_streets.csv'),
+    ]);
+
+    DB::statement('ALTER TABLE address_data_imports RENAME TO address_data_imports_hidden');
+
+    artisan('db:seed', ['--class' => AddressDataSeeder::class])
+        ->expectsOutputToContain('Skipped: address data tables are missing')
+        ->assertSuccessful();
 });


### PR DESCRIPTION
## Summary
- skip `AddressDataSeeder` when the address-data tables are unavailable during setup seeding
- make `addresses:check` treat missing address-data tables like an unavailable dataset instead of throwing a database exception
- add regressions for both missing-table crash paths and document the workspace-status fix in `CHANGELOG.md`

## Problem
Fresh workspace setup could abort during `db:seed` after the address-data seeder was added to `DatabaseSeeder`. Even after that seed path was guarded, `php artisan addresses:check` still crashed in partially provisioned workspaces when `address_data_imports` was unavailable.

## Validation
- `vendor/bin/pest tests/Feature/Seeders/AddressDataSeederTest.php`
- `vendor/bin/pest tests/Feature/AddressDataImportCommandTest.php --filter='addresses:check reports no active import when address data tables are missing'`
- `vendor/bin/pint --dirty`
- `vendor/bin/phpstan analyse app/Console/Commands/CheckAddressDataCommand.php database/seeders/AddressDataSeeder.php --no-progress`

## TDD / Validate-First Evidence
- Failing proof before implementation: `vendor/bin/pest tests/Feature/Seeders/AddressDataSeederTest.php --filter='skips gracefully when address data tables are missing'` failed with `SQLSTATE[42P01]: Undefined table ... relation "address_data_imports" does not exist`, and `vendor/bin/pest tests/Feature/AddressDataImportCommandTest.php --filter='addresses:check reports no active import when address data tables are missing'` failed with the same QueryException from `CheckAddressDataCommand`.
- Passing proof after implementation: the focused missing-table command regression now passes, the seeder regression file passes, and both paths now warn/return cleanly instead of aborting the workspace on partial address-data schemas.
- Validate-first exception reference: `N/A`
- No executable change reason: `N/A`
