### PR TITLE
fix(onboarding): require verified email for HR review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking:** Passkey **enrollment** at `POST /v1/me/passkeys/challenges/registration` now defaults to discoverable / resident credentials. `passkeys.resident_key` defaults to `required` (was `preferred`) and `passkeys.require_resident_key` defaults to `true` (was `false`); unrecognized `PASSKEY_RESIDENT_KEY` values are coerced back to `required`, and `require_resident_key` is forced to `true` whenever `resident_key === 'required'` so configuration drift cannot silently re-enable non-discoverable enrollment. Existing non-discoverable passkey credentials remain readable through `/v1/me/passkeys` but cannot be used for the discoverable-only public passkey login flow; affected users must sign in with primary credentials and enroll a new discoverable passkey. There is no public, email-scoped recovery path — reintroducing one would re-open the enumeration vector that the discoverable-only login contract closed. See [`docs/deployment.md` § Passkey Enrollment Contract](docs/deployment.md#4-passkey-enrollment-contract) for the operator/user runbook.
 - **Breaking:** Permission definitions are now strictly code-owned and seed-managed. The runtime API no longer exposes a permission-catalog management surface; `/v1/permissions*` has been removed, and the obsolete runtime permissions `permissions.create`, `permissions.update`, and `permissions.delete` are no longer seeded.
 
+### Security
+
+- enforced email verification on the HR onboarding-review endpoints (`POST /v1/onboarding-review/submissions/{submission}/approve`, `POST /v1/onboarding-review/submissions/{submission}/reject`, `POST /v1/onboarding-review/employees/{employee}/confirm`) by moving them into a dedicated route group with `verified` middleware, so unverified HR accounts can no longer approve, reject, or confirm onboarding dossiers
+
 ### Fixed
 
 - scoped `GET /v1/roles`, `GET /v1/roles/{id}`, `PATCH /v1/roles/{id}`, and `DELETE /v1/roles/{id}` to the authenticated tenant so cross-tenant role enumeration and mutation by raw role id now return `404` (refs `api#1078`)

--- a/routes/api.php
+++ b/routes/api.php
@@ -337,7 +337,9 @@ Route::prefix('v1')->group(function () {
             Route::post('/onboarding/submissions/{submission}/files', [OnboardingController::class, 'uploadSubmissionFile']);
             Route::delete('/onboarding/submissions/{submission}/files/{file}', [OnboardingController::class, 'deleteSubmissionFile']);
             Route::get('/onboarding/completion-status', [OnboardingController::class, 'getCompletionStatus']);
+        });
 
+        Route::middleware(['verified', 'tenant.inject'])->group(function () {
             // HR approval endpoints
             Route::post('/onboarding-review/submissions/{submission}/approve', [OnboardingController::class, 'approveSubmission']);
             Route::post('/onboarding-review/submissions/{submission}/reject', [OnboardingController::class, 'rejectSubmission']);

--- a/tests/Feature/Controllers/OnboardingControllerTest.php
+++ b/tests/Feature/Controllers/OnboardingControllerTest.php
@@ -2647,6 +2647,25 @@ describe('POST /v1/onboarding-review/submissions/{submission}/approve', function
         $response->assertStatus(401);
     });
 
+    test('returns 403 when user email is not verified', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.approve');
+        $this->user->forceFill(['email_verified_at' => null])->save();
+
+        $submission = OnboardingFormSubmission::factory()->create([
+            'employee_id' => $this->employee->id,
+            'form_template_id' => $this->template->id,
+            'status' => 'submitted',
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->postJson("/v1/onboarding-review/submissions/{$submission->id}/approve");
+
+        $response->assertForbidden()
+            ->assertJson([
+                'message' => 'Your email address is not verified.',
+            ]);
+    });
+
     test('returns 403 when user lacks onboarding.approve permission', function (): void {
         $submission = OnboardingFormSubmission::factory()->create([
             'employee_id' => $this->employee->id,
@@ -2806,6 +2825,27 @@ describe('POST /v1/onboarding-review/submissions/{submission}/reject', function 
         $response->assertStatus(401);
     });
 
+    test('returns 403 when user email is not verified', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.approve');
+        $this->user->forceFill(['email_verified_at' => null])->save();
+
+        $submission = OnboardingFormSubmission::factory()->create([
+            'employee_id' => $this->employee->id,
+            'form_template_id' => $this->template->id,
+            'status' => 'submitted',
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->postJson("/v1/onboarding-review/submissions/{$submission->id}/reject", [
+                'reason' => 'Incomplete information',
+            ]);
+
+        $response->assertForbidden()
+            ->assertJson([
+                'message' => 'Your email address is not verified.',
+            ]);
+    });
+
     test('returns 403 when user lacks onboarding.approve permission', function (): void {
         $submission = OnboardingFormSubmission::factory()->create([
             'employee_id' => $this->employee->id,
@@ -2888,6 +2928,25 @@ describe('POST /v1/onboarding-review/employees/{employee}/confirm', function () 
         $response = $this->postJson("/v1/onboarding-review/employees/{$this->employee->id}/confirm");
 
         $response->assertStatus(401);
+    });
+
+    test('returns 403 when user email is not verified', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.confirm');
+        $this->user->forceFill(['email_verified_at' => null])->save();
+
+        $this->employee->update([
+            'onboarding_workflow_status' => Employee::WORKFLOW_STATUS_SUBMITTED_FOR_REVIEW,
+            'onboarding_completed' => true,
+            'contract_start_date' => now()->addWeek()->toDateString(),
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->postJson("/v1/onboarding-review/employees/{$this->employee->id}/confirm");
+
+        $response->assertForbidden()
+            ->assertJson([
+                'message' => 'Your email address is not verified.',
+            ]);
     });
 
     test('returns 403 when user lacks onboarding.confirm permission', function (): void {


### PR DESCRIPTION
## Summary

- Reproduced defect: `routes/api.php` closed the `verified` middleware group before the HR onboarding-review routes, so an authenticated HR user with an unverified email could still approve, reject, or confirm onboarding dossiers.
- Moved the `/v1/onboarding-review/*` endpoints into a dedicated `['verified', 'tenant.inject']` route group while leaving the employee-facing onboarding endpoints outside `verified`.
- Added Pest regression coverage for the three HR onboarding-review endpoints and documented the security fix in `CHANGELOG.md`.

## Validation

- `vendor/bin/pint --dirty`
- `php artisan test tests/Feature/Controllers/OnboardingControllerTest.php --filter='onboarding-review|user email is not verified'`
- `php artisan test tests/Feature/AuthTest.php --filter='unverified users cannot access verified-only protected routes'`

## Linked Workspaces / Before Ready

- Linked workspaces used for this change: none.
- This PR must stay draft until GitHub checks pass and the final self-review in the PR view still finds zero issues.
- No additional out-of-scope findings were identified during this change.

Closes #1075

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes route-level access control for HR onboarding-review endpoints by adding `verified` middleware, which is security-sensitive and could block legitimate unverified HR users until verification; scope is small and covered by new regression tests.
> 
> **Overview**
> **Secures HR onboarding review actions** by enforcing email verification on the `/v1/onboarding-review/*` approve/reject/confirm endpoints via a dedicated `['verified', 'tenant.inject']` route group, preventing unverified authenticated HR accounts from changing onboarding dossier state.
> 
> Adds feature tests asserting these endpoints return `403` with the standard "Your email address is not verified." message when `email_verified_at` is null, and documents the change under a new *Security* entry in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fac287e46ba437234e7ecc85fa2da88c6304048. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->