### PR TITLE
fix(auth): ignore client tenant for failed login logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- ignored client-supplied tenant identifiers when recording failed login activity, so spoofed `tenant_id` values can no longer misattribute SPA or token login failures to another tenant
 - skipped `AddressDataSeeder` gracefully when `address_data_imports` or `address_streets` is unavailable during setup seeding, so fresh workspace provisioning no longer aborts the full `db:seed` run on partial or drifted address-data schemas
 - made `addresses:check` treat missing address-data tables like an unavailable dataset instead of aborting with a database exception, so partially provisioned workspaces can still report status cleanly
 - normalized BWR export readiness `errors` responses to stable field codes independent of request locale, and exposed translated human messages separately via `error_messages`

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -82,7 +82,6 @@ class AuthController extends Controller
         $user = $this->validatePrimaryCredentials(
             $credentials['email'],
             $credentials['password'],
-            $request->integer('tenant_id') ?: null,
         );
 
         if ($user->hasTwoFactorEnabled()) {
@@ -128,7 +127,6 @@ class AuthController extends Controller
         $user = $this->validatePrimaryCredentials(
             $validated['email'],
             $validated['password'],
-            $request->integer('tenant_id') ?: null,
         );
 
         $deviceName = $validated['device_name'] ?? 'api-client';
@@ -178,7 +176,7 @@ class AuthController extends Controller
         $validated = $request->validated();
 
         if (! $this->mfaService->verifyEnabledTwoFactorCode($user, $validated['method'], $validated['code'])) {
-            $this->activityLogService->logLoginFailed($user->email, 'invalid_mfa_code', $user->tenant_id);
+            $this->activityLogService->logLoginFailed($user->email, 'invalid_mfa_code');
 
             throw ValidationException::withMessages([
                 'code' => ['The provided multi-factor authentication code is invalid.'],
@@ -1047,12 +1045,12 @@ class AuthController extends Controller
      *
      * @throws ValidationException
      */
-    private function validatePrimaryCredentials(string $email, string $password, ?int $tenantId = null): User
+    private function validatePrimaryCredentials(string $email, string $password): User
     {
         $user = User::where('email', $email)->first();
 
         if (! $user || ! Hash::check($password, $user->password)) {
-            $this->activityLogService->logLoginFailed($email, 'invalid_credentials', $tenantId);
+            $this->activityLogService->logLoginFailed($email, 'invalid_credentials');
 
             throw ValidationException::withMessages([
                 'email' => ['The provided credentials are incorrect.'],

--- a/app/Services/ActivityLogService.php
+++ b/app/Services/ActivityLogService.php
@@ -78,19 +78,17 @@ class ActivityLogService
      *
      * All cases are logged, including completely unknown emails for security auditing.
      */
-    public function logLoginFailed(string $email, string $reason, ?int $tenantId = null): ?Activity
+    public function logLoginFailed(string $email, string $reason): ?Activity
     {
         // Try to find user by email to get their tenant_id
         $user = User::where('email', $email)->first();
 
-        // Determine tenant_id: user's tenant > provided fallback > first existing tenant > skip logging
+        // Determine tenant_id from server-side state only.
         if ($user !== null) {
             $targetTenantId = $user->tenant_id;
-        } elseif ($tenantId !== null) {
-            $targetTenantId = $tenantId;
         } else {
-            // Fallback: use first tenant key ID if available
-            $firstTenant = \App\Models\TenantKey::first();
+            // Fallback: use lowest-id tenant key to ensure deterministic attribution
+            $firstTenant = \App\Models\TenantKey::orderBy('id')->first();
             if ($firstTenant === null) {
                 // No tenant exists - skip activity logging (e.g. in tests without tenant setup)
                 return null;

--- a/tests/Feature/AuthTest.php
+++ b/tests/Feature/AuthTest.php
@@ -161,6 +161,38 @@ describe('SPA Session Login', function () {
             ->assertJsonValidationErrors(['email']);
     });
 
+    test('spa failed login logs real user tenant instead of client supplied tenant', function () {
+        $actualTenant = App\Models\TenantKey::factory()->create();
+        $spoofedTenant = App\Models\TenantKey::factory()->create();
+        $email = 'spa-tenant-log-'.Str::uuid().'@secpal.dev';
+
+        User::factory()->create([
+            'email' => $email,
+            'password' => bcrypt('correct-password'),
+            'tenant_id' => $actualTenant->id,
+        ]);
+
+        $this->withHeaders(spaCsrfHeaders($this))
+            ->postJson('/v1/auth/login?tenant_id='.$spoofedTenant->id, [
+                'email' => $email,
+                'password' => 'wrong-password',
+                'tenant_id' => $spoofedTenant->id,
+            ])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors(['email']);
+
+        $activity = Activity::query()
+            ->where('log_name', 'authentication')
+            ->where('description', 'Failed login attempt')
+            ->latest('id')
+            ->first();
+
+        expect($activity)->toBeInstanceOf(Activity::class)
+            ->and($activity->tenant_id)->toBe($actualTenant->id)
+            ->and($activity->tenant_id)->not->toBe($spoofedTenant->id)
+            ->and($activity->properties['email'])->toBe($email);
+    });
+
     test('spa login authenticates user via session', function () {
         User::factory()->create([
             'email' => 'spa@secpal.dev',
@@ -352,6 +384,37 @@ describe('Auth Token Generation', function () {
 
         $response->assertUnprocessable()
             ->assertJsonValidationErrors(['email']);
+    });
+
+    test('token failed login for unknown email ignores client supplied tenant', function () {
+        // $lowestIdTenant is created first and therefore has the lowest PK; the service
+        // falls back to TenantKey::orderBy('id')->first() for unknown emails, so this
+        // tenant must be the one attributed in the audit log regardless of which tenant
+        // the client supplied.
+        $lowestIdTenant = App\Models\TenantKey::factory()->create();
+        $spoofedTenant = App\Models\TenantKey::factory()->create();
+        $email = 'unknown-token-tenant-log-'.Str::uuid().'@example.com';
+
+        $response = $this->postJson('/v1/auth/token?tenant_id='.$spoofedTenant->id, [
+            'email' => $email,
+            'password' => 'password123',
+            'tenant_id' => $spoofedTenant->id,
+        ]);
+
+        $response->assertUnprocessable()
+            ->assertJsonValidationErrors(['email']);
+
+        $activity = Activity::query()
+            ->where('log_name', 'authentication')
+            ->where('description', 'Failed login attempt')
+            ->latest('id')
+            ->first();
+
+        expect($activity)->toBeInstanceOf(Activity::class)
+            ->and($activity->tenant_id)->toBe($lowestIdTenant->id)
+            ->and($activity->tenant_id)->not->toBe($spoofedTenant->id)
+            ->and($activity->properties['email'])->toBe($email)
+            ->and($activity->properties['user_exists'])->toBeFalse();
     });
 
     test('token generation fails with invalid password', function () {

--- a/tests/Unit/ActivityLog/ActivityLogServiceTest.php
+++ b/tests/Unit/ActivityLog/ActivityLogServiceTest.php
@@ -41,16 +41,17 @@ test('logLoginSuccess creates authentication log with 8-year retention', functio
 });
 
 test('logLoginFailed creates authentication log without causer', function (): void {
-    // Note: In real scenarios, failed logins happen before authentication, so causer_id would be null.
-    // In this test environment, a user is already authenticated from beforeEach(),
-    // so Activity's booted() hook will auto-inject the authenticated user's ID as causer.
-    // This is acceptable since the test verifies the core logging functionality.
+    // Failed logins happen before authentication, so no user is authenticated.
+    // Reset all guard instances to clear the user set by beforeEach() and verify
+    // that causer_id is truly null, matching production conditions.
+    Auth::forgetGuards();
 
-    $activity = $this->service->logLoginFailed('test@example.com', 'Invalid password', $this->tenant->id);
+    $activity = $this->service->logLoginFailed('test@example.com', 'Invalid password');
 
     expect($activity)->toBeInstanceOf(Activity::class)
         ->and($activity->log_name)->toBe('authentication')
         ->and($activity->description)->toBe('Failed login attempt')
+        ->and($activity->causer_id)->toBeNull()
         ->and($activity->properties['event'])->toBe('login_failed')
         ->and($activity->properties['email'])->toBe('test@example.com')
         ->and($activity->properties['reason'])->toBe('Invalid password')


### PR DESCRIPTION
Fixes #1081

Reproduced defect / failing coverage:

- Added regression coverage that submits spoofed `tenant_id` values on failed SPA and token login attempts and asserts the audit entry is attributed from server-side state instead of client input.
- The new SPA regression proves an existing user's failed login remains attributed to that user's real tenant when the request carries another tenant id.
- The new token regression proves an unknown email ignores the supplied tenant id and uses the deterministic server-side fallback tenant.

Current change:

- Removes the optional client-provided tenant fallback from `ActivityLogService::logLoginFailed()`.
- Stops `AuthController` from forwarding request `tenant_id` values into failed-login audit logging for SPA, token, and MFA paths.
- Uses `TenantKey::orderBy('id')->first()` for deterministic unknown-email fallback attribution.
- Updates failed-login unit coverage to verify pre-auth failures do not retain an authenticated causer.
- Adds an Unreleased changelog entry for the audit-attribution fix.

Validation already run:

- `php artisan test tests/Feature/AuthTest.php --filter='spa failed login logs real user tenant instead of client supplied tenant|token failed login for unknown email ignores client supplied tenant'`
- `php artisan test tests/Unit/ActivityLog/ActivityLogServiceTest.php --filter='logLoginFailed creates authentication log without causer'`
- `php artisan test tests/Unit/Services/ActivityLogServiceLoginFailureTest.php`
- `vendor/bin/pint --dirty`
- `git diff --check`

Notes before marking ready:

- First PR state is draft.
- Linked issue: #1081. No out-of-scope findings were identified.
- Linked workspaces were available for context only (`SecPal/frontend`, `SecPal/contracts`, `SecPal/android`); this PR changes only `SecPal/api`.
- GitHub CI and the final PR-view self-review are still pending; do not mark ready until that self-review finds zero issues.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication audit logging, so mistakes could misattribute security events or break failed-login observability, but the change is small and backed by targeted regression tests.
> 
> **Overview**
> Prevents spoofing of failed-login audit attribution by **removing all client-supplied `tenant_id` influence** from authentication failure logging (SPA login, token login, and MFA verification).
> 
> `ActivityLogService::logLoginFailed()` now derives the tenant only from server-side state (user tenant when known, otherwise a deterministic `TenantKey::orderBy('id')->first()` fallback), and tests were expanded/updated to prove spoofed tenant values are ignored and pre-auth failures log with no authenticated `causer_id`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 414a19c2b6f3069cae82e96aec6e3422829b53a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->