### PR TITLE
feat(api): expose Android push runtime metadata and registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - added the public `GET /v1/bootstrap` runtime-discovery endpoint for Android pre-login instance validation, deriving the canonical `api_base_url` from `APP_URL`, failing closed with documented `500`/`503`/`426` bootstrap responses when deployment metadata is incomplete or incompatible, and covering the success/failure slices with focused Pest tests plus operator bootstrap configuration docs (refs `api#1115`)
+- added authenticated Android push-device registration on the customer-hosted backend via `PUT/DELETE /v1/me/push-devices/{installationId}`, including tenant-safe encrypted token storage, bootstrap-advertised public Android push runtime metadata on `GET /v1/bootstrap`, deterministic `409` fail-closed handling for disabled or stale push runtime state, and focused Pest coverage plus deployment/operator documentation for the new `BOOTSTRAP_ANDROID_PUSH_*` settings (refs `api#1123`)
 
 ### Changed
 

--- a/app/Http/Controllers/Api/V1/BootstrapController.php
+++ b/app/Http/Controllers/Api/V1/BootstrapController.php
@@ -11,12 +11,15 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\GetBootstrapConfigurationRequest;
 use App\Support\AndroidPushRuntimeConfiguration;
 use App\Support\BootstrapContract;
+use App\Support\Concerns\InteractsWithConfigValues;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Response;
 use RuntimeException;
 
 class BootstrapController extends Controller
 {
+    use InteractsWithConfigValues;
+
     private const DEFAULT_RETRY_AFTER_SECONDS = 60;
 
     public function show(
@@ -291,41 +294,5 @@ class BootstrapController extends Controller
         }
 
         return strtolower((string) $components['scheme']).'://'.$authority.'/v1';
-    }
-
-    private function booleanConfig(string $key, bool $default): bool
-    {
-        $value = config($key, $default);
-
-        if (is_bool($value)) {
-            return $value;
-        }
-
-        if (is_int($value)) {
-            return $value !== 0;
-        }
-
-        if (is_string($value)) {
-            $parsed = filter_var($value, FILTER_VALIDATE_BOOL, FILTER_NULL_ON_FAILURE);
-
-            if ($parsed !== null) {
-                return $parsed;
-            }
-        }
-
-        return $default;
-    }
-
-    private function trimmedStringConfig(string $key): ?string
-    {
-        $value = config($key);
-
-        if (! is_string($value)) {
-            return null;
-        }
-
-        $value = trim($value);
-
-        return $value === '' ? null : $value;
     }
 }

--- a/app/Http/Controllers/Api/V1/BootstrapController.php
+++ b/app/Http/Controllers/Api/V1/BootstrapController.php
@@ -13,6 +13,7 @@ use App\Support\AndroidPushRuntimeConfiguration;
 use App\Support\BootstrapContract;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Response;
+use RuntimeException;
 
 class BootstrapController extends Controller
 {
@@ -83,7 +84,13 @@ class BootstrapController extends Controller
         ];
 
         if ($androidPushRuntimeConfiguration->isEnabled()) {
-            $data['android_push'] = $androidPushRuntimeConfiguration->publicMetadata();
+            $androidPushMetadata = $androidPushRuntimeConfiguration->publicMetadata();
+
+            if ($androidPushMetadata === null) {
+                throw new RuntimeException('Android push metadata is enabled but could not be assembled; this is a deployment configuration error.');
+            }
+
+            $data['android_push'] = $androidPushMetadata;
         }
 
         return response()->json(['data' => $data]);

--- a/app/Http/Controllers/Api/V1/BootstrapController.php
+++ b/app/Http/Controllers/Api/V1/BootstrapController.php
@@ -30,18 +30,22 @@ class BootstrapController extends Controller
         $displayName = $this->instanceDisplayName();
         $minimumSupportedAppVersion = $this->minimumSupportedAppVersion();
         $minimumSupportedAppBuild = $this->minimumSupportedAppBuild();
-        $missingFields = array_merge(
-            $this->missingRequiredFields(
+        if ($apiBaseUrl === null
+            || $displayName === null
+            || $minimumSupportedAppVersion === null
+            || $minimumSupportedAppBuild === null) {
+            return $this->invalidStateResponse($this->missingRequiredFields(
                 $apiBaseUrl,
                 $displayName,
                 $minimumSupportedAppVersion,
                 $minimumSupportedAppBuild,
-            ),
-            $androidPushRuntimeConfiguration->missingFields(),
-        );
+            ));
+        }
 
-        if ($missingFields !== []) {
-            return $this->invalidStateResponse($missingFields);
+        $androidPushMissingFields = $androidPushRuntimeConfiguration->missingFields();
+
+        if ($androidPushMissingFields !== []) {
+            return $this->invalidStateResponse($androidPushMissingFields);
         }
 
         if ($this->clientIsBelowMinimumSupportedVersion(

--- a/app/Http/Controllers/Api/V1/BootstrapController.php
+++ b/app/Http/Controllers/Api/V1/BootstrapController.php
@@ -9,19 +9,19 @@ namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\GetBootstrapConfigurationRequest;
+use App\Support\AndroidPushRuntimeConfiguration;
+use App\Support\BootstrapContract;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Response;
 
 class BootstrapController extends Controller
 {
-    private const BOOTSTRAP_VERSION = 'v1';
-
-    private const SCHEMA_VERSION = 1;
-
     private const DEFAULT_RETRY_AFTER_SECONDS = 60;
 
-    public function show(GetBootstrapConfigurationRequest $request): JsonResponse
-    {
+    public function show(
+        GetBootstrapConfigurationRequest $request,
+        AndroidPushRuntimeConfiguration $androidPushRuntimeConfiguration,
+    ): JsonResponse {
         if (! $this->bootstrapPublicEnabled()) {
             return $this->configurationUnavailableResponse();
         }
@@ -30,17 +30,18 @@ class BootstrapController extends Controller
         $displayName = $this->instanceDisplayName();
         $minimumSupportedAppVersion = $this->minimumSupportedAppVersion();
         $minimumSupportedAppBuild = $this->minimumSupportedAppBuild();
-
-        if ($apiBaseUrl === null
-            || $displayName === null
-            || $minimumSupportedAppVersion === null
-            || $minimumSupportedAppBuild === null) {
-            return $this->invalidStateResponse($this->missingRequiredFields(
+        $missingFields = array_merge(
+            $this->missingRequiredFields(
                 $apiBaseUrl,
                 $displayName,
                 $minimumSupportedAppVersion,
                 $minimumSupportedAppBuild,
-            ));
+            ),
+            $androidPushRuntimeConfiguration->missingFields(),
+        );
+
+        if ($missingFields !== []) {
+            return $this->invalidStateResponse($missingFields);
         }
 
         if ($this->clientIsBelowMinimumSupportedVersion(
@@ -57,26 +58,31 @@ class BootstrapController extends Controller
             );
         }
 
-        return response()->json([
-            'data' => [
-                'client_platform' => $request->clientPlatform(),
-                'api_base_url' => $apiBaseUrl,
-                'instance' => [
-                    'display_name' => $displayName,
-                ],
-                'compatibility' => [
-                    'bootstrap_version' => self::BOOTSTRAP_VERSION,
-                    'schema_version' => self::SCHEMA_VERSION,
-                    'minimum_supported_app_version' => $minimumSupportedAppVersion,
-                    'minimum_supported_app_build' => $minimumSupportedAppBuild,
-                ],
-                'features' => [
-                    'password_login' => $this->booleanConfig('bootstrap.features.password_login', true),
-                    'passkey_login' => $this->booleanConfig('bootstrap.features.passkey_login', true),
-                    'managed_android_enrollment' => $this->booleanConfig('bootstrap.features.managed_android_enrollment', false),
-                ],
+        $data = [
+            'client_platform' => $request->clientPlatform(),
+            'api_base_url' => $apiBaseUrl,
+            'instance' => [
+                'display_name' => $displayName,
             ],
-        ]);
+            'compatibility' => [
+                'bootstrap_version' => BootstrapContract::VERSION,
+                'schema_version' => BootstrapContract::SCHEMA_VERSION,
+                'minimum_supported_app_version' => $minimumSupportedAppVersion,
+                'minimum_supported_app_build' => $minimumSupportedAppBuild,
+            ],
+            'features' => [
+                'password_login' => $this->booleanConfig('bootstrap.features.password_login', true),
+                'passkey_login' => $this->booleanConfig('bootstrap.features.passkey_login', true),
+                'managed_android_enrollment' => $this->booleanConfig('bootstrap.features.managed_android_enrollment', false),
+                'android_push' => $androidPushRuntimeConfiguration->isEnabled(),
+            ],
+        ];
+
+        if ($androidPushRuntimeConfiguration->isEnabled()) {
+            $data['android_push'] = $androidPushRuntimeConfiguration->publicMetadata();
+        }
+
+        return response()->json(['data' => $data]);
     }
 
     /**
@@ -140,7 +146,7 @@ class BootstrapController extends Controller
                 'provided_app_build' => $providedAppBuild,
                 'minimum_supported_app_version' => $minimumSupportedAppVersion,
                 'minimum_supported_app_build' => $minimumSupportedAppBuild,
-                'bootstrap_version' => self::BOOTSTRAP_VERSION,
+                'bootstrap_version' => BootstrapContract::VERSION,
             ],
         ], 426);
     }

--- a/app/Http/Controllers/Api/V1/PushDeviceRegistrationController.php
+++ b/app/Http/Controllers/Api/V1/PushDeviceRegistrationController.php
@@ -59,6 +59,10 @@ class PushDeviceRegistrationController extends Controller
 
     public function destroy(Request $request, string $installationId): JsonResponse
     {
+        if (! $this->androidPushRuntimeConfiguration->isEnabled()) {
+            return $this->unsupportedConfigurationResponse();
+        }
+
         /** @var User $user */
         $user = $request->user();
         $revocation = $this->pushDeviceRegistrationService->revoke($user, $installationId);

--- a/app/Http/Controllers/Api/V1/PushDeviceRegistrationController.php
+++ b/app/Http/Controllers/Api/V1/PushDeviceRegistrationController.php
@@ -16,7 +16,6 @@ use App\Support\BootstrapContract;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
-use RuntimeException;
 
 class PushDeviceRegistrationController extends Controller
 {
@@ -31,15 +30,19 @@ class PushDeviceRegistrationController extends Controller
             return $this->unsupportedConfigurationResponse();
         }
 
-        if ($this->androidPushRuntimeConfiguration->missingFields() !== []) {
-            throw new RuntimeException('Android push runtime metadata is incomplete for this deployment.');
+        $missingFields = $this->androidPushRuntimeConfiguration->missingFields();
+
+        if ($missingFields !== []) {
+            return $this->invalidConfigurationResponse($missingFields);
         }
 
         $providedRevision = $request->integer('runtime.push_metadata_revision');
         $expectedRevision = $this->androidPushRuntimeConfiguration->metadataRevision();
 
         if ($expectedRevision === null) {
-            throw new RuntimeException('Android push runtime metadata revision is unavailable for this deployment.');
+            return $this->invalidConfigurationResponse([
+                'android_push.metadata_revision',
+            ]);
         }
 
         if ($providedRevision !== $expectedRevision) {
@@ -102,5 +105,19 @@ class PushDeviceRegistrationController extends Controller
                 'expected_push_metadata_revision' => $expectedRevision,
             ],
         ], Response::HTTP_CONFLICT);
+    }
+
+    /**
+     * @param  array<int, string>  $missingFields
+     */
+    private function invalidConfigurationResponse(array $missingFields): JsonResponse
+    {
+        return response()->json([
+            'message' => 'Public bootstrap configuration is incomplete for this deployment.',
+            'code' => 'BOOTSTRAP_STATE_INVALID',
+            'details' => [
+                'missing_fields' => $missingFields,
+            ],
+        ], Response::HTTP_INTERNAL_SERVER_ERROR);
     }
 }

--- a/app/Http/Controllers/Api/V1/PushDeviceRegistrationController.php
+++ b/app/Http/Controllers/Api/V1/PushDeviceRegistrationController.php
@@ -1,0 +1,102 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\UpsertPushDeviceRegistrationRequest;
+use App\Models\User;
+use App\Services\PushDeviceRegistrationService;
+use App\Support\AndroidPushRuntimeConfiguration;
+use App\Support\BootstrapContract;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use RuntimeException;
+
+class PushDeviceRegistrationController extends Controller
+{
+    public function __construct(
+        private readonly AndroidPushRuntimeConfiguration $androidPushRuntimeConfiguration,
+        private readonly PushDeviceRegistrationService $pushDeviceRegistrationService,
+    ) {}
+
+    public function upsert(UpsertPushDeviceRegistrationRequest $request, string $installationId): JsonResponse
+    {
+        if (! $this->androidPushRuntimeConfiguration->isEnabled()) {
+            return $this->unsupportedConfigurationResponse();
+        }
+
+        if ($this->androidPushRuntimeConfiguration->missingFields() !== []) {
+            throw new RuntimeException('Android push runtime metadata is incomplete for this deployment.');
+        }
+
+        $providedRevision = $request->integer('runtime.push_metadata_revision');
+        $expectedRevision = $this->androidPushRuntimeConfiguration->metadataRevision();
+
+        if ($expectedRevision === null) {
+            throw new RuntimeException('Android push runtime metadata revision is unavailable for this deployment.');
+        }
+
+        if ($providedRevision !== $expectedRevision) {
+            return $this->runtimeStateConflictResponse($providedRevision, $expectedRevision);
+        }
+
+        /** @var User $user */
+        $user = $request->user();
+        $result = $this->pushDeviceRegistrationService->upsert($user, $installationId, $request->validated());
+        $registration = $result['registration'];
+        $status = $result['created'] ? Response::HTTP_CREATED : Response::HTTP_OK;
+
+        return response()->json([
+            'data' => $registration->toApiArray(),
+        ], $status);
+    }
+
+    public function destroy(Request $request, string $installationId): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        $revocation = $this->pushDeviceRegistrationService->revoke($user, $installationId);
+
+        if ($revocation === null) {
+            abort(Response::HTTP_NOT_FOUND);
+        }
+
+        return response()->json([
+            'data' => $revocation,
+        ]);
+    }
+
+    private function unsupportedConfigurationResponse(): JsonResponse
+    {
+        return response()->json([
+            'message' => 'This deployment does not accept authenticated Android push-device registrations.',
+            'code' => 'ANDROID_PUSH_UNSUPPORTED',
+            'details' => [
+                'feature_flag' => 'android_push',
+                'provider' => BootstrapContract::ANDROID_PUSH_PROVIDER,
+                'retryable' => false,
+            ],
+        ], Response::HTTP_CONFLICT);
+    }
+
+    private function runtimeStateConflictResponse(int $providedRevision, int $expectedRevision): JsonResponse
+    {
+        return response()->json([
+            'message' => 'Android push runtime metadata changed; refresh bootstrap before retrying this registration.',
+            'code' => 'PUSH_RUNTIME_STATE_INVALID',
+            'details' => [
+                'bootstrap_version' => BootstrapContract::VERSION,
+                'schema_version' => BootstrapContract::SCHEMA_VERSION,
+                'provider' => BootstrapContract::ANDROID_PUSH_PROVIDER,
+                'provided_push_metadata_revision' => $providedRevision,
+                'expected_push_metadata_revision' => $expectedRevision,
+            ],
+        ], Response::HTTP_CONFLICT);
+    }
+}

--- a/app/Http/Requests/UpsertPushDeviceRegistrationRequest.php
+++ b/app/Http/Requests/UpsertPushDeviceRegistrationRequest.php
@@ -1,0 +1,47 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use App\Support\BootstrapContract;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpsertPushDeviceRegistrationRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            'platform' => ['required', 'string', Rule::in(['android'])],
+            'provider' => ['required', 'string', Rule::in([BootstrapContract::ANDROID_PUSH_PROVIDER])],
+            'device_name' => ['required', 'string', 'max:120'],
+            'push_token' => ['required', 'string', 'min:32', 'max:4096'],
+            'lifecycle_event' => ['required', 'string', Rule::in(['registered', 'token_rotated', 'app_updated'])],
+            'app' => ['required', 'array'],
+            'app.package_name' => ['required', 'string', Rule::in(['app.secpal'])],
+            'app.package_version_name' => ['nullable', 'string', 'max:50'],
+            'app.package_version_code' => ['nullable', 'integer', 'min:1'],
+            'device' => ['sometimes', 'array'],
+            'device.manufacturer' => ['nullable', 'string', 'max:120'],
+            'device.model' => ['nullable', 'string', 'max:120'],
+            'device.android_version' => ['nullable', 'string', 'max:30'],
+            'device.sdk_int' => ['nullable', 'integer', 'min:21'],
+            'runtime' => ['required', 'array'],
+            'runtime.bootstrap_version' => ['required', 'string', Rule::in([BootstrapContract::VERSION])],
+            'runtime.schema_version' => ['required', 'integer', Rule::in([BootstrapContract::SCHEMA_VERSION])],
+            'runtime.push_metadata_revision' => ['required', 'integer', 'min:1'],
+        ];
+    }
+}

--- a/app/Http/Requests/UpsertPushDeviceRegistrationRequest.php
+++ b/app/Http/Requests/UpsertPushDeviceRegistrationRequest.php
@@ -58,7 +58,7 @@ class UpsertPushDeviceRegistrationRequest extends FormRequest
     }
 
     /**
-     * @param  array<string, mixed>  $payload
+     * @param  array<array-key, mixed>  $payload
      * @param  list<string>  $path
      */
     private function setNestedInteger(array &$payload, array $path): void

--- a/app/Http/Requests/UpsertPushDeviceRegistrationRequest.php
+++ b/app/Http/Requests/UpsertPushDeviceRegistrationRequest.php
@@ -18,6 +18,18 @@ class UpsertPushDeviceRegistrationRequest extends FormRequest
         return true;
     }
 
+    protected function prepareForValidation(): void
+    {
+        $payload = $this->all();
+
+        $this->setNestedInteger($payload, ['app', 'package_version_code']);
+        $this->setNestedInteger($payload, ['device', 'sdk_int']);
+        $this->setNestedInteger($payload, ['runtime', 'schema_version']);
+        $this->setNestedInteger($payload, ['runtime', 'push_metadata_revision']);
+
+        $this->replace($payload);
+    }
+
     /**
      * @return array<string, array<int, mixed>>
      */
@@ -43,5 +55,31 @@ class UpsertPushDeviceRegistrationRequest extends FormRequest
             'runtime.schema_version' => ['required', 'integer', Rule::in([BootstrapContract::SCHEMA_VERSION])],
             'runtime.push_metadata_revision' => ['required', 'integer', 'min:1'],
         ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @param  list<string>  $path
+     */
+    private function setNestedInteger(array &$payload, array $path): void
+    {
+        $target = &$payload;
+        $lastIndex = array_key_last($path);
+
+        foreach ($path as $index => $segment) {
+            if (! is_array($target) || ! array_key_exists($segment, $target)) {
+                return;
+            }
+
+            if ($index === $lastIndex) {
+                if (is_string($target[$segment]) && filter_var($target[$segment], FILTER_VALIDATE_INT) !== false) {
+                    $target[$segment] = (int) $target[$segment];
+                }
+
+                return;
+            }
+
+            $target = &$target[$segment];
+        }
     }
 }

--- a/app/Models/PushDeviceRegistration.php
+++ b/app/Models/PushDeviceRegistration.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
-use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
@@ -39,7 +38,6 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  */
 class PushDeviceRegistration extends Model
 {
-    use HasFactory;
     use HasUuids;
 
     /**

--- a/app/Models/PushDeviceRegistration.php
+++ b/app/Models/PushDeviceRegistration.php
@@ -50,6 +50,7 @@ class PushDeviceRegistration extends Model
         'platform',
         'provider',
         'device_name',
+        'push_token_plain',
         'push_token_enc',
         'token_last_eight',
         'last_lifecycle_event',

--- a/app/Models/PushDeviceRegistration.php
+++ b/app/Models/PushDeviceRegistration.php
@@ -1,0 +1,158 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property string $id
+ * @property int $tenant_id
+ * @property string $user_id
+ * @property string $installation_id
+ * @property string $platform
+ * @property string $provider
+ * @property string $device_name
+ * @property string $push_token_enc
+ * @property string $token_last_eight
+ * @property string $last_lifecycle_event
+ * @property string $package_name
+ * @property string|null $package_version_name
+ * @property int|null $package_version_code
+ * @property string|null $manufacturer
+ * @property string|null $model
+ * @property string|null $android_version
+ * @property int|null $sdk_int
+ * @property string $bootstrap_version
+ * @property int $schema_version
+ * @property int $push_metadata_revision
+ * @property \Illuminate\Support\Carbon $created_at
+ * @property \Illuminate\Support\Carbon $updated_at
+ * @property-write string|null $push_token_plain
+ */
+class PushDeviceRegistration extends Model
+{
+    use HasFactory;
+    use HasUuids;
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'tenant_id',
+        'user_id',
+        'installation_id',
+        'platform',
+        'provider',
+        'device_name',
+        'push_token_enc',
+        'token_last_eight',
+        'last_lifecycle_event',
+        'package_name',
+        'package_version_name',
+        'package_version_code',
+        'manufacturer',
+        'model',
+        'android_version',
+        'sdk_int',
+        'bootstrap_version',
+        'schema_version',
+        'push_metadata_revision',
+    ];
+
+    /**
+     * @var list<string>
+     */
+    protected $hidden = [
+        'push_token_enc',
+    ];
+
+    private ?string $pushTokenPlain = null;
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'push_token_enc' => \App\Casts\EncryptedWithDek::class,
+            'package_version_code' => 'integer',
+            'sdk_int' => 'integer',
+            'schema_version' => 'integer',
+            'push_metadata_revision' => 'integer',
+            'created_at' => 'datetime',
+            'updated_at' => 'datetime',
+        ];
+    }
+
+    public function setPushTokenPlainAttribute(?string $value): void
+    {
+        $this->pushTokenPlain = $value;
+
+        if ($value !== null) {
+            $this->push_token_enc = $value;
+            $this->token_last_eight = substr($value, -8);
+        }
+    }
+
+    public function getPushTokenPlainAttribute(): ?string
+    {
+        return $this->pushTokenPlain;
+    }
+
+    /**
+     * @return BelongsTo<TenantKey, $this>
+     */
+    public function tenant(): BelongsTo
+    {
+        return $this->belongsTo(TenantKey::class, 'tenant_id');
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toApiArray(): array
+    {
+        return [
+            'installation_id' => $this->installation_id,
+            'platform' => $this->platform,
+            'provider' => $this->provider,
+            'device_name' => $this->device_name,
+            'token_last_eight' => $this->token_last_eight,
+            'last_lifecycle_event' => $this->last_lifecycle_event,
+            'app' => [
+                'package_name' => $this->package_name,
+                'package_version_name' => $this->package_version_name,
+                'package_version_code' => $this->package_version_code,
+            ],
+            'device' => [
+                'manufacturer' => $this->manufacturer,
+                'model' => $this->model,
+                'android_version' => $this->android_version,
+                'sdk_int' => $this->sdk_int,
+            ],
+            'runtime' => [
+                'bootstrap_version' => $this->bootstrap_version,
+                'schema_version' => $this->schema_version,
+                'push_metadata_revision' => $this->push_metadata_revision,
+            ],
+            'created_at' => $this->created_at->toIso8601String(),
+            'updated_at' => $this->updated_at->toIso8601String(),
+        ];
+    }
+}

--- a/app/Models/PushDeviceRegistration.php
+++ b/app/Models/PushDeviceRegistration.php
@@ -51,8 +51,6 @@ class PushDeviceRegistration extends Model
         'provider',
         'device_name',
         'push_token_plain',
-        'push_token_enc',
-        'token_last_eight',
         'last_lifecycle_event',
         'package_name',
         'package_version_name',

--- a/app/Services/PushDeviceRegistrationService.php
+++ b/app/Services/PushDeviceRegistrationService.php
@@ -24,13 +24,6 @@ final class PushDeviceRegistrationService
             throw new RuntimeException('Authenticated user must belong to a tenant before registering a push device.');
         }
 
-        $registration = PushDeviceRegistration::query()->firstOrNew([
-            'tenant_id' => $user->tenant_id,
-            'user_id' => $user->id,
-            'installation_id' => $installationId,
-        ]);
-
-        $created = ! $registration->exists;
         /** @var array<string, mixed> $app */
         $app = is_array($attributes['app'] ?? null) ? $attributes['app'] : [];
         /** @var array<string, mixed> $device */
@@ -38,25 +31,32 @@ final class PushDeviceRegistrationService
         /** @var array<string, mixed> $runtime */
         $runtime = is_array($attributes['runtime'] ?? null) ? $attributes['runtime'] : [];
 
-        $registration->tenant_id = $user->tenant_id;
-        $registration->user_id = $user->id;
-        $registration->installation_id = $installationId;
-        $registration->platform = $this->requiredString($attributes, 'platform');
-        $registration->provider = $this->requiredString($attributes, 'provider');
-        $registration->device_name = $this->requiredString($attributes, 'device_name');
-        $registration->push_token_plain = $this->requiredString($attributes, 'push_token');
-        $registration->last_lifecycle_event = $this->requiredString($attributes, 'lifecycle_event');
-        $registration->package_name = $this->requiredString($app, 'package_name');
-        $registration->package_version_name = $this->nullableString($app, 'package_version_name');
-        $registration->package_version_code = $this->nullableInt($app, 'package_version_code');
-        $registration->manufacturer = $this->nullableString($device, 'manufacturer');
-        $registration->model = $this->nullableString($device, 'model');
-        $registration->android_version = $this->nullableString($device, 'android_version');
-        $registration->sdk_int = $this->nullableInt($device, 'sdk_int');
-        $registration->bootstrap_version = $this->requiredString($runtime, 'bootstrap_version');
-        $registration->schema_version = $this->requiredInt($runtime, 'schema_version');
-        $registration->push_metadata_revision = $this->requiredInt($runtime, 'push_metadata_revision');
-        $registration->save();
+        $registration = PushDeviceRegistration::query()->updateOrCreate(
+            [
+                'tenant_id' => $user->tenant_id,
+                'user_id' => $user->id,
+                'installation_id' => $installationId,
+            ],
+            [
+                'platform' => $this->requiredString($attributes, 'platform'),
+                'provider' => $this->requiredString($attributes, 'provider'),
+                'device_name' => $this->requiredString($attributes, 'device_name'),
+                'push_token_plain' => $this->requiredString($attributes, 'push_token'),
+                'last_lifecycle_event' => $this->requiredString($attributes, 'lifecycle_event'),
+                'package_name' => $this->requiredString($app, 'package_name'),
+                'package_version_name' => $this->nullableString($app, 'package_version_name'),
+                'package_version_code' => $this->nullableInt($app, 'package_version_code'),
+                'manufacturer' => $this->nullableString($device, 'manufacturer'),
+                'model' => $this->nullableString($device, 'model'),
+                'android_version' => $this->nullableString($device, 'android_version'),
+                'sdk_int' => $this->nullableInt($device, 'sdk_int'),
+                'bootstrap_version' => $this->requiredString($runtime, 'bootstrap_version'),
+                'schema_version' => $this->requiredInt($runtime, 'schema_version'),
+                'push_metadata_revision' => $this->requiredInt($runtime, 'push_metadata_revision'),
+            ],
+        );
+
+        $created = $registration->wasRecentlyCreated;
 
         $freshRegistration = $registration->fresh();
 

--- a/app/Services/PushDeviceRegistrationService.php
+++ b/app/Services/PushDeviceRegistrationService.php
@@ -9,6 +9,7 @@ namespace App\Services;
 
 use App\Models\PushDeviceRegistration;
 use App\Models\User;
+use InvalidArgumentException;
 use RuntimeException;
 
 final class PushDeviceRegistrationService
@@ -30,44 +31,41 @@ final class PushDeviceRegistrationService
         ]);
 
         $created = ! $registration->exists;
+        /** @var array<string, mixed> $app */
         $app = is_array($attributes['app'] ?? null) ? $attributes['app'] : [];
+        /** @var array<string, mixed> $device */
         $device = is_array($attributes['device'] ?? null) ? $attributes['device'] : [];
+        /** @var array<string, mixed> $runtime */
         $runtime = is_array($attributes['runtime'] ?? null) ? $attributes['runtime'] : [];
 
         $registration->tenant_id = $user->tenant_id;
         $registration->user_id = $user->id;
         $registration->installation_id = $installationId;
-        $registration->platform = (string) $attributes['platform'];
-        $registration->provider = (string) $attributes['provider'];
-        $registration->device_name = (string) $attributes['device_name'];
-        $registration->push_token_plain = (string) $attributes['push_token'];
-        $registration->last_lifecycle_event = (string) $attributes['lifecycle_event'];
-        $registration->package_name = (string) ($app['package_name'] ?? '');
-        $registration->package_version_name = is_string($app['package_version_name'] ?? null)
-            ? $app['package_version_name']
-            : null;
-        $registration->package_version_code = is_int($app['package_version_code'] ?? null)
-            ? $app['package_version_code']
-            : null;
-        $registration->manufacturer = is_string($device['manufacturer'] ?? null)
-            ? $device['manufacturer']
-            : null;
-        $registration->model = is_string($device['model'] ?? null)
-            ? $device['model']
-            : null;
-        $registration->android_version = is_string($device['android_version'] ?? null)
-            ? $device['android_version']
-            : null;
-        $registration->sdk_int = is_int($device['sdk_int'] ?? null)
-            ? $device['sdk_int']
-            : null;
-        $registration->bootstrap_version = (string) ($runtime['bootstrap_version'] ?? '');
-        $registration->schema_version = (int) ($runtime['schema_version'] ?? 0);
-        $registration->push_metadata_revision = (int) ($runtime['push_metadata_revision'] ?? 0);
+        $registration->platform = $this->requiredString($attributes, 'platform');
+        $registration->provider = $this->requiredString($attributes, 'provider');
+        $registration->device_name = $this->requiredString($attributes, 'device_name');
+        $registration->push_token_plain = $this->requiredString($attributes, 'push_token');
+        $registration->last_lifecycle_event = $this->requiredString($attributes, 'lifecycle_event');
+        $registration->package_name = $this->requiredString($app, 'package_name');
+        $registration->package_version_name = $this->nullableString($app, 'package_version_name');
+        $registration->package_version_code = $this->nullableInt($app, 'package_version_code');
+        $registration->manufacturer = $this->nullableString($device, 'manufacturer');
+        $registration->model = $this->nullableString($device, 'model');
+        $registration->android_version = $this->nullableString($device, 'android_version');
+        $registration->sdk_int = $this->nullableInt($device, 'sdk_int');
+        $registration->bootstrap_version = $this->requiredString($runtime, 'bootstrap_version');
+        $registration->schema_version = $this->requiredInt($runtime, 'schema_version');
+        $registration->push_metadata_revision = $this->requiredInt($runtime, 'push_metadata_revision');
         $registration->save();
 
+        $freshRegistration = $registration->fresh();
+
+        if (! $freshRegistration instanceof PushDeviceRegistration) {
+            throw new RuntimeException('Unable to reload push device registration after save.');
+        }
+
         return [
-            'registration' => $registration->fresh(),
+            'registration' => $freshRegistration,
             'created' => $created,
         ];
     }
@@ -98,5 +96,69 @@ final class PushDeviceRegistrationService
             'installation_id' => $installationId,
             'revoked_at' => $revokedAt->toIso8601String(),
         ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $values
+     */
+    private function requiredString(array $values, string $key): string
+    {
+        $value = $values[$key] ?? null;
+
+        if (! is_string($value)) {
+            throw new InvalidArgumentException(sprintf('Expected string value for "%s".', $key));
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param  array<string, mixed>  $values
+     */
+    private function nullableString(array $values, string $key): ?string
+    {
+        $value = $values[$key] ?? null;
+
+        if ($value === null) {
+            return null;
+        }
+
+        if (! is_string($value)) {
+            throw new InvalidArgumentException(sprintf('Expected nullable string value for "%s".', $key));
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param  array<string, mixed>  $values
+     */
+    private function requiredInt(array $values, string $key): int
+    {
+        $value = $values[$key] ?? null;
+
+        if (! is_int($value)) {
+            throw new InvalidArgumentException(sprintf('Expected integer value for "%s".', $key));
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param  array<string, mixed>  $values
+     */
+    private function nullableInt(array $values, string $key): ?int
+    {
+        $value = $values[$key] ?? null;
+
+        if ($value === null) {
+            return null;
+        }
+
+        if (! is_int($value)) {
+            throw new InvalidArgumentException(sprintf('Expected nullable integer value for "%s".', $key));
+        }
+
+        return $value;
     }
 }

--- a/app/Services/PushDeviceRegistrationService.php
+++ b/app/Services/PushDeviceRegistrationService.php
@@ -1,0 +1,102 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\PushDeviceRegistration;
+use App\Models\User;
+use RuntimeException;
+
+final class PushDeviceRegistrationService
+{
+    /**
+     * @param  array<string, mixed>  $attributes
+     * @return array{registration: PushDeviceRegistration, created: bool}
+     */
+    public function upsert(User $user, string $installationId, array $attributes): array
+    {
+        if ($user->tenant_id === null) {
+            throw new RuntimeException('Authenticated user must belong to a tenant before registering a push device.');
+        }
+
+        $registration = PushDeviceRegistration::query()->firstOrNew([
+            'tenant_id' => $user->tenant_id,
+            'user_id' => $user->id,
+            'installation_id' => $installationId,
+        ]);
+
+        $created = ! $registration->exists;
+        $app = is_array($attributes['app'] ?? null) ? $attributes['app'] : [];
+        $device = is_array($attributes['device'] ?? null) ? $attributes['device'] : [];
+        $runtime = is_array($attributes['runtime'] ?? null) ? $attributes['runtime'] : [];
+
+        $registration->tenant_id = $user->tenant_id;
+        $registration->user_id = $user->id;
+        $registration->installation_id = $installationId;
+        $registration->platform = (string) $attributes['platform'];
+        $registration->provider = (string) $attributes['provider'];
+        $registration->device_name = (string) $attributes['device_name'];
+        $registration->push_token_plain = (string) $attributes['push_token'];
+        $registration->last_lifecycle_event = (string) $attributes['lifecycle_event'];
+        $registration->package_name = (string) ($app['package_name'] ?? '');
+        $registration->package_version_name = is_string($app['package_version_name'] ?? null)
+            ? $app['package_version_name']
+            : null;
+        $registration->package_version_code = is_int($app['package_version_code'] ?? null)
+            ? $app['package_version_code']
+            : null;
+        $registration->manufacturer = is_string($device['manufacturer'] ?? null)
+            ? $device['manufacturer']
+            : null;
+        $registration->model = is_string($device['model'] ?? null)
+            ? $device['model']
+            : null;
+        $registration->android_version = is_string($device['android_version'] ?? null)
+            ? $device['android_version']
+            : null;
+        $registration->sdk_int = is_int($device['sdk_int'] ?? null)
+            ? $device['sdk_int']
+            : null;
+        $registration->bootstrap_version = (string) ($runtime['bootstrap_version'] ?? '');
+        $registration->schema_version = (int) ($runtime['schema_version'] ?? 0);
+        $registration->push_metadata_revision = (int) ($runtime['push_metadata_revision'] ?? 0);
+        $registration->save();
+
+        return [
+            'registration' => $registration->fresh(),
+            'created' => $created,
+        ];
+    }
+
+    /**
+     * @return array{installation_id: string, revoked_at: string}|null
+     */
+    public function revoke(User $user, string $installationId): ?array
+    {
+        if ($user->tenant_id === null) {
+            return null;
+        }
+
+        $registration = PushDeviceRegistration::query()
+            ->where('tenant_id', $user->tenant_id)
+            ->where('user_id', $user->id)
+            ->where('installation_id', $installationId)
+            ->first();
+
+        if ($registration === null) {
+            return null;
+        }
+
+        $revokedAt = now();
+        $registration->delete();
+
+        return [
+            'installation_id' => $installationId,
+            'revoked_at' => $revokedAt->toIso8601String(),
+        ];
+    }
+}

--- a/app/Support/AndroidPushRuntimeConfiguration.php
+++ b/app/Support/AndroidPushRuntimeConfiguration.php
@@ -1,0 +1,114 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+final class AndroidPushRuntimeConfiguration
+{
+    public function isEnabled(): bool
+    {
+        return $this->booleanConfig('bootstrap.features.android_push', false);
+    }
+
+    public function metadataRevision(): ?int
+    {
+        $value = config('bootstrap.android_push.metadata_revision');
+
+        if (is_int($value) && $value > 0) {
+            return $value;
+        }
+
+        if (is_string($value) && is_numeric($value) && (int) $value > 0) {
+            return (int) $value;
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function missingFields(): array
+    {
+        if (! $this->isEnabled()) {
+            return [];
+        }
+
+        $missingFields = [];
+
+        if ($this->metadataRevision() === null) {
+            $missingFields[] = 'android_push.metadata_revision';
+        }
+
+        foreach (['api_key', 'project_id', 'application_id', 'sender_id'] as $field) {
+            if ($this->publicClientMetadataValue($field) === null) {
+                $missingFields[] = 'android_push.public_client_metadata.'.$field;
+            }
+        }
+
+        return $missingFields;
+    }
+
+    public function publicMetadata(): ?array
+    {
+        if (! $this->isEnabled() || $this->missingFields() !== []) {
+            return null;
+        }
+
+        return [
+            'provider' => BootstrapContract::ANDROID_PUSH_PROVIDER,
+            'metadata_revision' => $this->metadataRevision(),
+            'public_client_metadata' => [
+                'api_key' => $this->publicClientMetadataValue('api_key'),
+                'project_id' => $this->publicClientMetadataValue('project_id'),
+                'application_id' => $this->publicClientMetadataValue('application_id'),
+                'sender_id' => $this->publicClientMetadataValue('sender_id'),
+            ],
+        ];
+    }
+
+    private function publicClientMetadataValue(string $field): ?string
+    {
+        return $this->trimmedStringConfig('bootstrap.android_push.public_client_metadata.'.$field);
+    }
+
+    private function booleanConfig(string $key, bool $default): bool
+    {
+        $value = config($key, $default);
+
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        if (is_int($value)) {
+            return $value !== 0;
+        }
+
+        if (is_string($value)) {
+            $parsed = filter_var($value, FILTER_VALIDATE_BOOL, FILTER_NULL_ON_FAILURE);
+
+            if ($parsed !== null) {
+                return $parsed;
+            }
+        }
+
+        return $default;
+    }
+
+    private function trimmedStringConfig(string $key): ?string
+    {
+        $value = config($key);
+
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $value = trim($value);
+
+        return $value === '' ? null : $value;
+    }
+}

--- a/app/Support/AndroidPushRuntimeConfiguration.php
+++ b/app/Support/AndroidPushRuntimeConfiguration.php
@@ -20,17 +20,7 @@ final class AndroidPushRuntimeConfiguration
 
     public function metadataRevision(): ?int
     {
-        $value = config('bootstrap.android_push.metadata_revision');
-
-        if (is_int($value) && $value > 0) {
-            return $value;
-        }
-
-        if (is_string($value) && is_numeric($value) && (int) $value > 0) {
-            return (int) $value;
-        }
-
-        return null;
+        return $this->positiveIntegerConfig('bootstrap.android_push.metadata_revision');
     }
 
     /**
@@ -99,5 +89,20 @@ final class AndroidPushRuntimeConfiguration
     private function publicClientMetadataValue(string $field): ?string
     {
         return $this->trimmedStringConfig('bootstrap.android_push.public_client_metadata.'.$field);
+    }
+
+    private function positiveIntegerConfig(string $key): ?int
+    {
+        $value = config($key);
+
+        if (is_int($value)) {
+            return $value > 0 ? $value : null;
+        }
+
+        if (! is_string($value) || ! preg_match('/^[1-9][0-9]*$/', $value)) {
+            return null;
+        }
+
+        return (int) $value;
     }
 }

--- a/app/Support/AndroidPushRuntimeConfiguration.php
+++ b/app/Support/AndroidPushRuntimeConfiguration.php
@@ -7,8 +7,12 @@ declare(strict_types=1);
 
 namespace App\Support;
 
+use App\Support\Concerns\InteractsWithConfigValues;
+
 final class AndroidPushRuntimeConfiguration
 {
+    use InteractsWithConfigValues;
+
     public function isEnabled(): bool
     {
         return $this->booleanConfig('bootstrap.features.android_push', false);
@@ -95,41 +99,5 @@ final class AndroidPushRuntimeConfiguration
     private function publicClientMetadataValue(string $field): ?string
     {
         return $this->trimmedStringConfig('bootstrap.android_push.public_client_metadata.'.$field);
-    }
-
-    private function booleanConfig(string $key, bool $default): bool
-    {
-        $value = config($key, $default);
-
-        if (is_bool($value)) {
-            return $value;
-        }
-
-        if (is_int($value)) {
-            return $value !== 0;
-        }
-
-        if (is_string($value)) {
-            $parsed = filter_var($value, FILTER_VALIDATE_BOOL, FILTER_NULL_ON_FAILURE);
-
-            if ($parsed !== null) {
-                return $parsed;
-            }
-        }
-
-        return $default;
-    }
-
-    private function trimmedStringConfig(string $key): ?string
-    {
-        $value = config($key);
-
-        if (! is_string($value)) {
-            return null;
-        }
-
-        $value = trim($value);
-
-        return $value === '' ? null : $value;
     }
 }

--- a/app/Support/AndroidPushRuntimeConfiguration.php
+++ b/app/Support/AndroidPushRuntimeConfiguration.php
@@ -53,20 +53,37 @@ final class AndroidPushRuntimeConfiguration
         return $missingFields;
     }
 
+    /**
+     * @return array{provider: string, metadata_revision: int, public_client_metadata: array{api_key: string, project_id: string, application_id: string, sender_id: string}}|null
+     */
     public function publicMetadata(): ?array
     {
         if (! $this->isEnabled() || $this->missingFields() !== []) {
             return null;
         }
 
+        $metadataRevision = $this->metadataRevision();
+        $apiKey = $this->publicClientMetadataValue('api_key');
+        $projectId = $this->publicClientMetadataValue('project_id');
+        $applicationId = $this->publicClientMetadataValue('application_id');
+        $senderId = $this->publicClientMetadataValue('sender_id');
+
+        if ($metadataRevision === null
+            || $apiKey === null
+            || $projectId === null
+            || $applicationId === null
+            || $senderId === null) {
+            return null;
+        }
+
         return [
             'provider' => BootstrapContract::ANDROID_PUSH_PROVIDER,
-            'metadata_revision' => $this->metadataRevision(),
+            'metadata_revision' => $metadataRevision,
             'public_client_metadata' => [
-                'api_key' => $this->publicClientMetadataValue('api_key'),
-                'project_id' => $this->publicClientMetadataValue('project_id'),
-                'application_id' => $this->publicClientMetadataValue('application_id'),
-                'sender_id' => $this->publicClientMetadataValue('sender_id'),
+                'api_key' => $apiKey,
+                'project_id' => $projectId,
+                'application_id' => $applicationId,
+                'sender_id' => $senderId,
             ],
         ];
     }

--- a/app/Support/AndroidPushRuntimeConfiguration.php
+++ b/app/Support/AndroidPushRuntimeConfiguration.php
@@ -40,8 +40,12 @@ final class AndroidPushRuntimeConfiguration
 
         $missingFields = [];
 
-        if ($this->metadataRevision() === null) {
+        $rawRevision = config('bootstrap.android_push.metadata_revision');
+
+        if ($rawRevision === null) {
             $missingFields[] = 'android_push.metadata_revision';
+        } elseif ($this->metadataRevision() === null) {
+            $missingFields[] = 'android_push.metadata_revision (present but invalid; must be a positive integer)';
         }
 
         foreach (['api_key', 'project_id', 'application_id', 'sender_id'] as $field) {

--- a/app/Support/BootstrapContract.php
+++ b/app/Support/BootstrapContract.php
@@ -1,0 +1,17 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+final class BootstrapContract
+{
+    public const VERSION = 'v1';
+
+    public const SCHEMA_VERSION = 2;
+
+    public const ANDROID_PUSH_PROVIDER = 'fcm';
+}

--- a/app/Support/Concerns/InteractsWithConfigValues.php
+++ b/app/Support/Concerns/InteractsWithConfigValues.php
@@ -1,0 +1,47 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace App\Support\Concerns;
+
+trait InteractsWithConfigValues
+{
+    private function booleanConfig(string $key, bool $default): bool
+    {
+        $value = config($key, $default);
+
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        if (is_int($value)) {
+            return $value !== 0;
+        }
+
+        if (is_string($value)) {
+            $parsed = filter_var($value, FILTER_VALIDATE_BOOL, FILTER_NULL_ON_FAILURE);
+
+            if ($parsed !== null) {
+                return $parsed;
+            }
+        }
+
+        return $default;
+    }
+
+    private function trimmedStringConfig(string $key): ?string
+    {
+        $value = config($key);
+
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $value = trim($value);
+
+        return $value === '' ? null : $value;
+    }
+}

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -17,7 +17,7 @@ return [
         'android_push' => filter_var(env('BOOTSTRAP_ANDROID_PUSH_ENABLED', false), FILTER_VALIDATE_BOOL),
     ],
     'android_push' => [
-        'metadata_revision' => ($androidPushRevision = env('BOOTSTRAP_ANDROID_PUSH_METADATA_REVISION')) !== null ? (int) $androidPushRevision : null,
+        'metadata_revision' => env('BOOTSTRAP_ANDROID_PUSH_METADATA_REVISION'),
         'public_client_metadata' => [
             'api_key' => env('BOOTSTRAP_ANDROID_PUSH_PUBLIC_API_KEY'),
             'project_id' => env('BOOTSTRAP_ANDROID_PUSH_PUBLIC_PROJECT_ID'),

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -17,7 +17,7 @@ return [
         'android_push' => filter_var(env('BOOTSTRAP_ANDROID_PUSH_ENABLED', false), FILTER_VALIDATE_BOOL),
     ],
     'android_push' => [
-        'metadata_revision' => env('BOOTSTRAP_ANDROID_PUSH_METADATA_REVISION') !== null ? (int) env('BOOTSTRAP_ANDROID_PUSH_METADATA_REVISION') : null,
+        'metadata_revision' => ($androidPushRevision = env('BOOTSTRAP_ANDROID_PUSH_METADATA_REVISION')) !== null ? (int) $androidPushRevision : null,
         'public_client_metadata' => [
             'api_key' => env('BOOTSTRAP_ANDROID_PUSH_PUBLIC_API_KEY'),
             'project_id' => env('BOOTSTRAP_ANDROID_PUSH_PUBLIC_PROJECT_ID'),

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -14,5 +14,15 @@ return [
         'password_login' => filter_var(env('BOOTSTRAP_PASSWORD_LOGIN_ENABLED', true), FILTER_VALIDATE_BOOL),
         'passkey_login' => filter_var(env('BOOTSTRAP_PASSKEY_LOGIN_ENABLED', true), FILTER_VALIDATE_BOOL),
         'managed_android_enrollment' => filter_var(env('BOOTSTRAP_MANAGED_ANDROID_ENROLLMENT_ENABLED', false), FILTER_VALIDATE_BOOL),
+        'android_push' => filter_var(env('BOOTSTRAP_ANDROID_PUSH_ENABLED', false), FILTER_VALIDATE_BOOL),
+    ],
+    'android_push' => [
+        'metadata_revision' => env('BOOTSTRAP_ANDROID_PUSH_METADATA_REVISION') !== null ? (int) env('BOOTSTRAP_ANDROID_PUSH_METADATA_REVISION') : null,
+        'public_client_metadata' => [
+            'api_key' => env('BOOTSTRAP_ANDROID_PUSH_PUBLIC_API_KEY'),
+            'project_id' => env('BOOTSTRAP_ANDROID_PUSH_PUBLIC_PROJECT_ID'),
+            'application_id' => env('BOOTSTRAP_ANDROID_PUSH_PUBLIC_APPLICATION_ID'),
+            'sender_id' => env('BOOTSTRAP_ANDROID_PUSH_PUBLIC_SENDER_ID'),
+        ],
     ],
 ];

--- a/database/migrations/2026_05_23_130000_create_push_device_registrations_table.php
+++ b/database/migrations/2026_05_23_130000_create_push_device_registrations_table.php
@@ -1,0 +1,48 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('push_device_registrations', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignId('tenant_id')->constrained('tenant_keys')->cascadeOnDelete();
+            $table->foreignUuid('user_id')->constrained('users')->cascadeOnDelete();
+            $table->uuid('installation_id');
+            $table->string('platform', 32);
+            $table->string('provider', 32);
+            $table->string('device_name', 120);
+            $table->text('push_token_enc');
+            $table->char('token_last_eight', 8);
+            $table->string('last_lifecycle_event', 32);
+            $table->string('package_name', 120);
+            $table->string('package_version_name', 50)->nullable();
+            $table->unsignedInteger('package_version_code')->nullable();
+            $table->string('manufacturer', 120)->nullable();
+            $table->string('model', 120)->nullable();
+            $table->string('android_version', 30)->nullable();
+            $table->unsignedInteger('sdk_int')->nullable();
+            $table->string('bootstrap_version', 16);
+            $table->unsignedInteger('schema_version');
+            $table->unsignedInteger('push_metadata_revision');
+            $table->timestamps();
+
+            $table->unique(['tenant_id', 'user_id', 'installation_id'], 'push_device_registrations_tenant_user_installation_unique');
+            $table->index(['tenant_id', 'provider'], 'push_device_registrations_tenant_provider_index');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('push_device_registrations');
+    }
+};

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -103,6 +103,12 @@ BOOTSTRAP_MINIMUM_SUPPORTED_APP_BUILD=10400
 BOOTSTRAP_PASSWORD_LOGIN_ENABLED=true
 BOOTSTRAP_PASSKEY_LOGIN_ENABLED=true
 BOOTSTRAP_MANAGED_ANDROID_ENROLLMENT_ENABLED=false
+BOOTSTRAP_ANDROID_PUSH_ENABLED=true
+BOOTSTRAP_ANDROID_PUSH_METADATA_REVISION=3
+BOOTSTRAP_ANDROID_PUSH_PUBLIC_API_KEY=public-client-api-key-demo-1234567890
+BOOTSTRAP_ANDROID_PUSH_PUBLIC_PROJECT_ID=secpal-demo-push
+BOOTSTRAP_ANDROID_PUSH_PUBLIC_APPLICATION_ID=1:1234567890:android:abcdef1234567890
+BOOTSTRAP_ANDROID_PUSH_PUBLIC_SENDER_ID=1234567890
 BOOTSTRAP_RETRYABLE=true
 BOOTSTRAP_RETRY_AFTER_SECONDS=60
 
@@ -151,12 +157,58 @@ Expose the public runtime-discovery endpoint at `GET /v1/bootstrap` only after t
 - `APP_NAME` is used as the public instance display name unless `BOOTSTRAP_INSTANCE_DISPLAY_NAME` overrides it.
 - `BOOTSTRAP_MINIMUM_SUPPORTED_APP_VERSION` and `BOOTSTRAP_MINIMUM_SUPPORTED_APP_BUILD` are required. If either is missing, the endpoint fails closed with `500 BOOTSTRAP_STATE_INVALID` instead of falling back to SecPal-hosted defaults.
 - Set `BOOTSTRAP_PUBLIC_ENABLED=false` when the deployment should return the documented `503 BOOTSTRAP_CONFIG_UNAVAILABLE` response instead of serving bootstrap metadata.
-- `BOOTSTRAP_PASSWORD_LOGIN_ENABLED`, `BOOTSTRAP_PASSKEY_LOGIN_ENABLED`, and `BOOTSTRAP_MANAGED_ANDROID_ENROLLMENT_ENABLED` define the pre-login feature flags Android receives before login.
+- `BOOTSTRAP_PASSWORD_LOGIN_ENABLED`, `BOOTSTRAP_PASSKEY_LOGIN_ENABLED`, `BOOTSTRAP_MANAGED_ANDROID_ENROLLMENT_ENABLED`, and `BOOTSTRAP_ANDROID_PUSH_ENABLED` define the pre-login feature flags Android receives before login.
+- When `BOOTSTRAP_ANDROID_PUSH_ENABLED=true`, the public bootstrap response also exposes an `android_push` object with provider `fcm`, the deployment-defined `metadata_revision`, and the public Android client metadata fields required for runtime initialization.
+- When Android push bootstrap is enabled, `BOOTSTRAP_ANDROID_PUSH_METADATA_REVISION`, `BOOTSTRAP_ANDROID_PUSH_PUBLIC_API_KEY`, `BOOTSTRAP_ANDROID_PUSH_PUBLIC_PROJECT_ID`, `BOOTSTRAP_ANDROID_PUSH_PUBLIC_APPLICATION_ID`, and `BOOTSTRAP_ANDROID_PUSH_PUBLIC_SENDER_ID` are all required. Missing values fail closed with `500 BOOTSTRAP_STATE_INVALID`.
+- `BOOTSTRAP_ANDROID_PUSH_METADATA_REVISION` must be incremented whenever any public Android push client metadata changes so authenticated registrations with stale bootstrap state can be rejected deterministically.
+- Only public Android runtime metadata belongs here. Never place server credentials, service-account JSON, or private push delivery secrets in bootstrap configuration.
 
 Verify the deployed response with the canonical public origin:
 
 ```bash
 curl --fail 'https://customer-api.example/v1/bootstrap?client_platform=android&app_version=1.4.0&app_build=10400'
+```
+
+### Authenticated Android Push-Device Registration
+
+Authenticated Android clients register one stable installation identifier against the selected customer-hosted backend:
+
+- `PUT /v1/me/push-devices/{installationId}` creates or updates the authenticated app installation's push token and runtime metadata.
+- `DELETE /v1/me/push-devices/{installationId}` revokes the selected installation on logout, uninstall, or explicit cleanup.
+- Clients must echo the current `android_push.metadata_revision` from `GET /v1/bootstrap` in `runtime.push_metadata_revision`.
+- When the deployment disables Android push registration, the upsert endpoint fails closed with `409 ANDROID_PUSH_UNSUPPORTED`.
+- When the client presents stale bootstrap metadata, the upsert endpoint fails closed with `409 PUSH_RUNTIME_STATE_INVALID` and the expected revision details.
+
+Example registration request:
+
+```bash
+curl --fail-with-body \
+  -X PUT 'https://customer-api.example/v1/me/push-devices/a0b1c2d3-e4f5-4a67-89ab-0c1d2e3f4a5b' \
+  -H 'Authorization: Bearer YOUR_API_TOKEN' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "platform": "android",
+    "provider": "fcm",
+    "device_name": "SM-G556B reception tablet",
+    "push_token": "e6pGmJq4Yk12:APA91bH8mP7rQ6sT5uV4wX3yZ2aBcDeFgHiJkLmNoPqRsTuVwXyZ1234567890abcdef",
+    "lifecycle_event": "registered",
+    "app": {
+      "package_name": "app.secpal",
+      "package_version_name": "1.5.0",
+      "package_version_code": 10500
+    },
+    "device": {
+      "manufacturer": "Samsung",
+      "model": "SM-G556B",
+      "android_version": "16",
+      "sdk_int": 36
+    },
+    "runtime": {
+      "bootstrap_version": "v1",
+      "schema_version": 2,
+      "push_metadata_revision": 3
+    }
+  }'
 ```
 
 ---

--- a/docs/guides/production-deployment.md
+++ b/docs/guides/production-deployment.md
@@ -324,6 +324,12 @@ BOOTSTRAP_MINIMUM_SUPPORTED_APP_BUILD=10400
 BOOTSTRAP_PASSWORD_LOGIN_ENABLED=true
 BOOTSTRAP_PASSKEY_LOGIN_ENABLED=true
 BOOTSTRAP_MANAGED_ANDROID_ENROLLMENT_ENABLED=false
+BOOTSTRAP_ANDROID_PUSH_ENABLED=true
+BOOTSTRAP_ANDROID_PUSH_METADATA_REVISION=3
+BOOTSTRAP_ANDROID_PUSH_PUBLIC_API_KEY=public-client-api-key-demo-1234567890
+BOOTSTRAP_ANDROID_PUSH_PUBLIC_PROJECT_ID=secpal-demo-push
+BOOTSTRAP_ANDROID_PUSH_PUBLIC_APPLICATION_ID=1:1234567890:android:abcdef1234567890
+BOOTSTRAP_ANDROID_PUSH_PUBLIC_SENDER_ID=1234567890
 BOOTSTRAP_RETRYABLE=true
 BOOTSTRAP_RETRY_AFTER_SECONDS=60
 
@@ -380,6 +386,10 @@ LOG_LEVEL=warning
 ```
 
 `GET /v1/bootstrap` derives the canonical `api_base_url` from `APP_URL` and appends `/v1`. Keep `APP_URL` pointed at the externally reachable API origin, and set the `BOOTSTRAP_MINIMUM_SUPPORTED_APP_*` values before exposing the public bootstrap endpoint on a customer-hosted deployment.
+
+When `BOOTSTRAP_ANDROID_PUSH_ENABLED=true`, the same bootstrap response advertises authenticated Android push registration support and returns an `android_push` object with the deployment-defined `metadata_revision` plus the public Android runtime metadata needed by the SDK. Missing `BOOTSTRAP_ANDROID_PUSH_*` public values fail closed with `500 BOOTSTRAP_STATE_INVALID`; there is no fallback to SecPal-owned defaults.
+
+Authenticated Android clients register against the selected customer-hosted backend via `PUT /v1/me/push-devices/{installationId}` and revoke via `DELETE /v1/me/push-devices/{installationId}`. Clients must echo the current `android_push.metadata_revision` in `runtime.push_metadata_revision`; stale registrations are rejected with `409 PUSH_RUNTIME_STATE_INVALID`, and deployments with Android push disabled reject registration with `409 ANDROID_PUSH_UNSUPPORTED`.
 
 ## Client Configuration
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -16,6 +16,7 @@ use App\Http\Controllers\Api\V1\EmployeeQualificationController;
 use App\Http\Controllers\Api\V1\OnboardingController;
 use App\Http\Controllers\Api\V1\OrganizationalScopeController;
 use App\Http\Controllers\Api\V1\OrganizationalUnitController;
+use App\Http\Controllers\Api\V1\PushDeviceRegistrationController;
 use App\Http\Controllers\Api\V1\QualificationController;
 use App\Http\Controllers\Api\V1\RoleManagementController;
 use App\Http\Controllers\Api\V1\SiteAssignmentController;
@@ -104,6 +105,10 @@ Route::prefix('v1')->group(function () {
         Route::post('/auth/email/verification-notification', [AuthController::class, 'sendVerificationNotification'])
             ->middleware('throttle:6,1');
         Route::get('/me', [AuthController::class, 'me']);
+        Route::put('/me/push-devices/{installationId}', [PushDeviceRegistrationController::class, 'upsert'])
+            ->whereUuid('installationId');
+        Route::delete('/me/push-devices/{installationId}', [PushDeviceRegistrationController::class, 'destroy'])
+            ->whereUuid('installationId');
 
         Route::middleware('throttle:address-autocomplete')->group(function () {
             Route::get('/addresses/de/streets', [AddressController::class, 'streets']);

--- a/tests/Feature/Api/V1/BootstrapApiTest.php
+++ b/tests/Feature/Api/V1/BootstrapApiTest.php
@@ -23,6 +23,12 @@ beforeEach(function (): void {
         'bootstrap.features.password_login' => true,
         'bootstrap.features.passkey_login' => true,
         'bootstrap.features.managed_android_enrollment' => true,
+        'bootstrap.features.android_push' => true,
+        'bootstrap.android_push.metadata_revision' => 3,
+        'bootstrap.android_push.public_client_metadata.api_key' => 'public-client-api-key-demo-1234567890',
+        'bootstrap.android_push.public_client_metadata.project_id' => 'secpal-demo-push',
+        'bootstrap.android_push.public_client_metadata.application_id' => '1:1234567890:android:abcdef1234567890',
+        'bootstrap.android_push.public_client_metadata.sender_id' => '1234567890',
     ]);
 });
 
@@ -38,7 +44,7 @@ test('public bootstrap returns deployment-derived runtime metadata for a support
                 ],
                 'compatibility' => [
                     'bootstrap_version' => 'v1',
-                    'schema_version' => 1,
+                    'schema_version' => 2,
                     'minimum_supported_app_version' => '1.4.0',
                     'minimum_supported_app_build' => 10400,
                 ],
@@ -46,9 +52,29 @@ test('public bootstrap returns deployment-derived runtime metadata for a support
                     'password_login' => true,
                     'passkey_login' => true,
                     'managed_android_enrollment' => true,
+                    'android_push' => true,
+                ],
+                'android_push' => [
+                    'provider' => 'fcm',
+                    'metadata_revision' => 3,
+                    'public_client_metadata' => [
+                        'api_key' => 'public-client-api-key-demo-1234567890',
+                        'project_id' => 'secpal-demo-push',
+                        'application_id' => '1:1234567890:android:abcdef1234567890',
+                        'sender_id' => '1234567890',
+                    ],
                 ],
             ],
         ]);
+});
+
+test('public bootstrap omits android push metadata when authenticated push registration is disabled', function (): void {
+    config(['bootstrap.features.android_push' => false]);
+
+    getJson('/v1/bootstrap?client_platform=android&app_version=1.4.0&app_build=10400')
+        ->assertOk()
+        ->assertJsonPath('data.features.android_push', false)
+        ->assertJsonMissingPath('data.android_push');
 });
 
 test('public bootstrap rejects android clients below the configured minimum version', function (): void {
@@ -109,6 +135,26 @@ test('public bootstrap fails closed when required bootstrap metadata is missing'
                     'instance.display_name',
                     'compatibility.minimum_supported_app_version',
                     'compatibility.minimum_supported_app_build',
+                ],
+            ],
+        ]);
+});
+
+test('public bootstrap fails closed when android push metadata is enabled but incomplete', function (): void {
+    config([
+        'bootstrap.android_push.metadata_revision' => null,
+        'bootstrap.android_push.public_client_metadata.api_key' => null,
+    ]);
+
+    getJson('/v1/bootstrap?client_platform=android&app_version=1.4.0&app_build=10400')
+        ->assertInternalServerError()
+        ->assertExactJson([
+            'message' => 'Public bootstrap configuration is incomplete for this deployment.',
+            'code' => 'BOOTSTRAP_STATE_INVALID',
+            'details' => [
+                'missing_fields' => [
+                    'android_push.metadata_revision',
+                    'android_push.public_client_metadata.api_key',
                 ],
             ],
         ]);

--- a/tests/Feature/Api/V1/BootstrapApiTest.php
+++ b/tests/Feature/Api/V1/BootstrapApiTest.php
@@ -160,6 +160,24 @@ test('public bootstrap fails closed when android push metadata is enabled but in
         ]);
 });
 
+test('public bootstrap fails closed when android push metadata revision is not a strict positive integer', function (): void {
+    config([
+        'bootstrap.android_push.metadata_revision' => '3.5',
+    ]);
+
+    getJson('/v1/bootstrap?client_platform=android&app_version=1.4.0&app_build=10400')
+        ->assertInternalServerError()
+        ->assertExactJson([
+            'message' => 'Public bootstrap configuration is incomplete for this deployment.',
+            'code' => 'BOOTSTRAP_STATE_INVALID',
+            'details' => [
+                'missing_fields' => [
+                    'android_push.metadata_revision (present but invalid; must be a positive integer)',
+                ],
+            ],
+        ]);
+});
+
 test('public bootstrap fails closed when APP_URL contains a non-root path prefix', function (): void {
     config(['app.url' => 'https://api.secpal.dev/api']);
 

--- a/tests/Feature/Api/V1/PushDeviceRegistrationApiTest.php
+++ b/tests/Feature/Api/V1/PushDeviceRegistrationApiTest.php
@@ -1,0 +1,330 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+use App\Models\TenantKey;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\deleteJson;
+use function Pest\Laravel\putJson;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function (): void {
+    incrementTestKekCounter();
+    TenantKey::setKekPath(getTestKekPath());
+    TenantKey::generateKek();
+
+    config([
+        'bootstrap.features.android_push' => true,
+        'bootstrap.android_push.metadata_revision' => 3,
+        'bootstrap.android_push.public_client_metadata.api_key' => 'public-client-api-key-demo-1234567890',
+        'bootstrap.android_push.public_client_metadata.project_id' => 'secpal-demo-push',
+        'bootstrap.android_push.public_client_metadata.application_id' => '1:1234567890:android:abcdef1234567890',
+        'bootstrap.android_push.public_client_metadata.sender_id' => '1234567890',
+    ]);
+});
+
+afterEach(function (): void {
+    cleanupTestKekFile();
+    TenantKey::setKekPath(null);
+});
+
+/**
+ * @return array{tenant: TenantKey, user: User}
+ */
+function createPushDeviceContext(): array
+{
+    $tenant = TenantKey::create(TenantKey::generateEnvelopeKeys());
+    $user = User::factory()->create(['tenant_id' => $tenant->id]);
+
+    return [
+        'tenant' => $tenant,
+        'user' => $user,
+    ];
+}
+
+function pushDevicePayload(string $pushToken, string $lifecycleEvent = 'registered'): array
+{
+    return [
+        'platform' => 'android',
+        'provider' => 'fcm',
+        'device_name' => 'SM-G556B reception tablet',
+        'push_token' => $pushToken,
+        'lifecycle_event' => $lifecycleEvent,
+        'app' => [
+            'package_name' => 'app.secpal',
+            'package_version_name' => '1.5.0',
+            'package_version_code' => 10500,
+        ],
+        'device' => [
+            'manufacturer' => 'Samsung',
+            'model' => 'SM-G556B',
+            'android_version' => '16',
+            'sdk_int' => 36,
+        ],
+        'runtime' => [
+            'bootstrap_version' => 'v1',
+            'schema_version' => 2,
+            'push_metadata_revision' => 3,
+        ],
+    ];
+}
+
+test('authenticated user can create android push device registration', function (): void {
+    ['tenant' => $tenant, 'user' => $user] = createPushDeviceContext();
+
+    actingAs($user, 'sanctum');
+
+    $installationId = 'a0b1c2d3-e4f5-4a67-89ab-0c1d2e3f4a5b';
+
+    $response = putJson('/v1/me/push-devices/'.$installationId, pushDevicePayload(
+        'e6pGmJq4Yk12:APA91bH8mP7rQ6sT5uV4wX3yZ2aBcDeFgHiJkLmNoPqRsTuVwXyZ1234567890abcdef'
+    ));
+
+    $response->assertCreated()
+        ->assertJsonPath('data.installation_id', $installationId)
+        ->assertJsonPath('data.platform', 'android')
+        ->assertJsonPath('data.provider', 'fcm')
+        ->assertJsonPath('data.device_name', 'SM-G556B reception tablet')
+        ->assertJsonPath('data.token_last_eight', '90abcdef')
+        ->assertJsonPath('data.last_lifecycle_event', 'registered')
+        ->assertJsonPath('data.runtime.bootstrap_version', 'v1')
+        ->assertJsonPath('data.runtime.schema_version', 2)
+        ->assertJsonPath('data.runtime.push_metadata_revision', 3)
+        ->assertJsonStructure([
+            'data' => [
+                'installation_id',
+                'platform',
+                'provider',
+                'device_name',
+                'token_last_eight',
+                'last_lifecycle_event',
+                'app' => [
+                    'package_name',
+                    'package_version_name',
+                    'package_version_code',
+                ],
+                'device' => [
+                    'manufacturer',
+                    'model',
+                    'android_version',
+                    'sdk_int',
+                ],
+                'runtime' => [
+                    'bootstrap_version',
+                    'schema_version',
+                    'push_metadata_revision',
+                ],
+                'created_at',
+                'updated_at',
+            ],
+        ]);
+
+    $this->assertDatabaseHas('push_device_registrations', [
+        'tenant_id' => $tenant->id,
+        'user_id' => $user->id,
+        'installation_id' => $installationId,
+        'platform' => 'android',
+        'provider' => 'fcm',
+        'device_name' => 'SM-G556B reception tablet',
+        'token_last_eight' => '90abcdef',
+        'last_lifecycle_event' => 'registered',
+        'package_name' => 'app.secpal',
+        'package_version_name' => '1.5.0',
+        'package_version_code' => 10500,
+        'bootstrap_version' => 'v1',
+        'schema_version' => 2,
+        'push_metadata_revision' => 3,
+    ]);
+});
+
+test('repeating put updates the existing android push device registration', function (): void {
+    ['tenant' => $tenant, 'user' => $user] = createPushDeviceContext();
+
+    actingAs($user, 'sanctum');
+
+    $installationId = 'a0b1c2d3-e4f5-4a67-89ab-0c1d2e3f4a5b';
+
+    putJson('/v1/me/push-devices/'.$installationId, pushDevicePayload(
+        'e6pGmJq4Yk12:APA91bH8mP7rQ6sT5uV4wX3yZ2aBcDeFgHiJkLmNoPqRsTuVwXyZ1234567890abcdef'
+    ))->assertCreated();
+
+    $response = putJson('/v1/me/push-devices/'.$installationId, [
+        ...pushDevicePayload(
+            'x9y8z7w6v5u4:APA91bHfedcba0987654321QwErTyUiOpAsDfGhJkLmNoPqRsTuVwXyZfedcba09',
+            'token_rotated',
+        ),
+        'app' => [
+            'package_name' => 'app.secpal',
+            'package_version_name' => '1.5.1',
+            'package_version_code' => 10501,
+        ],
+    ]);
+
+    $response->assertOk()
+        ->assertJsonPath('data.installation_id', $installationId)
+        ->assertJsonPath('data.token_last_eight', 'fedcba09')
+        ->assertJsonPath('data.last_lifecycle_event', 'token_rotated')
+        ->assertJsonPath('data.app.package_version_name', '1.5.1')
+        ->assertJsonPath('data.app.package_version_code', 10501);
+
+    $this->assertDatabaseHas('push_device_registrations', [
+        'tenant_id' => $tenant->id,
+        'user_id' => $user->id,
+        'installation_id' => $installationId,
+        'token_last_eight' => 'fedcba09',
+        'last_lifecycle_event' => 'token_rotated',
+        'package_version_name' => '1.5.1',
+        'package_version_code' => 10501,
+    ]);
+
+    expect(DB::table('push_device_registrations')
+        ->where('tenant_id', $tenant->id)
+        ->where('user_id', $user->id)
+        ->where('installation_id', $installationId)
+        ->count())->toBe(1);
+});
+
+test('same installation id can be registered independently in another tenant', function (): void {
+    ['tenant' => $firstTenant, 'user' => $firstUser] = createPushDeviceContext();
+    ['tenant' => $secondTenant, 'user' => $secondUser] = createPushDeviceContext();
+
+    $installationId = 'a0b1c2d3-e4f5-4a67-89ab-0c1d2e3f4a5b';
+
+    actingAs($firstUser, 'sanctum');
+    putJson('/v1/me/push-devices/'.$installationId, pushDevicePayload(
+        'e6pGmJq4Yk12:APA91bH8mP7rQ6sT5uV4wX3yZ2aBcDeFgHiJkLmNoPqRsTuVwXyZ1234567890abcdef'
+    ))->assertCreated();
+
+    actingAs($secondUser, 'sanctum');
+    putJson('/v1/me/push-devices/'.$installationId, pushDevicePayload(
+        'n1m2b3v4c5x6:APA91bH0a1b2c3d4e5f6g7h8i9j0kLmNoPqRsTuVwXyZ76543210ghijkl90mnopqr'
+    ))->assertCreated();
+
+    $this->assertDatabaseHas('push_device_registrations', [
+        'tenant_id' => $firstTenant->id,
+        'user_id' => $firstUser->id,
+        'installation_id' => $installationId,
+    ]);
+
+    $this->assertDatabaseHas('push_device_registrations', [
+        'tenant_id' => $secondTenant->id,
+        'user_id' => $secondUser->id,
+        'installation_id' => $installationId,
+    ]);
+});
+
+test('authenticated user can revoke their android push device registration', function (): void {
+    ['tenant' => $tenant, 'user' => $user] = createPushDeviceContext();
+
+    actingAs($user, 'sanctum');
+
+    $installationId = 'a0b1c2d3-e4f5-4a67-89ab-0c1d2e3f4a5b';
+
+    putJson('/v1/me/push-devices/'.$installationId, pushDevicePayload(
+        'e6pGmJq4Yk12:APA91bH8mP7rQ6sT5uV4wX3yZ2aBcDeFgHiJkLmNoPqRsTuVwXyZ1234567890abcdef'
+    ))->assertCreated();
+
+    deleteJson('/v1/me/push-devices/'.$installationId)
+        ->assertOk()
+        ->assertJsonPath('data.installation_id', $installationId)
+        ->assertJsonStructure([
+            'data' => [
+                'installation_id',
+                'revoked_at',
+            ],
+        ]);
+
+    $this->assertDatabaseMissing('push_device_registrations', [
+        'tenant_id' => $tenant->id,
+        'user_id' => $user->id,
+        'installation_id' => $installationId,
+    ]);
+});
+
+test('revoking a missing android push device registration returns not found', function (): void {
+    ['user' => $user] = createPushDeviceContext();
+
+    actingAs($user, 'sanctum');
+
+    deleteJson('/v1/me/push-devices/a0b1c2d3-e4f5-4a67-89ab-0c1d2e3f4a5b')
+        ->assertNotFound();
+});
+
+test('android push device registration is rejected when the deployment disables the feature', function (): void {
+    ['user' => $user] = createPushDeviceContext();
+
+    config(['bootstrap.features.android_push' => false]);
+
+    actingAs($user, 'sanctum');
+
+    putJson('/v1/me/push-devices/a0b1c2d3-e4f5-4a67-89ab-0c1d2e3f4a5b', pushDevicePayload(
+        'e6pGmJq4Yk12:APA91bH8mP7rQ6sT5uV4wX3yZ2aBcDeFgHiJkLmNoPqRsTuVwXyZ1234567890abcdef'
+    ))
+        ->assertStatus(409)
+        ->assertExactJson([
+            'message' => 'This deployment does not accept authenticated Android push-device registrations.',
+            'code' => 'ANDROID_PUSH_UNSUPPORTED',
+            'details' => [
+                'feature_flag' => 'android_push',
+                'provider' => 'fcm',
+                'retryable' => false,
+            ],
+        ]);
+});
+
+test('android push device registration rejects stale bootstrap metadata', function (): void {
+    ['user' => $user] = createPushDeviceContext();
+
+    actingAs($user, 'sanctum');
+
+    putJson('/v1/me/push-devices/a0b1c2d3-e4f5-4a67-89ab-0c1d2e3f4a5b', [
+        ...pushDevicePayload(
+            'e6pGmJq4Yk12:APA91bH8mP7rQ6sT5uV4wX3yZ2aBcDeFgHiJkLmNoPqRsTuVwXyZ1234567890abcdef'
+        ),
+        'runtime' => [
+            'bootstrap_version' => 'v1',
+            'schema_version' => 2,
+            'push_metadata_revision' => 2,
+        ],
+    ])
+        ->assertStatus(409)
+        ->assertExactJson([
+            'message' => 'Android push runtime metadata changed; refresh bootstrap before retrying this registration.',
+            'code' => 'PUSH_RUNTIME_STATE_INVALID',
+            'details' => [
+                'bootstrap_version' => 'v1',
+                'schema_version' => 2,
+                'provider' => 'fcm',
+                'provided_push_metadata_revision' => 2,
+                'expected_push_metadata_revision' => 3,
+            ],
+        ]);
+});
+
+test('android push device registration validates malformed payloads', function (): void {
+    ['user' => $user] = createPushDeviceContext();
+
+    actingAs($user, 'sanctum');
+
+    putJson('/v1/me/push-devices/a0b1c2d3-e4f5-4a67-89ab-0c1d2e3f4a5b', [
+        ...pushDevicePayload('too-short'),
+        'app' => [
+            'package_name' => 'com.example.invalid',
+            'package_version_name' => '1.5.0',
+            'package_version_code' => 10500,
+        ],
+    ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors([
+            'push_token',
+            'app.package_name',
+        ]);
+});

--- a/tests/Feature/Api/V1/PushDeviceRegistrationApiTest.php
+++ b/tests/Feature/Api/V1/PushDeviceRegistrationApiTest.php
@@ -143,6 +143,66 @@ test('authenticated user can create android push device registration', function 
         'schema_version' => 2,
         'push_metadata_revision' => 3,
     ]);
+
+    $storedToken = DB::table('push_device_registrations')
+        ->where('tenant_id', $tenant->id)
+        ->where('user_id', $user->id)
+        ->where('installation_id', $installationId)
+        ->value('push_token_enc');
+
+    expect($storedToken)->toBeString()->not->toBe(
+        'e6pGmJq4Yk12:APA91bH8mP7rQ6sT5uV4wX3yZ2aBcDeFgHiJkLmNoPqRsTuVwXyZ1234567890abcdef'
+    );
+
+    $decodedToken = json_decode($storedToken, true);
+
+    expect($decodedToken)->toBeArray()
+        ->toHaveKeys(['ciphertext', 'nonce'])
+        ->and($decodedToken['ciphertext'])->toBeString()->not->toBe('')
+        ->and($decodedToken['nonce'])->toBeString()->not->toBe('');
+});
+
+test('android push device registration accepts integer-like numeric strings', function (): void {
+    ['tenant' => $tenant, 'user' => $user] = createPushDeviceContext();
+
+    actingAs($user, 'sanctum');
+
+    $installationId = 'a0b1c2d3-e4f5-4a67-89ab-0c1d2e3f4a5b';
+
+    putJson('/v1/me/push-devices/'.$installationId, [
+        ...pushDevicePayload('e6pGmJq4Yk12:APA91bH8mP7rQ6sT5uV4wX3yZ2aBcDeFgHiJkLmNoPqRsTuVwXyZ1234567890abcdef'),
+        'app' => [
+            'package_name' => 'app.secpal',
+            'package_version_name' => '1.5.0',
+            'package_version_code' => '10500',
+        ],
+        'device' => [
+            'manufacturer' => 'Samsung',
+            'model' => 'SM-G556B',
+            'android_version' => '16',
+            'sdk_int' => '36',
+        ],
+        'runtime' => [
+            'bootstrap_version' => 'v1',
+            'schema_version' => '2',
+            'push_metadata_revision' => '3',
+        ],
+    ])
+        ->assertCreated()
+        ->assertJsonPath('data.app.package_version_code', 10500)
+        ->assertJsonPath('data.device.sdk_int', 36)
+        ->assertJsonPath('data.runtime.schema_version', 2)
+        ->assertJsonPath('data.runtime.push_metadata_revision', 3);
+
+    $this->assertDatabaseHas('push_device_registrations', [
+        'tenant_id' => $tenant->id,
+        'user_id' => $user->id,
+        'installation_id' => $installationId,
+        'package_version_code' => 10500,
+        'sdk_int' => 36,
+        'schema_version' => 2,
+        'push_metadata_revision' => 3,
+    ]);
 });
 
 test('repeating put updates the existing android push device registration', function (): void {
@@ -325,6 +385,28 @@ test('android push device registration rejects stale bootstrap metadata', functi
                 'provider' => 'fcm',
                 'provided_push_metadata_revision' => 2,
                 'expected_push_metadata_revision' => 3,
+            ],
+        ]);
+});
+
+test('android push device registration fails closed when android push metadata is invalid', function (): void {
+    ['user' => $user] = createPushDeviceContext();
+
+    config(['bootstrap.android_push.metadata_revision' => '3.5']);
+
+    actingAs($user, 'sanctum');
+
+    putJson('/v1/me/push-devices/a0b1c2d3-e4f5-4a67-89ab-0c1d2e3f4a5b', pushDevicePayload(
+        'e6pGmJq4Yk12:APA91bH8mP7rQ6sT5uV4wX3yZ2aBcDeFgHiJkLmNoPqRsTuVwXyZ1234567890abcdef'
+    ))
+        ->assertInternalServerError()
+        ->assertExactJson([
+            'message' => 'Public bootstrap configuration is incomplete for this deployment.',
+            'code' => 'BOOTSTRAP_STATE_INVALID',
+            'details' => [
+                'missing_fields' => [
+                    'android_push.metadata_revision (present but invalid; must be a positive integer)',
+                ],
             ],
         ]);
 });

--- a/tests/Feature/Api/V1/PushDeviceRegistrationApiTest.php
+++ b/tests/Feature/Api/V1/PushDeviceRegistrationApiTest.php
@@ -280,6 +280,26 @@ test('android push device registration is rejected when the deployment disables 
         ]);
 });
 
+test('android push device revocation is rejected when the deployment disables the feature', function (): void {
+    ['user' => $user] = createPushDeviceContext();
+
+    config(['bootstrap.features.android_push' => false]);
+
+    actingAs($user, 'sanctum');
+
+    deleteJson('/v1/me/push-devices/a0b1c2d3-e4f5-4a67-89ab-0c1d2e3f4a5b')
+        ->assertStatus(409)
+        ->assertExactJson([
+            'message' => 'This deployment does not accept authenticated Android push-device registrations.',
+            'code' => 'ANDROID_PUSH_UNSUPPORTED',
+            'details' => [
+                'feature_flag' => 'android_push',
+                'provider' => 'fcm',
+                'retryable' => false,
+            ],
+        ]);
+});
+
 test('android push device registration rejects stale bootstrap metadata', function (): void {
     ['user' => $user] = createPushDeviceContext();
 


### PR DESCRIPTION
## Summary
- extend `GET /v1/bootstrap` with deployment-defined Android push runtime metadata, schema version `2`, and the `android_push` feature flag
- add tenant-safe encrypted Android push-device registration and revocation endpoints at `PUT/DELETE /v1/me/push-devices/{installationId}`
- document the new `BOOTSTRAP_ANDROID_PUSH_*` operator settings and cover success/failure paths with focused Pest tests

## Validation
- `vendor/bin/pint --dirty`
- `vendor/bin/phpstan analyse app/Http/Controllers/Api/V1/BootstrapController.php app/Models/PushDeviceRegistration.php app/Services/PushDeviceRegistrationService.php app/Support/AndroidPushRuntimeConfiguration.php`
- `php artisan test tests/Feature/Api/V1/BootstrapApiTest.php tests/Feature/Api/V1/PushDeviceRegistrationApiTest.php`

## References
- Parent epic: #1121
- Closes #1123

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new authenticated endpoints and a new encrypted-at-rest persistence path for push tokens, plus a bootstrap schema bump; misconfiguration or validation drift could block mobile registration/login flows.
> 
> **Overview**
> Extends `GET /v1/bootstrap` to **schema version 2** and advertises Android push support via a new `features.android_push` flag, optionally returning an `android_push` metadata object sourced from new `BOOTSTRAP_ANDROID_PUSH_*` settings and failing closed when that config is incomplete/invalid.
> 
> Adds authenticated Android push device registration and revocation via `PUT`/`DELETE /v1/me/push-devices/{installationId}`, including strict payload validation, deterministic `409` handling for disabled/stale runtime metadata revisions, and tenant-scoped encrypted storage of push tokens in a new `push_device_registrations` table; updates docs and Pest coverage accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c67c4dab4fcc1482dfcf5c68a330f4c1c180d27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->