### PR TITLE
fix(address-data): handle missing tables in status command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - skipped `AddressDataSeeder` gracefully when `address_data_imports` or `address_streets` is unavailable during setup seeding, so fresh workspace provisioning no longer aborts the full `db:seed` run on partial or drifted address-data schemas
+- made `addresses:check` treat missing address-data tables like an unavailable dataset instead of aborting with a database exception, so partially provisioned workspaces can still report status cleanly
 - normalized BWR export readiness `errors` responses to stable field codes independent of request locale, and exposed translated human messages separately via `error_messages`
 - fixed address autocomplete availability checks to return `503 address_data_unavailable` when address data tables are missing, instead of leaking a database exception as a 500
 - stopped exposing `employee_qualifications.document_path` through the public qualification attach/update API and `EmployeeQualificationResource`; the storage path remains internal and regression coverage now proves requests ignore it while list/show responses omit it

--- a/app/Console/Commands/CheckAddressDataCommand.php
+++ b/app/Console/Commands/CheckAddressDataCommand.php
@@ -6,6 +6,7 @@
 namespace App\Console\Commands;
 
 use App\Models\AddressDataImport;
+use App\Services\AddressData\AddressSuggestionService;
 use App\Support\AddressDataConfig;
 use Illuminate\Console\Command;
 
@@ -21,14 +22,10 @@ class CheckAddressDataCommand extends Command
      */
     protected $description = 'Show the active OpenPLZ address import status.';
 
-    public function handle(): int
+    public function handle(AddressSuggestionService $suggestions): int
     {
         $country = AddressDataConfig::string('address_data.country', 'DE');
-        $active = AddressDataImport::query()
-            ->where('country_code', $country)
-            ->whereNotNull('activated_at')
-            ->orderByDesc('id')
-            ->first();
+        $active = $suggestions->activeImport($country);
 
         if ($active === null) {
             $this->components->warn('No activated address import is available.');

--- a/tests/Feature/AddressDataImportCommandTest.php
+++ b/tests/Feature/AddressDataImportCommandTest.php
@@ -7,6 +7,7 @@ use App\Models\AddressDataImport;
 use App\Models\AddressStreet;
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
 
 uses(RefreshDatabase::class);
 
@@ -126,6 +127,14 @@ test('addresses:check reports the active import metadata', function (): void {
         ->assertSuccessful();
 
     expect($activeImport->fresh()?->id)->toBe($activeImport->id);
+});
+
+test('addresses:check reports no active import when address data tables are missing', function (): void {
+    DB::statement('ALTER TABLE address_data_imports RENAME TO address_data_imports_hidden');
+
+    $this->artisan('addresses:check')
+        ->expectsOutputToContain('No activated address import is available.')
+        ->assertSuccessful();
 });
 
 test('addresses:import keeps street rows from other countries when pruning old imports', function (): void {


### PR DESCRIPTION
## Summary
- handle missing address-data tables in `addresses:check` without raising a query exception
- cover the missing-table status-command regression in the feature test suite
- record the follow-up fix in `CHANGELOG.md`

## TDD / Validate-First Evidence
- reproduced the failing `addresses:check` path when `address_data_imports` is unavailable
- `php artisan test tests/Feature/AddressDataImportCommandTest.php`
- `vendor/bin/pint --test app/Console/Commands/CheckAddressDataCommand.php tests/Feature/AddressDataImportCommandTest.php`
- `vendor/bin/phpstan analyse app/Console/Commands/CheckAddressDataCommand.php --no-progress`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change to a console status command to tolerate missing address-data tables, plus a focused regression test.
> 
> **Overview**
> `addresses:check` now resolves the active OpenPLZ import via `AddressSuggestionService::activeImport()` so missing `address_data_imports` tables are treated as “no dataset available” instead of throwing a database exception.
> 
> Adds a regression test that simulates the missing-table scenario and updates `CHANGELOG.md` to document the behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4adcff2cb842ebc613ff3fbcafd6676ebcb4aa77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->