### PR TITLE
docs(passkeys): warn on APP_KEY fallback rotation coupling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,8 +14,17 @@ FRONTEND_URL=https://app.secpal.dev
 # HMAC secret used to derive deterministic fallback allow_credentials descriptors for
 # unknown / unenrolled emails on the public passkey challenge endpoints, preventing
 # account-existence enumeration via 422 responses.
-# Defaults to APP_KEY when unset. Set an independent secret to allow key rotation
-# without invalidating the application encryption key.
+#
+# Defaults to APP_KEY when unset. There is no real-user authentication impact in
+# either configuration: fallback descriptors are phantom credential IDs that will
+# never match a real authenticator entry.
+#
+# Operational note: when this variable is unset, rotating APP_KEY (a normal
+# operational task) silently changes the fallback descriptor IDs issued before and
+# after the rotation. Set PASSKEY_AUTHENTICATION_FALLBACK_SECRET to an independent
+# random value if you want stable fallback IDs across APP_KEY rotations (useful for
+# log correlation and incident investigation). The service emits a single
+# `Log::warning` per request when APP_KEY is being used as the fallback source.
 # PASSKEY_AUTHENTICATION_FALLBACK_SECRET=
 
 APP_LOCALE=en

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Breaking:** Employee residential addresses live in `employee_addresses` (encrypted street/postal/city fields per row, optional residence date range). The API uses `addresses[]` instead of flat `address_*` attributes and `address_history` JSON on `employees`. Legacy values are migrated into `employee_addresses` during rollout, but clients must adopt `addresses[]` going forward.
 - **Breaking:** The `PASSKEY_AUTHENTICATION_MEDIATION` environment variable and the `passkeys.authentication_mediation` config key have been removed. The passkey authentication challenge mediation is now always `optional`; remove the env var from your deployment configuration.
+- documented the `APP_KEY` rotation impact on the passkey authentication fallback `allow_credentials` HMAC in `.env.example`, `docs/deployment.md`, and `docs/deployment-checklist.md`, and surfaced an operational `Log::warning` (deduped to one entry per request) from `PasskeyService` whenever a fallback descriptor is generated while `PASSKEY_AUTHENTICATION_FALLBACK_SECRET` is unset and `APP_KEY` is being used as the HMAC source; there is no real-user authentication impact (fallback descriptors are phantom credential IDs), but operators are now alerted to the silent coupling so APP_KEY rotation does not surprise incident investigators
 
 ### Fixed
 

--- a/app/Services/PasskeyService.php
+++ b/app/Services/PasskeyService.php
@@ -9,6 +9,7 @@ use App\Exceptions\PasskeyAuthenticationFallbackSecretException;
 use App\Models\PasskeyCredential;
 use App\Models\User;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use ParagonIE\ConstantTime\Base64UrlSafe;
 use Symfony\Component\Serializer\Serializer;
@@ -40,6 +41,13 @@ class PasskeyService
     private AuthenticatorAttestationResponseValidator $attestationValidator;
 
     private AuthenticatorAssertionResponseValidator $assertionValidator;
+
+    /**
+     * Dedupes the APP_KEY-fallback warning to a single log entry per service
+     * instance (one per request via DI), so repeated unknown-email challenge
+     * lookups don't spam logs while still leaving a visible operational trail.
+     */
+    private bool $appKeyFallbackWarningEmitted = false;
 
     public function __construct()
     {
@@ -341,6 +349,8 @@ class PasskeyService
             );
         }
 
+        $this->warnIfFallbackSecretIsAppKey();
+
         if (Str::startsWith($secret, 'base64:')) {
             $decodedSecret = base64_decode(Str::after($secret, 'base64:'), true);
 
@@ -354,6 +364,33 @@ class PasskeyService
         }
 
         return $secret;
+    }
+
+    /**
+     * Surface an operational warning when the fallback HMAC secret is being
+     * sourced from APP_KEY rather than the dedicated
+     * PASSKEY_AUTHENTICATION_FALLBACK_SECRET. APP_KEY rotation (a routine
+     * operational task) silently changes the deterministic fallback
+     * allow_credentials descriptors issued for unknown / unenrolled emails.
+     * There is no real-user authentication impact (fallback descriptors are
+     * phantom IDs that never match a real authenticator), but the coupling is
+     * non-obvious during incident investigation. See issue #1096.
+     */
+    private function warnIfFallbackSecretIsAppKey(): void
+    {
+        if ($this->appKeyFallbackWarningEmitted) {
+            return;
+        }
+
+        if (! (bool) config('passkeys.authentication_fallback_uses_app_key', false)) {
+            return;
+        }
+
+        $this->appKeyFallbackWarningEmitted = true;
+
+        Log::warning(
+            'Passkey authentication fallback HMAC secret is derived from APP_KEY because PASSKEY_AUTHENTICATION_FALLBACK_SECRET is not set. Rotating APP_KEY will silently change the deterministic fallback allow_credentials descriptors issued for unknown / unenrolled emails (no real-user impact). Set PASSKEY_AUTHENTICATION_FALLBACK_SECRET independently to decouple the fallback IDs from APP_KEY rotation.',
+        );
     }
 
     /**

--- a/config/passkeys.php
+++ b/config/passkeys.php
@@ -11,6 +11,15 @@ $frontendOriginEntries = array_values(array_filter(array_map(
 
 $frontendHost = parse_url($frontendUrl, PHP_URL_HOST);
 
+// Dedicated fallback secret (preferred). When unset/blank the deterministic
+// fallback `allow_credentials` HMAC is derived from APP_KEY, which means an
+// APP_KEY rotation will silently change the phantom credential IDs issued for
+// unknown / unenrolled emails. Set PASSKEY_AUTHENTICATION_FALLBACK_SECRET
+// independently when stable fallback IDs across APP_KEY rotations are desired.
+$dedicatedFallbackSecret = (string) env('PASSKEY_AUTHENTICATION_FALLBACK_SECRET', '');
+$appKeyFallbackSecret = (string) env('APP_KEY', '');
+$resolvedFallbackSecret = $dedicatedFallbackSecret !== '' ? $dedicatedFallbackSecret : $appKeyFallbackSecret;
+
 return [
     'rp_id' => (string) env('PASSKEY_RP_ID', is_string($frontendHost) ? $frontendHost : 'app.secpal.dev'),
     'rp_name' => (string) env('PASSKEY_RP_NAME', env('APP_NAME', 'SecPal')),
@@ -19,7 +28,8 @@ return [
     'challenge_timeout_ms' => (int) env('PASSKEY_CHALLENGE_TIMEOUT_MS', 60000),
     'challenge_expiration_minutes' => (int) env('PASSKEY_CHALLENGE_EXPIRATION_MINUTES', 10),
     'attestation' => (string) env('PASSKEY_ATTESTATION', 'none'),
-    'authentication_fallback_secret' => (string) (env('PASSKEY_AUTHENTICATION_FALLBACK_SECRET') ?: env('APP_KEY', '')),
+    'authentication_fallback_secret' => $resolvedFallbackSecret,
+    'authentication_fallback_uses_app_key' => $dedicatedFallbackSecret === '' && $appKeyFallbackSecret !== '',
     'user_verification' => (string) env('PASSKEY_USER_VERIFICATION', 'preferred'),
     'resident_key' => (string) env('PASSKEY_RESIDENT_KEY', 'preferred'),
     'require_resident_key' => filter_var(env('PASSKEY_REQUIRE_RESIDENT_KEY', false), FILTER_VALIDATE_BOOL),

--- a/docs/deployment-checklist.md
+++ b/docs/deployment-checklist.md
@@ -60,6 +60,15 @@ Quick reference checklist for SecPal API production deployment.
 - [ ] Restrict `.env` permissions: `chmod 0600 .env`
 - [ ] Set `.env` ownership: `chown www-data:www-data .env`
 
+### Passkey Authentication Fallback Secret
+
+- [ ] Set `PASSKEY_AUTHENTICATION_FALLBACK_SECRET` to an independent random value
+      (e.g. `base64:$(php -r "echo base64_encode(random_bytes(32));")`) so that
+      deterministic passkey fallback `allow_credentials` IDs remain stable across
+      `APP_KEY` rotations. Falling back to `APP_KEY` is supported but emits a
+      `Log::warning` once per request whenever the fallback path is exercised.
+      See [deployment.md → Passkey Authentication Fallback Secret](./deployment.md#3-passkey-authentication-fallback-secret).
+
 ---
 
 ## Initial Setup

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -12,6 +12,9 @@ Complete guide for deploying SecPal API to production environments.
 - [Prerequisites](#prerequisites)
 - [Environment Setup](#environment-setup)
 - [Security Configuration](#security-configuration)
+  - [1. Generate Key Encryption Key (KEK)](#1-generate-key-encryption-key-kek)
+  - [2. File Permissions](#2-file-permissions)
+  - [3. Passkey Authentication Fallback Secret](#3-passkey-authentication-fallback-secret)
 - [Database Setup](#database-setup)
 - [Tenant Key Initialization](#tenant-key-initialization)
 - [Health Check Verification](#health-check-verification)
@@ -183,6 +186,53 @@ sudo chmod -R 775 storage bootstrap/cache
 sudo chmod 0600 .env
 sudo chown www-data:www-data .env
 ```
+
+### 3. Passkey Authentication Fallback Secret
+
+The public passkey challenge endpoints (`/v1/auth/passkey/challenge`,
+`/v1/auth/token/passkey/challenge`) return a deterministic fallback
+`allow_credentials` descriptor for unknown or unenrolled emails so the response
+shape cannot be used to enumerate accounts. The HMAC key for that descriptor is
+sourced from `PASSKEY_AUTHENTICATION_FALLBACK_SECRET`, falling back to
+`APP_KEY` when the dedicated variable is not set.
+
+There is **no real-user authentication impact** in either configuration:
+fallback descriptors are phantom credential IDs that never match a real
+authenticator entry.
+
+**APP_KEY rotation coupling (operational):**
+
+When `PASSKEY_AUTHENTICATION_FALLBACK_SECRET` is **not** configured, rotating
+`APP_KEY` (a normal operational task) silently changes the fallback descriptor
+IDs issued before vs. after the rotation. The service emits a single
+`Log::warning` per request whenever the fallback path is exercised under this
+configuration, e.g.:
+
+```txt
+Passkey authentication fallback HMAC secret is derived from APP_KEY because
+PASSKEY_AUTHENTICATION_FALLBACK_SECRET is not set. Rotating APP_KEY will
+silently change the deterministic fallback allow_credentials descriptors
+issued for unknown / unenrolled emails (no real-user impact). Set
+PASSKEY_AUTHENTICATION_FALLBACK_SECRET independently to decouple the fallback
+IDs from APP_KEY rotation.
+```
+
+**Recommended for production:** set `PASSKEY_AUTHENTICATION_FALLBACK_SECRET`
+to an independent random value so that fallback descriptor IDs remain stable
+across `APP_KEY` rotations. This makes log correlation and incident
+investigation easier and removes the silent coupling.
+
+```bash
+# Generate a 32-byte random secret and write it to .env (preserving any
+# existing entry — review the file after running).
+php -r "echo 'PASSKEY_AUTHENTICATION_FALLBACK_SECRET=base64:'.base64_encode(random_bytes(32)).PHP_EOL;" >> .env
+```
+
+This secret is **not** used to authenticate real users and does not require
+the same backup/rotation discipline as `APP_KEY` or the KEK. Treat it like
+any other application secret: keep it out of version control, scope it to
+each environment, and rotate only when you intentionally want to invalidate
+historical fallback descriptor IDs.
 
 ---
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -189,8 +189,8 @@ sudo chown www-data:www-data .env
 
 ### 3. Passkey Authentication Fallback Secret
 
-The public passkey challenge endpoints (`/v1/auth/passkey/challenge`,
-`/v1/auth/token/passkey/challenge`) return a deterministic fallback
+The public passkey challenge endpoints (`POST /v1/auth/passkeys/challenges`,
+`POST /v1/auth/token/passkeys/challenges`) return a deterministic fallback
 `allow_credentials` descriptor for unknown or unenrolled emails so the response
 shape cannot be used to enumerate accounts. The HMAC key for that descriptor is
 sourced from `PASSKEY_AUTHENTICATION_FALLBACK_SECRET`, falling back to

--- a/tests/Unit/Services/PasskeyServiceTest.php
+++ b/tests/Unit/Services/PasskeyServiceTest.php
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use App\Services\PasskeyService;
+use Illuminate\Support\Facades\Log;
 
 describe('PasskeyService::formatApiPayload', function () {
     test('registration options are converted to snake_case for the API response', function () {
@@ -102,6 +103,122 @@ describe('PasskeyService authentication fallback secret', function () {
                 RuntimeException::class,
                 'Passkey authentication fallback secret must be configured via PASSKEY_AUTHENTICATION_FALLBACK_SECRET or APP_KEY.',
             );
+    });
+
+    test('a warning is logged once per service instance when the fallback secret is derived from APP_KEY', function () {
+        $appKey = 'base64:'.base64_encode(str_repeat('k', 32));
+        config()->set('passkeys.authentication_fallback_secret', $appKey);
+        config()->set('passkeys.authentication_fallback_uses_app_key', true);
+
+        Log::shouldReceive('warning')
+            ->once()
+            ->withArgs(fn (string $message): bool => str_contains($message, 'Passkey authentication fallback HMAC secret is derived from APP_KEY')
+                && str_contains($message, 'PASSKEY_AUTHENTICATION_FALLBACK_SECRET'));
+
+        $service = app(PasskeyService::class);
+
+        $service->buildAuthenticationOptions(null, 'first@secpal.dev');
+        $service->buildAuthenticationOptions(null, 'second@secpal.dev');
+    });
+
+    test('no warning is logged when the dedicated fallback secret is configured', function () {
+        $dedicatedSecret = 'base64:'.base64_encode(str_repeat('s', 32));
+        config()->set('passkeys.authentication_fallback_secret', $dedicatedSecret);
+        config()->set('passkeys.authentication_fallback_uses_app_key', false);
+
+        Log::shouldReceive('warning')->never();
+
+        $service = app(PasskeyService::class);
+
+        $service->buildAuthenticationOptions(null, 'user@secpal.dev');
+    });
+});
+
+describe('passkeys.authentication_fallback_uses_app_key config flag', function () {
+    /**
+     * Re-evaluate `config/passkeys.php` against a temporary env override so we
+     * can assert the env-resolution branches directly without mutating the live
+     * application config bag.
+     *
+     * Declared as a closure inside the describe block to avoid a file-scope
+     * function declaration, which would be registered globally and could cause
+     * "Cannot redeclare" fatals under parallel test runs.
+     *
+     * @param  array<string, string|false>  $envOverrides
+     * @return array<string, mixed>
+     */
+    $loadConfig = function (array $envOverrides): array {
+        $original = [];
+
+        foreach ($envOverrides as $name => $value) {
+            $original[$name] = getenv($name);
+
+            if ($value === false) {
+                putenv($name);
+                unset($_ENV[$name], $_SERVER[$name]);
+
+                continue;
+            }
+
+            putenv("{$name}={$value}");
+            $_ENV[$name] = $value;
+            $_SERVER[$name] = $value;
+        }
+
+        try {
+            /** @var array<string, mixed> $config */
+            $config = require base_path('config/passkeys.php');
+
+            return $config;
+        } finally {
+            foreach ($original as $name => $value) {
+                if ($value === false) {
+                    putenv($name);
+                    unset($_ENV[$name], $_SERVER[$name]);
+
+                    continue;
+                }
+
+                putenv("{$name}={$value}");
+                $_ENV[$name] = $value;
+                $_SERVER[$name] = $value;
+            }
+        }
+    };
+
+    test('the flag is true when only APP_KEY is set', function () use ($loadConfig) {
+        $appKey = 'base64:'.base64_encode(str_repeat('a', 32));
+
+        $config = $loadConfig([
+            'PASSKEY_AUTHENTICATION_FALLBACK_SECRET' => false,
+            'APP_KEY' => $appKey,
+        ]);
+
+        expect($config['authentication_fallback_secret'])->toBe($appKey)
+            ->and($config['authentication_fallback_uses_app_key'])->toBeTrue();
+    });
+
+    test('the flag is false when the dedicated secret is set', function () use ($loadConfig) {
+        $appKey = 'base64:'.base64_encode(str_repeat('a', 32));
+        $dedicated = 'base64:'.base64_encode(str_repeat('d', 32));
+
+        $config = $loadConfig([
+            'PASSKEY_AUTHENTICATION_FALLBACK_SECRET' => $dedicated,
+            'APP_KEY' => $appKey,
+        ]);
+
+        expect($config['authentication_fallback_secret'])->toBe($dedicated)
+            ->and($config['authentication_fallback_uses_app_key'])->toBeFalse();
+    });
+
+    test('the flag is false when neither the dedicated secret nor APP_KEY is set', function () use ($loadConfig) {
+        $config = $loadConfig([
+            'PASSKEY_AUTHENTICATION_FALLBACK_SECRET' => false,
+            'APP_KEY' => false,
+        ]);
+
+        expect($config['authentication_fallback_secret'])->toBe('')
+            ->and($config['authentication_fallback_uses_app_key'])->toBeFalse();
     });
 });
 


### PR DESCRIPTION
## Failing test / reproduced defect

Issue #1096 tracks the operational defect: when `PASSKEY_AUTHENTICATION_FALLBACK_SECRET` is unset, passkey fallback `allow_credentials` IDs are derived from `APP_KEY`, so routine `APP_KEY` rotation silently changes the deterministic phantom credential IDs used for unknown or unenrolled emails. The new unit coverage would fail before this change because `passkeys.authentication_fallback_uses_app_key` did not exist and `PasskeyService` did not emit an operational warning for the APP_KEY-derived fallback path.

Closes #1096.

## Current change

- Adds `passkeys.authentication_fallback_uses_app_key` so the service can distinguish a dedicated fallback secret from the `APP_KEY` fallback.
- Logs one warning per `PasskeyService` instance when fallback descriptors are generated while the HMAC secret is derived from `APP_KEY`.
- Documents the no-real-user-authentication-impact behavior and the APP_KEY rotation coupling in `.env.example`, `docs/deployment.md`, `docs/deployment-checklist.md`, and `CHANGELOG.md`.

## Validation already run

- `php artisan test tests/Unit/Services/PasskeyServiceTest.php`
- `vendor/bin/pint --dirty`
- `git diff --check`
- `reuse lint`
- Verified the commit is signed with `git log --show-signature --oneline -1`.

## Linked workspaces / readiness notes

- Linked workspaces were available for `SecPal/contracts`, `SecPal/frontend`, and `SecPal/android`, but this PR is API-only and did not require changes in those workspaces.
- Keep this PR in draft until GitHub CI completes and the final PR-view self-review finds zero issues. Do not mark ready before that final self-review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an operational warning and a config flag around passkey fallback-secret resolution, plus documentation/tests, without changing real-user authentication behavior.
> 
> **Overview**
> Clarifies and surfaces the operational coupling where passkey fallback `allow_credentials` HMAC defaults to `APP_KEY` when `PASSKEY_AUTHENTICATION_FALLBACK_SECRET` is unset, meaning routine `APP_KEY` rotation changes the deterministic phantom credential IDs.
> 
> Adds `passkeys.authentication_fallback_uses_app_key` in `config/passkeys.php` and emits a deduped `Log::warning` from `PasskeyService` when generating fallback descriptors under the `APP_KEY`-derived configuration, with new unit coverage. Updates `.env.example` and deployment docs/checklist (and the changelog) to recommend setting an independent fallback secret for stable IDs across `APP_KEY` rotations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6970eef189f0ab9ba1bf68ee23897b8e9029a025. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->