### PR TITLE
test(auth): cover MFA challenge invalidation after failed verify

### DIFF
--- a/tests/Feature/Auth/MfaApiEndpointsTest.php
+++ b/tests/Feature/Auth/MfaApiEndpointsTest.php
@@ -163,7 +163,7 @@ test('invalid TOTP challenge attempts are rate limited with retry headers', func
         ->and($response->headers->get('X-RateLimit-Reset'))->not->toBeNull();
 });
 
-test('invalid MFA verification forgets the login challenge', function () {
+test('invalid MFA verification invalidates the login challenge for later retries', function () {
     $user = User::factory()->create([
         'email' => 'mfa-forget-challenge@secpal.dev',
         'password' => bcrypt('password123'),
@@ -189,6 +189,11 @@ test('invalid MFA verification forgets the login challenge', function () {
     ])->assertUnprocessable();
 
     expect(app(LoginMfaChallengeService::class)->find($challengeId))->toBeNull();
+
+    $this->postJson('/v1/auth/mfa-challenges/'.$challengeId.'/verify', [
+        'method' => 'totp',
+        'code' => $user->fresh()->makeTwoFactorCode(),
+    ])->assertNotFound();
 });
 
 test('invalid recovery-code challenge attempts are rate limited with retry headers', function () {


### PR DESCRIPTION
## Reproduced Validation
- Added regression coverage for issue #1080 by asserting that `POST /v1/auth/mfa-challenges/{challengeId}/verify` returns `422` for an invalid TOTP code and then `404` when the same `challengeId` is retried with a valid code.

## Summary
- Strengthened `tests/Feature/Auth/MfaApiEndpointsTest.php` to prove a failed MFA verification invalidates the pending login challenge for any later retry against the same challenge ID.
- Kept the change scoped to the existing MFA endpoint coverage for this single security invariant.

## Validation
- `vendor/bin/pest tests/Feature/Auth/MfaApiEndpointsTest.php`
- `vendor/bin/pint --dirty`

## Ready Follow-up
- GitHub Actions checks still need to complete.
- Final self-review in the PR view still needs to confirm zero issues before marking this draft ready.
- Linked workspaces: none used; no cross-workspace follow-up is required.

Closes #1080

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to a feature test and only strengthen expectations around MFA challenge lifecycle behavior.
> 
> **Overview**
> Adds a regression assertion in `MfaApiEndpointsTest` that after `POST /v1/auth/mfa-challenges/{id}/verify` returns `422` for an invalid TOTP code, the challenge is removed and a later retry with a valid code against the same `challengeId` returns `404`.
> 
> Renames the test description to explicitly reflect this *invalidation-on-failure* behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29e0ad43f20b7595dad92cea6caa519714af06b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->