### PR TITLE
feat(api): add customer-owned android push delivery primitives

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,14 @@ APP_URL=https://api.secpal.dev
 # BOOTSTRAP_MANAGED_ANDROID_ENROLLMENT_ENABLED=false
 # BOOTSTRAP_RETRYABLE=true
 # BOOTSTRAP_RETRY_AFTER_SECONDS=60
+# Customer-owned Android push delivery stays backend-only; never expose these through GET /v1/bootstrap.
+# ANDROID_PUSH_FCM_PROJECT_ID=customer-owned-push
+# ANDROID_PUSH_FCM_CLIENT_EMAIL=firebase-adminsdk-abc123@customer-owned-push.iam.gserviceaccount.com
+# ANDROID_PUSH_FCM_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n"
+# ANDROID_PUSH_FCM_TOKEN_URI=https://oauth2.googleapis.com/token
+# ANDROID_PUSH_FCM_API_BASE_URL=https://fcm.googleapis.com
+# ANDROID_PUSH_FCM_CONNECT_TIMEOUT=5
+# ANDROID_PUSH_FCM_TIMEOUT=10
 FRONTEND_URL=https://app.secpal.dev
 # Optional override for native Android passkey origin validation when a
 # non-canonical signing key is used outside the official SecPal release path.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - added the public `GET /v1/bootstrap` runtime-discovery endpoint for Android pre-login instance validation, deriving the canonical `api_base_url` from `APP_URL`, failing closed with documented `500`/`503`/`426` bootstrap responses when deployment metadata is incomplete or incompatible, and covering the success/failure slices with focused Pest tests plus operator bootstrap configuration docs (refs `api#1115`)
 - added authenticated Android push-device registration on the customer-hosted backend via `PUT/DELETE /v1/me/push-devices/{installationId}`, including tenant-safe encrypted token storage, bootstrap-advertised public Android push runtime metadata on `GET /v1/bootstrap`, deterministic `409` fail-closed handling for disabled or stale push runtime state, and focused Pest coverage plus deployment/operator documentation for the new `BOOTSTRAP_ANDROID_PUSH_*` settings (refs `api#1123`)
+- added customer-owned Android push delivery primitives for the customer-hosted backend, including backend-only `ANDROID_PUSH_FCM_*` operator configuration, direct FCM HTTP v1 send and queue job support, safe stale-token cleanup on invalid delivery outcomes, bootstrap non-leak coverage for private provider credentials, and deployment documentation that removes any dependency on SecPal-operated push routing for customer-owned installations (refs `api#1122`)
 
 ### Changed
 

--- a/app/Casts/EncryptedWithDek.php
+++ b/app/Casts/EncryptedWithDek.php
@@ -9,6 +9,7 @@
 namespace App\Casts;
 
 use App\Exceptions\CorruptedEncryptedAttributeException;
+use App\Exceptions\TenantKeyDecryptionException;
 use App\Models\TenantKey;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Database\Eloquent\Model;
@@ -65,11 +66,7 @@ class EncryptedWithDek implements CastsAttributes
 
         try {
             return $tenant->decrypt($ciphertext, $nonce);
-        } catch (\RuntimeException $exception) {
-            if ($exception->getMessage() !== 'Failed to decrypt data') {
-                throw $exception;
-            }
-
+        } catch (TenantKeyDecryptionException $exception) {
             throw new CorruptedEncryptedAttributeException(
                 "Failed to decrypt encrypted data for {$key}",
                 previous: $exception,

--- a/app/Casts/EncryptedWithDek.php
+++ b/app/Casts/EncryptedWithDek.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * SPDX-FileCopyrightText: 2025 SecPal Contributors
+ * SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */

--- a/app/Casts/EncryptedWithDek.php
+++ b/app/Casts/EncryptedWithDek.php
@@ -39,7 +39,7 @@ class EncryptedWithDek implements CastsAttributes
         }
 
         if (! is_string($value)) {
-            throw new \RuntimeException("Expected string value for {$key}, got ".gettype($value));
+            throw new CorruptedEncryptedAttributeException("Expected string value for {$key}, got ".gettype($value));
         }
 
         // Decode JSON structure: {ciphertext: base64, nonce: base64}

--- a/app/Casts/EncryptedWithDek.php
+++ b/app/Casts/EncryptedWithDek.php
@@ -8,6 +8,7 @@
 
 namespace App\Casts;
 
+use App\Exceptions\CorruptedEncryptedAttributeException;
 use App\Models\TenantKey;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Database\Eloquent\Model;
@@ -44,18 +45,18 @@ class EncryptedWithDek implements CastsAttributes
         // Decode JSON structure: {ciphertext: base64, nonce: base64}
         $data = json_decode($value, true);
         if (! is_array($data) || ! isset($data['ciphertext'], $data['nonce'])) {
-            throw new \RuntimeException("Invalid encrypted data format for {$key}");
+            throw new CorruptedEncryptedAttributeException("Invalid encrypted data format for {$key}");
         }
 
         if (! is_string($data['ciphertext']) || ! is_string($data['nonce'])) {
-            throw new \RuntimeException("Invalid ciphertext/nonce types for {$key}");
+            throw new CorruptedEncryptedAttributeException("Invalid ciphertext/nonce types for {$key}");
         }
 
         $ciphertext = base64_decode($data['ciphertext'], true);
         $nonce = base64_decode($data['nonce'], true);
 
         if ($ciphertext === false || $nonce === false) {
-            throw new \RuntimeException("Failed to decode base64 data for {$key}");
+            throw new CorruptedEncryptedAttributeException("Failed to decode base64 data for {$key}");
         }
 
         // Get tenant and decrypt

--- a/app/Casts/EncryptedWithDek.php
+++ b/app/Casts/EncryptedWithDek.php
@@ -63,7 +63,18 @@ class EncryptedWithDek implements CastsAttributes
         /** @var TenantKey $tenant */
         $tenant = TenantKey::findOrFail($attributes['tenant_id']);
 
-        return $tenant->decrypt($ciphertext, $nonce);
+        try {
+            return $tenant->decrypt($ciphertext, $nonce);
+        } catch (\RuntimeException $exception) {
+            if ($exception->getMessage() !== 'Failed to decrypt data') {
+                throw $exception;
+            }
+
+            throw new CorruptedEncryptedAttributeException(
+                "Failed to decrypt encrypted data for {$key}",
+                previous: $exception,
+            );
+        }
     }
 
     /**

--- a/app/Exceptions/CorruptedEncryptedAttributeException.php
+++ b/app/Exceptions/CorruptedEncryptedAttributeException.php
@@ -1,0 +1,12 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace App\Exceptions;
+
+use RuntimeException;
+
+final class CorruptedEncryptedAttributeException extends RuntimeException {}

--- a/app/Exceptions/TenantKeyDecryptionException.php
+++ b/app/Exceptions/TenantKeyDecryptionException.php
@@ -1,0 +1,12 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace App\Exceptions;
+
+use RuntimeException;
+
+final class TenantKeyDecryptionException extends RuntimeException {}

--- a/app/Jobs/DeliverAndroidPushMessage.php
+++ b/app/Jobs/DeliverAndroidPushMessage.php
@@ -22,7 +22,7 @@ final class DeliverAndroidPushMessage implements ShouldQueue
     use Queueable;
     use SerializesModels;
 
-    public int $tries = 3;
+    public int $tries = 4;
 
     public int $timeout = 30;
 

--- a/app/Jobs/DeliverAndroidPushMessage.php
+++ b/app/Jobs/DeliverAndroidPushMessage.php
@@ -9,6 +9,7 @@ namespace App\Jobs;
 
 use App\Models\PushDeviceRegistration;
 use App\Services\AndroidPushDeliveryService;
+use App\Support\AndroidPushDeliveryConfiguration;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -44,8 +45,14 @@ final class DeliverAndroidPushMessage implements ShouldQueue
         return [10, 60, 300];
     }
 
-    public function handle(AndroidPushDeliveryService $deliveryService): void
+    public function handle(AndroidPushDeliveryService $deliveryService, AndroidPushDeliveryConfiguration $configuration): void
     {
+        if ($configuration->missingFields() !== []) {
+            $this->fail('Android push delivery is not configured for this deployment.');
+
+            return;
+        }
+
         $registration = PushDeviceRegistration::query()->find($this->pushDeviceRegistrationId);
 
         if (! $registration instanceof PushDeviceRegistration) {

--- a/app/Jobs/DeliverAndroidPushMessage.php
+++ b/app/Jobs/DeliverAndroidPushMessage.php
@@ -47,15 +47,15 @@ final class DeliverAndroidPushMessage implements ShouldQueue
 
     public function handle(AndroidPushDeliveryService $deliveryService, AndroidPushDeliveryConfiguration $configuration): void
     {
-        if ($configuration->missingFields() !== []) {
-            $this->fail('Android push delivery is not configured for this deployment.');
-
-            return;
-        }
-
         $registration = PushDeviceRegistration::query()->find($this->pushDeviceRegistrationId);
 
         if (! $registration instanceof PushDeviceRegistration) {
+            return;
+        }
+
+        if ($configuration->missingFields() !== []) {
+            $this->fail('Android push delivery is not configured for this deployment.');
+
             return;
         }
 

--- a/app/Jobs/DeliverAndroidPushMessage.php
+++ b/app/Jobs/DeliverAndroidPushMessage.php
@@ -1,0 +1,57 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace App\Jobs;
+
+use App\Models\PushDeviceRegistration;
+use App\Services\AndroidPushDeliveryService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+final class DeliverAndroidPushMessage implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $tries = 3;
+
+    public int $timeout = 30;
+
+    /**
+     * @param  array<string, string>  $data
+     */
+    public function __construct(
+        public string $pushDeviceRegistrationId,
+        public string $title,
+        public string $body,
+        public array $data = [],
+    ) {}
+
+    /**
+     * @return array<int, int>
+     */
+    public function backoff(): array
+    {
+        return [10, 60, 300];
+    }
+
+    public function handle(AndroidPushDeliveryService $deliveryService): void
+    {
+        $registration = PushDeviceRegistration::query()->find($this->pushDeviceRegistrationId);
+
+        if (! $registration instanceof PushDeviceRegistration) {
+            return;
+        }
+
+        $deliveryService->send($registration, $this->title, $this->body, $this->data);
+    }
+}

--- a/app/Models/PushDeviceRegistration.php
+++ b/app/Models/PushDeviceRegistration.php
@@ -35,6 +35,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property \Illuminate\Support\Carbon $created_at
  * @property \Illuminate\Support\Carbon $updated_at
  * @property-write string|null $push_token_plain
+ * @property-read string|null $push_token_dec
  */
 class PushDeviceRegistration extends Model
 {
@@ -104,15 +105,16 @@ class PushDeviceRegistration extends Model
         return $this->pushTokenPlain;
     }
 
-    public function deliveryToken(): ?string
+    public function getPushTokenDecAttribute(): ?string
     {
         $token = $this->getAttributeValue('push_token_enc');
 
-        if (! is_string($token) || trim($token) === '') {
-            return null;
-        }
+        return (is_string($token) && trim($token) !== '') ? $token : null;
+    }
 
-        return $token;
+    public function deliveryToken(): ?string
+    {
+        return $this->push_token_dec;
     }
 
     /**

--- a/app/Models/PushDeviceRegistration.php
+++ b/app/Models/PushDeviceRegistration.php
@@ -104,6 +104,17 @@ class PushDeviceRegistration extends Model
         return $this->pushTokenPlain;
     }
 
+    public function deliveryToken(): ?string
+    {
+        $token = $this->getAttributeValue('push_token_enc');
+
+        if (! is_string($token) || trim($token) === '') {
+            return null;
+        }
+
+        return $token;
+    }
+
     /**
      * @return BelongsTo<TenantKey, $this>
      */

--- a/app/Models/TenantKey.php
+++ b/app/Models/TenantKey.php
@@ -11,6 +11,7 @@ namespace App\Models;
 use App\Exceptions\TenantKeyDecryptionException;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use SodiumException;
 
 /**
  * TenantKey model for managing per-tenant envelope encryption keys.
@@ -581,14 +582,21 @@ class TenantKey extends Model
     /**
      * Decrypt ciphertext using the tenant's DEK.
      *
-     * @throws TenantKeyDecryptionException if decryption fails
+     * @throws \RuntimeException if tenant key material cannot be loaded
+     * @throws TenantKeyDecryptionException if ciphertext authentication fails
+     * @throws \RuntimeException if tenant key material cannot be loaded
      */
     public function decrypt(string $ciphertext, string $nonce): string
     {
         $dek = $this->unwrapDek();
-        $plaintext = sodium_crypto_secretbox_open($ciphertext, $nonce, $dek);
 
-        sodium_memzero($dek);
+        try {
+            $plaintext = sodium_crypto_secretbox_open($ciphertext, $nonce, $dek);
+        } catch (SodiumException $exception) {
+            throw new TenantKeyDecryptionException('Failed to decrypt data', previous: $exception);
+        } finally {
+            sodium_memzero($dek);
+        }
 
         if ($plaintext === false) {
             throw new TenantKeyDecryptionException('Failed to decrypt data');

--- a/app/Models/TenantKey.php
+++ b/app/Models/TenantKey.php
@@ -8,6 +8,7 @@
 
 namespace App\Models;
 
+use App\Exceptions\CorruptedEncryptedAttributeException;
 use App\Exceptions\TenantKeyDecryptionException;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -513,7 +514,8 @@ class TenantKey extends Model
     /**
      * Unwrap the Data Encryption Key (DEK).
      *
-     * @throws \RuntimeException if unwrapping fails
+     * @throws CorruptedEncryptedAttributeException if the wrapped DEK fails authentication (corrupt envelope)
+     * @throws \RuntimeException if the KEK cannot be loaded (operational/transient)
      */
     public function unwrapDek(): string
     {
@@ -528,7 +530,7 @@ class TenantKey extends Model
         sodium_memzero($kek);
 
         if ($dek === false) {
-            throw new \RuntimeException('Failed to unwrap DEK');
+            throw new CorruptedEncryptedAttributeException('Failed to unwrap DEK');
         }
 
         return $dek;
@@ -582,7 +584,6 @@ class TenantKey extends Model
     /**
      * Decrypt ciphertext using the tenant's DEK.
      *
-     * @throws \RuntimeException if tenant key material cannot be loaded
      * @throws TenantKeyDecryptionException if ciphertext authentication fails
      * @throws \RuntimeException if tenant key material cannot be loaded
      */

--- a/app/Models/TenantKey.php
+++ b/app/Models/TenantKey.php
@@ -8,6 +8,7 @@
 
 namespace App\Models;
 
+use App\Exceptions\TenantKeyDecryptionException;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
@@ -580,7 +581,7 @@ class TenantKey extends Model
     /**
      * Decrypt ciphertext using the tenant's DEK.
      *
-     * @throws \RuntimeException if decryption fails
+     * @throws TenantKeyDecryptionException if decryption fails
      */
     public function decrypt(string $ciphertext, string $nonce): string
     {
@@ -590,7 +591,7 @@ class TenantKey extends Model
         sodium_memzero($dek);
 
         if ($plaintext === false) {
-            throw new \RuntimeException('Failed to decrypt data');
+            throw new TenantKeyDecryptionException('Failed to decrypt data');
         }
 
         return $plaintext;

--- a/app/Services/AndroidPushDeliveryService.php
+++ b/app/Services/AndroidPushDeliveryService.php
@@ -161,7 +161,6 @@ final class AndroidPushDeliveryService
 
         $encodedPayload = $this->base64UrlEncode(json_encode([
             'iss' => $clientEmail,
-            'sub' => $clientEmail,
             'aud' => $this->configuration->tokenUri(),
             'scope' => self::FIREBASE_MESSAGING_SCOPE,
             'iat' => $issuedAt,
@@ -245,9 +244,7 @@ final class AndroidPushDeliveryService
             return false;
         }
 
-        $status = data_get($responseBody, 'error.status');
-
-        if ($providerErrorCode !== 'INVALID_ARGUMENT' && $status !== 'INVALID_ARGUMENT') {
+        if ($providerErrorCode !== 'INVALID_ARGUMENT') {
             return false;
         }
 

--- a/app/Services/AndroidPushDeliveryService.php
+++ b/app/Services/AndroidPushDeliveryService.php
@@ -133,7 +133,7 @@ final class AndroidPushDeliveryService
             throw new RuntimeException('Android push delivery is not configured for this deployment.');
         }
 
-        $issuedAt = now()->timestamp;
+        $issuedAt = now()->getTimestamp();
 
         $encodedHeader = $this->base64UrlEncode(json_encode([
             'alg' => 'RS256',
@@ -156,10 +156,10 @@ final class AndroidPushDeliveryService
             throw new RuntimeException('Android push delivery private key is invalid.');
         }
 
-        $signature = '';
+        $signature = null;
         $signatureCreated = openssl_sign($unsignedToken, $signature, $opensslKey, OPENSSL_ALGO_SHA256);
 
-        if (! $signatureCreated) {
+        if (! $signatureCreated || ! is_string($signature)) {
             throw new RuntimeException('Unable to sign the Firebase service-account assertion.');
         }
 

--- a/app/Services/AndroidPushDeliveryService.php
+++ b/app/Services/AndroidPushDeliveryService.php
@@ -61,22 +61,29 @@ final class AndroidPushDeliveryService
             ];
         }
 
+        $message = [
+            'token' => $deviceToken,
+            'notification' => [
+                'title' => $title,
+                'body' => $body,
+            ],
+            'android' => [
+                'priority' => 'high',
+            ],
+        ];
+
+        $normalizedData = $this->normalizeMessageData($data);
+
+        if ($normalizedData !== []) {
+            $message['data'] = $normalizedData;
+        }
+
         $response = Http::acceptJson()
             ->withToken($this->fetchAccessToken())
             ->connectTimeout($this->configuration->connectTimeout())
             ->timeout($this->configuration->timeout())
             ->post($messageEndpoint, [
-                'message' => [
-                    'token' => $deviceToken,
-                    'notification' => [
-                        'title' => $title,
-                        'body' => $body,
-                    ],
-                    'data' => $this->normalizeMessageData($data),
-                    'android' => [
-                        'priority' => 'high',
-                    ],
-                ],
+                'message' => $message,
             ]);
 
         if ($response->successful()) {

--- a/app/Services/AndroidPushDeliveryService.php
+++ b/app/Services/AndroidPushDeliveryService.php
@@ -215,20 +215,24 @@ final class AndroidPushDeliveryService
 
         $details = data_get($responseBody, 'error.details');
 
-        if (! is_array($details)) {
-            return null;
+        if (is_array($details)) {
+            foreach ($details as $detail) {
+                if (! is_array($detail)) {
+                    continue;
+                }
+
+                $errorCode = $detail['errorCode'] ?? null;
+
+                if (is_string($errorCode) && trim($errorCode) !== '') {
+                    return $errorCode;
+                }
+            }
         }
 
-        foreach ($details as $detail) {
-            if (! is_array($detail)) {
-                continue;
-            }
+        $status = data_get($responseBody, 'error.status');
 
-            $errorCode = $detail['errorCode'] ?? null;
-
-            if (is_string($errorCode) && trim($errorCode) !== '') {
-                return $errorCode;
-            }
+        if (is_string($status) && trim($status) !== '') {
+            return $status;
         }
 
         return null;
@@ -236,7 +240,7 @@ final class AndroidPushDeliveryService
 
     private function shouldDeleteRegistration(?string $providerErrorCode, mixed $responseBody): bool
     {
-        if (in_array($providerErrorCode, ['UNREGISTERED', 'SENDER_ID_MISMATCH'], true)) {
+        if ($providerErrorCode === 'UNREGISTERED') {
             return true;
         }
 

--- a/app/Services/AndroidPushDeliveryService.php
+++ b/app/Services/AndroidPushDeliveryService.php
@@ -1,0 +1,272 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\PushDeviceRegistration;
+use App\Support\AndroidPushDeliveryConfiguration;
+use Illuminate\Support\Facades\Http;
+use InvalidArgumentException;
+use RuntimeException;
+
+final class AndroidPushDeliveryService
+{
+    private const FIREBASE_MESSAGING_SCOPE = 'https://www.googleapis.com/auth/firebase.messaging';
+
+    public function __construct(
+        private readonly AndroidPushDeliveryConfiguration $configuration,
+    ) {}
+
+    /**
+     * @param  array<string, string>  $data
+     * @return array{delivered: bool, provider_message_id: string|null, invalid_token: bool, provider_error_code: string|null}
+     */
+    public function send(PushDeviceRegistration $registration, string $title, string $body, array $data = []): array
+    {
+        if ($this->configuration->missingFields() !== []) {
+            throw new RuntimeException('Android push delivery is not configured for this deployment.');
+        }
+
+        $messageEndpoint = $this->configuration->messageEndpoint();
+
+        if ($messageEndpoint === null) {
+            throw new RuntimeException('Android push delivery is not configured for this deployment.');
+        }
+
+        $deviceToken = $registration->deliveryToken();
+
+        if ($deviceToken === null) {
+            throw new RuntimeException('Android push delivery requires a decryptable device token.');
+        }
+
+        $response = Http::acceptJson()
+            ->withToken($this->fetchAccessToken())
+            ->connectTimeout($this->configuration->connectTimeout())
+            ->timeout($this->configuration->timeout())
+            ->post($messageEndpoint, [
+                'message' => [
+                    'token' => $deviceToken,
+                    'notification' => [
+                        'title' => $title,
+                        'body' => $body,
+                    ],
+                    'data' => $this->normalizeMessageData($data),
+                    'android' => [
+                        'priority' => 'high',
+                    ],
+                ],
+            ]);
+
+        if ($response->successful()) {
+            $providerMessageId = $response->json('name');
+
+            if (! is_string($providerMessageId) || trim($providerMessageId) === '') {
+                throw new RuntimeException('Firebase push delivery succeeded without returning a provider message id.');
+            }
+
+            return [
+                'delivered' => true,
+                'provider_message_id' => $providerMessageId,
+                'invalid_token' => false,
+                'provider_error_code' => null,
+            ];
+        }
+
+        $responseBody = $response->json();
+        $providerErrorCode = $this->providerErrorCode($responseBody);
+
+        if ($this->shouldDeleteRegistration($providerErrorCode, $responseBody)) {
+            $registration->delete();
+
+            return [
+                'delivered' => false,
+                'provider_message_id' => null,
+                'invalid_token' => true,
+                'provider_error_code' => $providerErrorCode,
+            ];
+        }
+
+        throw new RuntimeException(sprintf(
+            'Firebase push delivery failed with HTTP %d%s.',
+            $response->status(),
+            $providerErrorCode === null ? '' : ' ('.$providerErrorCode.')',
+        ));
+    }
+
+    private function fetchAccessToken(): string
+    {
+        $response = Http::asForm()
+            ->acceptJson()
+            ->connectTimeout($this->configuration->connectTimeout())
+            ->timeout($this->configuration->timeout())
+            ->post($this->configuration->tokenUri(), [
+                'grant_type' => 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+                'assertion' => $this->buildJwtAssertion(),
+            ]);
+
+        if (! $response->successful()) {
+            throw new RuntimeException(sprintf(
+                'Unable to fetch a Firebase access token for Android push delivery (HTTP %d).',
+                $response->status(),
+            ));
+        }
+
+        $accessToken = $response->json('access_token');
+
+        if (! is_string($accessToken) || trim($accessToken) === '') {
+            throw new RuntimeException('Firebase access token response did not include an access_token value.');
+        }
+
+        return $accessToken;
+    }
+
+    private function buildJwtAssertion(): string
+    {
+        $clientEmail = $this->configuration->clientEmail();
+        $privateKey = $this->configuration->privateKey();
+
+        if ($clientEmail === null || $privateKey === null) {
+            throw new RuntimeException('Android push delivery is not configured for this deployment.');
+        }
+
+        $issuedAt = now()->timestamp;
+
+        $encodedHeader = $this->base64UrlEncode(json_encode([
+            'alg' => 'RS256',
+            'typ' => 'JWT',
+        ], JSON_THROW_ON_ERROR));
+
+        $encodedPayload = $this->base64UrlEncode(json_encode([
+            'iss' => $clientEmail,
+            'sub' => $clientEmail,
+            'aud' => $this->configuration->tokenUri(),
+            'scope' => self::FIREBASE_MESSAGING_SCOPE,
+            'iat' => $issuedAt,
+            'exp' => $issuedAt + 3600,
+        ], JSON_THROW_ON_ERROR));
+
+        $unsignedToken = $encodedHeader.'.'.$encodedPayload;
+        $opensslKey = openssl_pkey_get_private($privateKey);
+
+        if ($opensslKey === false) {
+            throw new RuntimeException('Android push delivery private key is invalid.');
+        }
+
+        $signature = '';
+        $signatureCreated = openssl_sign($unsignedToken, $signature, $opensslKey, OPENSSL_ALGO_SHA256);
+
+        if (! $signatureCreated) {
+            throw new RuntimeException('Unable to sign the Firebase service-account assertion.');
+        }
+
+        return $unsignedToken.'.'.$this->base64UrlEncode($signature);
+    }
+
+    /**
+     * @param  array<string, string>  $data
+     * @return array<string, string>
+     */
+    private function normalizeMessageData(array $data): array
+    {
+        $normalized = [];
+
+        foreach ($data as $key => $value) {
+            if (! is_string($key) || trim($key) === '') {
+                throw new InvalidArgumentException('Android push message data keys must be non-empty strings.');
+            }
+
+            if (! is_string($value)) {
+                throw new InvalidArgumentException(sprintf('Android push message data value for "%s" must be a string.', $key));
+            }
+
+            $normalized[$key] = $value;
+        }
+
+        return $normalized;
+    }
+
+    private function providerErrorCode(mixed $responseBody): ?string
+    {
+        if (! is_array($responseBody)) {
+            return null;
+        }
+
+        $details = data_get($responseBody, 'error.details');
+
+        if (! is_array($details)) {
+            return null;
+        }
+
+        foreach ($details as $detail) {
+            if (! is_array($detail)) {
+                continue;
+            }
+
+            $errorCode = $detail['errorCode'] ?? null;
+
+            if (is_string($errorCode) && trim($errorCode) !== '') {
+                return $errorCode;
+            }
+        }
+
+        return null;
+    }
+
+    private function shouldDeleteRegistration(?string $providerErrorCode, mixed $responseBody): bool
+    {
+        if (in_array($providerErrorCode, ['UNREGISTERED', 'SENDER_ID_MISMATCH'], true)) {
+            return true;
+        }
+
+        if (! is_array($responseBody)) {
+            return false;
+        }
+
+        $status = data_get($responseBody, 'error.status');
+
+        if ($providerErrorCode !== 'INVALID_ARGUMENT' && $status !== 'INVALID_ARGUMENT') {
+            return false;
+        }
+
+        $message = data_get($responseBody, 'error.message');
+
+        if (is_string($message) && str_contains(strtolower($message), 'registration token')) {
+            return true;
+        }
+
+        $details = data_get($responseBody, 'error.details');
+
+        if (! is_array($details)) {
+            return false;
+        }
+
+        foreach ($details as $detail) {
+            if (! is_array($detail)) {
+                continue;
+            }
+
+            $fieldViolations = $detail['fieldViolations'] ?? null;
+
+            if (! is_array($fieldViolations)) {
+                continue;
+            }
+
+            foreach ($fieldViolations as $fieldViolation) {
+                if (is_array($fieldViolation) && ($fieldViolation['field'] ?? null) === 'message.token') {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private function base64UrlEncode(string $value): string
+    {
+        return rtrim(strtr(base64_encode($value), '+/', '-_'), '=');
+    }
+}

--- a/app/Services/AndroidPushDeliveryService.php
+++ b/app/Services/AndroidPushDeliveryService.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace App\Services;
 
+use App\Exceptions\CorruptedEncryptedAttributeException;
 use App\Models\PushDeviceRegistration;
 use App\Support\AndroidPushDeliveryConfiguration;
 use Illuminate\Support\Facades\Http;
@@ -39,7 +40,7 @@ final class AndroidPushDeliveryService
 
         try {
             $deviceToken = $registration->deliveryToken();
-        } catch (\Throwable) {
+        } catch (CorruptedEncryptedAttributeException) {
             $registration->delete();
 
             return [
@@ -51,14 +52,7 @@ final class AndroidPushDeliveryService
         }
 
         if ($deviceToken === null) {
-            $registration->delete();
-
-            return [
-                'delivered' => false,
-                'provider_message_id' => null,
-                'invalid_token' => true,
-                'provider_error_code' => 'MISSING_TOKEN',
-            ];
+            throw new RuntimeException('Android push delivery requires a decryptable device token.');
         }
 
         $message = [

--- a/app/Services/AndroidPushDeliveryService.php
+++ b/app/Services/AndroidPushDeliveryService.php
@@ -37,10 +37,28 @@ final class AndroidPushDeliveryService
             throw new RuntimeException('Android push delivery is not configured for this deployment.');
         }
 
-        $deviceToken = $registration->deliveryToken();
+        try {
+            $deviceToken = $registration->deliveryToken();
+        } catch (\Throwable) {
+            $registration->delete();
+
+            return [
+                'delivered' => false,
+                'provider_message_id' => null,
+                'invalid_token' => true,
+                'provider_error_code' => 'DECRYPTION_FAILURE',
+            ];
+        }
 
         if ($deviceToken === null) {
-            throw new RuntimeException('Android push delivery requires a decryptable device token.');
+            $registration->delete();
+
+            return [
+                'delivered' => false,
+                'provider_message_id' => null,
+                'invalid_token' => true,
+                'provider_error_code' => 'MISSING_TOKEN',
+            ];
         }
 
         $response = Http::acceptJson()

--- a/app/Support/AndroidPushDeliveryConfiguration.php
+++ b/app/Support/AndroidPushDeliveryConfiguration.php
@@ -77,31 +77,16 @@ final class AndroidPushDeliveryConfiguration
 
     public function connectTimeout(): int
     {
-        return $this->positiveIntegerConfig('services.fcm.connect_timeout', 5);
+        return $this->positiveIntegerConfig('services.fcm.connect_timeout', 5) ?? 5;
     }
 
     public function timeout(): int
     {
-        return $this->positiveIntegerConfig('services.fcm.timeout', 10);
+        return $this->positiveIntegerConfig('services.fcm.timeout', 10) ?? 10;
     }
 
     private function apiBaseUrl(): string
     {
         return rtrim($this->trimmedStringConfig('services.fcm.api_base_url') ?? 'https://fcm.googleapis.com', '/');
-    }
-
-    private function positiveIntegerConfig(string $key, int $default): int
-    {
-        $value = config($key);
-
-        if (is_int($value) && $value > 0) {
-            return $value;
-        }
-
-        if (is_string($value) && preg_match('/^[1-9][0-9]*$/', $value)) {
-            return (int) $value;
-        }
-
-        return $default;
     }
 }

--- a/app/Support/AndroidPushDeliveryConfiguration.php
+++ b/app/Support/AndroidPushDeliveryConfiguration.php
@@ -1,0 +1,107 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use App\Support\Concerns\InteractsWithConfigValues;
+
+final class AndroidPushDeliveryConfiguration
+{
+    use InteractsWithConfigValues;
+
+    /**
+     * @return array<int, string>
+     */
+    public function missingFields(): array
+    {
+        $missingFields = [];
+
+        if ($this->projectId() === null) {
+            $missingFields[] = 'services.fcm.project_id';
+        }
+
+        if ($this->clientEmail() === null) {
+            $missingFields[] = 'services.fcm.client_email';
+        }
+
+        if ($this->privateKey() === null) {
+            $missingFields[] = 'services.fcm.private_key';
+        }
+
+        return $missingFields;
+    }
+
+    public function projectId(): ?string
+    {
+        return $this->trimmedStringConfig('services.fcm.project_id');
+    }
+
+    public function clientEmail(): ?string
+    {
+        return $this->trimmedStringConfig('services.fcm.client_email');
+    }
+
+    public function privateKey(): ?string
+    {
+        $privateKey = $this->trimmedStringConfig('services.fcm.private_key');
+
+        if ($privateKey === null) {
+            return null;
+        }
+
+        $normalized = str_replace(["\r\n", "\r"], "\n", str_replace('\\n', "\n", $privateKey));
+
+        return trim($normalized) === '' ? null : $normalized;
+    }
+
+    public function tokenUri(): string
+    {
+        return $this->trimmedStringConfig('services.fcm.token_uri')
+            ?? 'https://oauth2.googleapis.com/token';
+    }
+
+    public function messageEndpoint(): ?string
+    {
+        $projectId = $this->projectId();
+
+        if ($projectId === null) {
+            return null;
+        }
+
+        return sprintf('%s/v1/projects/%s/messages:send', $this->apiBaseUrl(), rawurlencode($projectId));
+    }
+
+    public function connectTimeout(): int
+    {
+        return $this->positiveIntegerConfig('services.fcm.connect_timeout', 5);
+    }
+
+    public function timeout(): int
+    {
+        return $this->positiveIntegerConfig('services.fcm.timeout', 10);
+    }
+
+    private function apiBaseUrl(): string
+    {
+        return rtrim($this->trimmedStringConfig('services.fcm.api_base_url') ?? 'https://fcm.googleapis.com', '/');
+    }
+
+    private function positiveIntegerConfig(string $key, int $default): int
+    {
+        $value = config($key);
+
+        if (is_int($value) && $value > 0) {
+            return $value;
+        }
+
+        if (is_string($value) && preg_match('/^[1-9][0-9]*$/', $value)) {
+            return (int) $value;
+        }
+
+        return $default;
+    }
+}

--- a/app/Support/AndroidPushRuntimeConfiguration.php
+++ b/app/Support/AndroidPushRuntimeConfiguration.php
@@ -90,19 +90,4 @@ final class AndroidPushRuntimeConfiguration
     {
         return $this->trimmedStringConfig('bootstrap.android_push.public_client_metadata.'.$field);
     }
-
-    private function positiveIntegerConfig(string $key): ?int
-    {
-        $value = config($key);
-
-        if (is_int($value)) {
-            return $value > 0 ? $value : null;
-        }
-
-        if (! is_string($value) || ! preg_match('/^[1-9][0-9]*$/', $value)) {
-            return null;
-        }
-
-        return (int) $value;
-    }
 }

--- a/app/Support/Concerns/InteractsWithConfigValues.php
+++ b/app/Support/Concerns/InteractsWithConfigValues.php
@@ -44,4 +44,19 @@ trait InteractsWithConfigValues
 
         return $value === '' ? null : $value;
     }
+
+    private function positiveIntegerConfig(string $key, ?int $default = null): ?int
+    {
+        $value = config($key);
+
+        if (is_int($value)) {
+            return $value > 0 ? $value : $default;
+        }
+
+        if (! is_string($value) || ! preg_match('/^[1-9][0-9]*$/', $value)) {
+            return $default;
+        }
+
+        return (int) $value;
+    }
 }

--- a/config/services.php
+++ b/config/services.php
@@ -38,4 +38,14 @@ return [
         ],
     ],
 
+    'fcm' => [
+        'project_id' => env('ANDROID_PUSH_FCM_PROJECT_ID'),
+        'client_email' => env('ANDROID_PUSH_FCM_CLIENT_EMAIL'),
+        'private_key' => env('ANDROID_PUSH_FCM_PRIVATE_KEY'),
+        'token_uri' => env('ANDROID_PUSH_FCM_TOKEN_URI', 'https://oauth2.googleapis.com/token'),
+        'api_base_url' => env('ANDROID_PUSH_FCM_API_BASE_URL', 'https://fcm.googleapis.com'),
+        'connect_timeout' => env('ANDROID_PUSH_FCM_CONNECT_TIMEOUT', 5),
+        'timeout' => env('ANDROID_PUSH_FCM_TIMEOUT', 10),
+    ],
+
 ];

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -109,6 +109,14 @@ BOOTSTRAP_ANDROID_PUSH_PUBLIC_API_KEY=public-client-api-key-demo-1234567890
 BOOTSTRAP_ANDROID_PUSH_PUBLIC_PROJECT_ID=secpal-demo-push
 BOOTSTRAP_ANDROID_PUSH_PUBLIC_APPLICATION_ID=1:1234567890:android:abcdef1234567890
 BOOTSTRAP_ANDROID_PUSH_PUBLIC_SENDER_ID=1234567890
+# Customer-owned Android push delivery (backend-only)
+ANDROID_PUSH_FCM_PROJECT_ID=customer-owned-push
+ANDROID_PUSH_FCM_CLIENT_EMAIL=firebase-adminsdk-abc123@customer-owned-push.iam.gserviceaccount.com
+ANDROID_PUSH_FCM_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\nREPLACE_WITH_DEPLOYMENT_SECRET\n-----END PRIVATE KEY-----\n"
+ANDROID_PUSH_FCM_TOKEN_URI=https://oauth2.googleapis.com/token
+ANDROID_PUSH_FCM_API_BASE_URL=https://fcm.googleapis.com
+ANDROID_PUSH_FCM_CONNECT_TIMEOUT=5
+ANDROID_PUSH_FCM_TIMEOUT=10
 BOOTSTRAP_RETRYABLE=true
 BOOTSTRAP_RETRY_AFTER_SECONDS=60
 
@@ -162,6 +170,7 @@ Expose the public runtime-discovery endpoint at `GET /v1/bootstrap` only after t
 - When Android push bootstrap is enabled, `BOOTSTRAP_ANDROID_PUSH_METADATA_REVISION`, `BOOTSTRAP_ANDROID_PUSH_PUBLIC_API_KEY`, `BOOTSTRAP_ANDROID_PUSH_PUBLIC_PROJECT_ID`, `BOOTSTRAP_ANDROID_PUSH_PUBLIC_APPLICATION_ID`, and `BOOTSTRAP_ANDROID_PUSH_PUBLIC_SENDER_ID` are all required. Missing values fail closed with `500 BOOTSTRAP_STATE_INVALID`.
 - `BOOTSTRAP_ANDROID_PUSH_METADATA_REVISION` must be incremented whenever any public Android push client metadata changes so authenticated registrations with stale bootstrap state can be rejected deterministically.
 - Only public Android runtime metadata belongs here. Never place server credentials, service-account JSON, or private push delivery secrets in bootstrap configuration.
+- Customer-owned Android push delivery credentials stay backend-only in `ANDROID_PUSH_FCM_*`; they are not read from or exposed through the bootstrap payload.
 
 Verify the deployed response with the canonical public origin:
 
@@ -178,6 +187,16 @@ Authenticated Android clients register one stable installation identifier agains
 - Clients must echo the current `android_push.metadata_revision` from `GET /v1/bootstrap` in `runtime.push_metadata_revision`.
 - When the deployment disables Android push registration, the upsert endpoint fails closed with `409 ANDROID_PUSH_UNSUPPORTED`.
 - When the client presents stale bootstrap metadata, the upsert endpoint fails closed with `409 PUSH_RUNTIME_STATE_INVALID` and the expected revision details.
+
+### Customer-Owned Android Push Delivery
+
+Customer-hosted deployments can send Android push directly from the backend without any SecPal-operated relay.
+
+- Configure `ANDROID_PUSH_FCM_PROJECT_ID`, `ANDROID_PUSH_FCM_CLIENT_EMAIL`, and `ANDROID_PUSH_FCM_PRIVATE_KEY` on the API deployment. These values are required for server-side FCM HTTP v1 delivery and stay backend-only.
+- `ANDROID_PUSH_FCM_PRIVATE_KEY` may be provided either as a real multiline secret or as a single-line value containing literal `\n` escapes exactly like the example above.
+- Missing or invalid `ANDROID_PUSH_FCM_*` credentials fail closed during delivery. The backend does not fall back to SecPal-owned routing when customer-owned delivery is selected.
+- The queueable send primitive is `App\Jobs\DeliverAndroidPushMessage`; it runs on the default queue worker. Ensure the deployment's default queue worker is active before relying on asynchronous delivery.
+- Delivery outcomes that indicate a stale or invalid registration token (`UNREGISTERED`, `SENDER_ID_MISMATCH`, or token-specific invalid-argument responses) delete the stored registration so the next authenticated app session must re-register with fresh runtime metadata.
 
 Example registration request:
 

--- a/docs/guides/production-deployment.md
+++ b/docs/guides/production-deployment.md
@@ -330,6 +330,13 @@ BOOTSTRAP_ANDROID_PUSH_PUBLIC_API_KEY=public-client-api-key-demo-1234567890
 BOOTSTRAP_ANDROID_PUSH_PUBLIC_PROJECT_ID=secpal-demo-push
 BOOTSTRAP_ANDROID_PUSH_PUBLIC_APPLICATION_ID=1:1234567890:android:abcdef1234567890
 BOOTSTRAP_ANDROID_PUSH_PUBLIC_SENDER_ID=1234567890
+ANDROID_PUSH_FCM_PROJECT_ID=customer-owned-push
+ANDROID_PUSH_FCM_CLIENT_EMAIL=firebase-adminsdk-abc123@customer-owned-push.iam.gserviceaccount.com
+ANDROID_PUSH_FCM_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\nREPLACE_WITH_DEPLOYMENT_SECRET\n-----END PRIVATE KEY-----\n"
+ANDROID_PUSH_FCM_TOKEN_URI=https://oauth2.googleapis.com/token
+ANDROID_PUSH_FCM_API_BASE_URL=https://fcm.googleapis.com
+ANDROID_PUSH_FCM_CONNECT_TIMEOUT=5
+ANDROID_PUSH_FCM_TIMEOUT=10
 BOOTSTRAP_RETRYABLE=true
 BOOTSTRAP_RETRY_AFTER_SECONDS=60
 
@@ -390,6 +397,10 @@ LOG_LEVEL=warning
 When `BOOTSTRAP_ANDROID_PUSH_ENABLED=true`, the same bootstrap response advertises authenticated Android push registration support and returns an `android_push` object with the deployment-defined `metadata_revision` plus the public Android runtime metadata needed by the SDK. Missing `BOOTSTRAP_ANDROID_PUSH_*` public values fail closed with `500 BOOTSTRAP_STATE_INVALID`; there is no fallback to SecPal-owned defaults.
 
 Authenticated Android clients register against the selected customer-hosted backend via `PUT /v1/me/push-devices/{installationId}` and revoke via `DELETE /v1/me/push-devices/{installationId}`. Clients must echo the current `android_push.metadata_revision` in `runtime.push_metadata_revision`; stale registrations are rejected with `409 PUSH_RUNTIME_STATE_INVALID`, and deployments with Android push disabled reject registration with `409 ANDROID_PUSH_UNSUPPORTED`.
+
+Customer-owned Android push delivery uses the backend-only `ANDROID_PUSH_FCM_*` secrets above and sends directly to FCM HTTP v1 from the customer-hosted API. Those credentials never appear in `GET /v1/bootstrap`, and missing or invalid values fail closed during delivery instead of falling back to any SecPal-operated routing path.
+
+The queueable delivery primitive is `App\Jobs\DeliverAndroidPushMessage` on the default queue. Keep the default queue worker running, and expect delivery outcomes such as `UNREGISTERED`, `SENDER_ID_MISMATCH`, or token-specific invalid-argument responses to delete the stored device registration so clients must re-register.
 
 ## Client Configuration
 

--- a/tests/Feature/Api/V1/BootstrapApiTest.php
+++ b/tests/Feature/Api/V1/BootstrapApiTest.php
@@ -77,6 +77,26 @@ test('public bootstrap omits android push metadata when authenticated push regis
         ->assertJsonMissingPath('data.android_push');
 });
 
+test('public bootstrap never exposes server side android push credentials', function (): void {
+    config([
+        'services.fcm.project_id' => 'customer-owned-server-project',
+        'services.fcm.client_email' => 'firebase-adminsdk@customer-owned-server-project.iam.gserviceaccount.com',
+        'services.fcm.private_key' => "-----BEGIN PRIVATE KEY-----\nserver-only-secret\n-----END PRIVATE KEY-----\n",
+    ]);
+
+    $response = getJson('/v1/bootstrap?client_platform=android&app_version=1.4.0&app_build=10400');
+
+    $response->assertOk()
+        ->assertJsonMissingPath('data.android_push.project_id')
+        ->assertJsonMissingPath('data.android_push.client_email')
+        ->assertJsonMissingPath('data.android_push.private_key');
+
+    expect($response->getContent())
+        ->not->toContain('customer-owned-server-project')
+        ->not->toContain('firebase-adminsdk@customer-owned-server-project.iam.gserviceaccount.com')
+        ->not->toContain('server-only-secret');
+});
+
 test('public bootstrap rejects android clients below the configured minimum version', function (): void {
     getJson('/v1/bootstrap?client_platform=android&app_version=1.3.2&app_build=10302')
         ->assertStatus(426)

--- a/tests/Feature/Jobs/DeliverAndroidPushMessageTest.php
+++ b/tests/Feature/Jobs/DeliverAndroidPushMessageTest.php
@@ -10,6 +10,7 @@ use App\Models\PushDeviceRegistration;
 use App\Models\TenantKey;
 use App\Models\User;
 use App\Services\AndroidPushDeliveryService;
+use App\Support\AndroidPushDeliveryConfiguration;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
@@ -105,7 +106,7 @@ test('job dispatches android push delivery for an existing registration', functi
         'Compliance alert',
         'Permit expires soon.',
         ['category' => 'compliance_alert'],
-    ))->handle(app(AndroidPushDeliveryService::class));
+    ))->handle(app(AndroidPushDeliveryService::class), app(AndroidPushDeliveryConfiguration::class));
 
     Http::assertSent(function (Request $request): bool {
         if ($request->url() !== 'https://fcm.googleapis.com/v1/projects/customer-owned-project/messages:send') {
@@ -126,7 +127,26 @@ test('job skips missing registrations', function (): void {
         'Compliance alert',
         'Permit expires soon.',
         ['category' => 'compliance_alert'],
-    ))->handle(app(AndroidPushDeliveryService::class));
+    ))->handle(app(AndroidPushDeliveryService::class), app(AndroidPushDeliveryConfiguration::class));
+
+    Http::assertNothingSent();
+});
+
+test('job makes no delivery attempts when fcm credentials are missing', function (): void {
+    config([
+        'services.fcm.project_id' => null,
+        'services.fcm.client_email' => null,
+        'services.fcm.private_key' => null,
+    ]);
+
+    Http::fake();
+
+    (new DeliverAndroidPushMessage(
+        (string) Str::uuid(),
+        'Compliance alert',
+        'Permit expires soon.',
+        ['category' => 'compliance_alert'],
+    ))->handle(app(AndroidPushDeliveryService::class), app(AndroidPushDeliveryConfiguration::class));
 
     Http::assertNothingSent();
 });

--- a/tests/Feature/Jobs/DeliverAndroidPushMessageTest.php
+++ b/tests/Feature/Jobs/DeliverAndroidPushMessageTest.php
@@ -150,6 +150,6 @@ test('job can be queued for asynchronous android push delivery', function (): vo
 
     expect((new DeliverAndroidPushMessage('push-registration-id', 'title', 'body'))->backoff())
         ->toBe([10, 60, 300])
-        ->and((new DeliverAndroidPushMessage('push-registration-id', 'title', 'body'))->tries)->toBe(3)
+        ->and((new DeliverAndroidPushMessage('push-registration-id', 'title', 'body'))->tries)->toBe(4)
         ->and((new DeliverAndroidPushMessage('push-registration-id', 'title', 'body'))->timeout)->toBe(30);
 });

--- a/tests/Feature/Jobs/DeliverAndroidPushMessageTest.php
+++ b/tests/Feature/Jobs/DeliverAndroidPushMessageTest.php
@@ -122,17 +122,23 @@ test('job dispatches android push delivery for an existing registration', functi
 test('job skips missing registrations', function (): void {
     Http::fake();
 
-    (new DeliverAndroidPushMessage(
+    $job = (new DeliverAndroidPushMessage(
         (string) Str::uuid(),
         'Compliance alert',
         'Permit expires soon.',
         ['category' => 'compliance_alert'],
-    ))->handle(app(AndroidPushDeliveryService::class), app(AndroidPushDeliveryConfiguration::class));
+    ))->withFakeQueueInteractions();
+
+    $job->handle(app(AndroidPushDeliveryService::class), app(AndroidPushDeliveryConfiguration::class));
+
+    $job->assertNotFailed();
 
     Http::assertNothingSent();
 });
 
 test('job makes no delivery attempts when fcm credentials are missing', function (): void {
+    $registration = createQueuedAndroidPushRegistration($this->tenant, $this->user);
+
     config([
         'services.fcm.project_id' => null,
         'services.fcm.client_email' => null,
@@ -141,12 +147,16 @@ test('job makes no delivery attempts when fcm credentials are missing', function
 
     Http::fake();
 
-    (new DeliverAndroidPushMessage(
-        (string) Str::uuid(),
+    $job = (new DeliverAndroidPushMessage(
+        $registration->id,
         'Compliance alert',
         'Permit expires soon.',
         ['category' => 'compliance_alert'],
-    ))->handle(app(AndroidPushDeliveryService::class), app(AndroidPushDeliveryConfiguration::class));
+    ))->withFakeQueueInteractions();
+
+    $job->handle(app(AndroidPushDeliveryService::class), app(AndroidPushDeliveryConfiguration::class));
+
+    $job->assertFailedWith('Android push delivery is not configured for this deployment.');
 
     Http::assertNothingSent();
 });

--- a/tests/Feature/Jobs/DeliverAndroidPushMessageTest.php
+++ b/tests/Feature/Jobs/DeliverAndroidPushMessageTest.php
@@ -1,0 +1,155 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+use App\Jobs\DeliverAndroidPushMessage;
+use App\Models\PushDeviceRegistration;
+use App\Models\TenantKey;
+use App\Models\User;
+use App\Services\AndroidPushDeliveryService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Str;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function (): void {
+    incrementTestKekCounter();
+    TenantKey::setKekPath(getTestKekPath());
+    TenantKey::generateKek();
+
+    $this->tenant = TenantKey::create(TenantKey::generateEnvelopeKeys());
+    $this->user = User::factory()->create(['tenant_id' => $this->tenant->id]);
+
+    config([
+        'services.fcm.project_id' => 'customer-owned-project',
+        'services.fcm.client_email' => 'firebase-adminsdk@customer-owned-project.iam.gserviceaccount.com',
+        'services.fcm.private_key' => generateQueuedFirebaseTestPrivateKey(),
+        'services.fcm.token_uri' => 'https://oauth2.googleapis.com/token',
+        'services.fcm.connect_timeout' => 5,
+        'services.fcm.timeout' => 10,
+    ]);
+});
+
+afterEach(function (): void {
+    cleanupTestKekFile();
+    TenantKey::setKekPath(null);
+});
+
+function createQueuedAndroidPushRegistration(TenantKey $tenant, User $user): PushDeviceRegistration
+{
+    return PushDeviceRegistration::query()->create([
+        'tenant_id' => $tenant->id,
+        'user_id' => $user->id,
+        'installation_id' => 'a0b1c2d3-e4f5-4a67-89ab-0c1d2e3f4a5b',
+        'platform' => 'android',
+        'provider' => 'fcm',
+        'device_name' => 'SM-G556B reception tablet',
+        'push_token_plain' => 'e6pGmJq4Yk12:APA91bH8mP7rQ6sT5uV4wX3yZ2aBcDeFgHiJkLmNoPqRsTuVwXyZ1234567890abcdef',
+        'last_lifecycle_event' => 'registered',
+        'package_name' => 'app.secpal',
+        'package_version_name' => '1.5.0',
+        'package_version_code' => 10500,
+        'manufacturer' => 'Samsung',
+        'model' => 'SM-G556B',
+        'android_version' => '16',
+        'sdk_int' => 36,
+        'bootstrap_version' => 'v1',
+        'schema_version' => 2,
+        'push_metadata_revision' => 3,
+    ]);
+}
+
+function generateQueuedFirebaseTestPrivateKey(): string
+{
+    $privateKey = openssl_pkey_new([
+        'private_key_bits' => 2048,
+        'private_key_type' => OPENSSL_KEYTYPE_RSA,
+    ]);
+
+    if ($privateKey === false) {
+        throw new RuntimeException('Unable to generate a test RSA private key for queued Android push delivery coverage.');
+    }
+
+    $exportedKey = null;
+    $exportSucceeded = openssl_pkey_export($privateKey, $exportedKey);
+
+    if (! $exportSucceeded || ! is_string($exportedKey) || trim($exportedKey) === '') {
+        throw new RuntimeException('Unable to export the generated queued Android push delivery private key.');
+    }
+
+    return $exportedKey;
+}
+
+test('job dispatches android push delivery for an existing registration', function (): void {
+    $registration = createQueuedAndroidPushRegistration($this->tenant, $this->user);
+
+    Http::fake([
+        'https://oauth2.googleapis.com/token' => Http::response([
+            'access_token' => 'google-access-token',
+            'token_type' => 'Bearer',
+            'expires_in' => 3600,
+        ], 200),
+        'https://fcm.googleapis.com/v1/projects/customer-owned-project/messages:send' => Http::response([
+            'name' => 'projects/customer-owned-project/messages/0:1710000000000000%1234abcd1234abcd',
+        ], 200),
+    ]);
+
+    (new DeliverAndroidPushMessage(
+        $registration->id,
+        'Compliance alert',
+        'Permit expires soon.',
+        ['category' => 'compliance_alert'],
+    ))->handle(app(AndroidPushDeliveryService::class));
+
+    Http::assertSent(function (Request $request): bool {
+        if ($request->url() !== 'https://fcm.googleapis.com/v1/projects/customer-owned-project/messages:send') {
+            return false;
+        }
+
+        return data_get($request->data(), 'message.notification.title') === 'Compliance alert'
+            && data_get($request->data(), 'message.notification.body') === 'Permit expires soon.'
+            && data_get($request->data(), 'message.data.category') === 'compliance_alert';
+    });
+});
+
+test('job skips missing registrations', function (): void {
+    Http::fake();
+
+    (new DeliverAndroidPushMessage(
+        (string) Str::uuid(),
+        'Compliance alert',
+        'Permit expires soon.',
+        ['category' => 'compliance_alert'],
+    ))->handle(app(AndroidPushDeliveryService::class));
+
+    Http::assertNothingSent();
+});
+
+test('job can be queued for asynchronous android push delivery', function (): void {
+    Queue::fake();
+
+    DeliverAndroidPushMessage::dispatch(
+        'push-registration-id',
+        'Compliance alert',
+        'Permit expires soon.',
+        ['category' => 'compliance_alert'],
+    );
+
+    Queue::assertPushed(DeliverAndroidPushMessage::class, function (DeliverAndroidPushMessage $job): bool {
+        return $job->pushDeviceRegistrationId === 'push-registration-id'
+            && $job->title === 'Compliance alert'
+            && $job->body === 'Permit expires soon.'
+            && $job->data === ['category' => 'compliance_alert'];
+    });
+
+    expect((new DeliverAndroidPushMessage('push-registration-id', 'title', 'body'))->backoff())
+        ->toBe([10, 60, 300])
+        ->and((new DeliverAndroidPushMessage('push-registration-id', 'title', 'body'))->tries)->toBe(3)
+        ->and((new DeliverAndroidPushMessage('push-registration-id', 'title', 'body'))->timeout)->toBe(30);
+});

--- a/tests/Feature/TenantKeyTest.php
+++ b/tests/Feature/TenantKeyTest.php
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+use App\Exceptions\TenantKeyDecryptionException;
 use App\Models\TenantKey;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\Support\TenantKeyReadabilityOverride;
@@ -136,7 +137,7 @@ test('throws exception on decryption with wrong nonce', function (): void {
     $wrongNonce = random_bytes(SODIUM_CRYPTO_SECRETBOX_NONCEBYTES);
 
     expect(fn () => $tenantKey->decrypt($encrypted['ciphertext'], $wrongNonce))
-        ->toThrow(RuntimeException::class, 'Failed to decrypt data');
+        ->toThrow(TenantKeyDecryptionException::class, 'Failed to decrypt data');
 });
 
 test('generates consistent blind index for same plaintext', function (): void {

--- a/tests/Unit/Services/AndroidPushDeliveryServiceTest.php
+++ b/tests/Unit/Services/AndroidPushDeliveryServiceTest.php
@@ -1,0 +1,221 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+declare(strict_types=1);
+
+use App\Models\PushDeviceRegistration;
+use App\Models\TenantKey;
+use App\Models\User;
+use App\Services\AndroidPushDeliveryService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function (): void {
+    incrementTestKekCounter();
+    TenantKey::setKekPath(getTestKekPath());
+    TenantKey::generateKek();
+
+    $this->tenant = TenantKey::create(TenantKey::generateEnvelopeKeys());
+    $this->user = User::factory()->create(['tenant_id' => $this->tenant->id]);
+
+    $privateKey = generateFirebaseTestPrivateKey();
+
+    config([
+        'services.fcm.project_id' => 'customer-owned-project',
+        'services.fcm.client_email' => 'firebase-adminsdk@customer-owned-project.iam.gserviceaccount.com',
+        'services.fcm.private_key' => $privateKey,
+        'services.fcm.token_uri' => 'https://oauth2.googleapis.com/token',
+        'services.fcm.connect_timeout' => 5,
+        'services.fcm.timeout' => 10,
+    ]);
+});
+
+afterEach(function (): void {
+    cleanupTestKekFile();
+    TenantKey::setKekPath(null);
+});
+
+/**
+ * @return array{tenant: TenantKey, user: User}
+ */
+function createAndroidPushDeliveryContext(): array
+{
+    $tenant = TenantKey::create(TenantKey::generateEnvelopeKeys());
+    $user = User::factory()->create(['tenant_id' => $tenant->id]);
+
+    return [
+        'tenant' => $tenant,
+        'user' => $user,
+    ];
+}
+
+function createAndroidPushRegistration(TenantKey $tenant, User $user): PushDeviceRegistration
+{
+    return PushDeviceRegistration::query()->create([
+        'tenant_id' => $tenant->id,
+        'user_id' => $user->id,
+        'installation_id' => 'a0b1c2d3-e4f5-4a67-89ab-0c1d2e3f4a5b',
+        'platform' => 'android',
+        'provider' => 'fcm',
+        'device_name' => 'SM-G556B reception tablet',
+        'push_token_plain' => 'e6pGmJq4Yk12:APA91bH8mP7rQ6sT5uV4wX3yZ2aBcDeFgHiJkLmNoPqRsTuVwXyZ1234567890abcdef',
+        'last_lifecycle_event' => 'registered',
+        'package_name' => 'app.secpal',
+        'package_version_name' => '1.5.0',
+        'package_version_code' => 10500,
+        'manufacturer' => 'Samsung',
+        'model' => 'SM-G556B',
+        'android_version' => '16',
+        'sdk_int' => 36,
+        'bootstrap_version' => 'v1',
+        'schema_version' => 2,
+        'push_metadata_revision' => 3,
+    ]);
+}
+
+function generateFirebaseTestPrivateKey(): string
+{
+    $privateKey = openssl_pkey_new([
+        'private_key_bits' => 2048,
+        'private_key_type' => OPENSSL_KEYTYPE_RSA,
+    ]);
+
+    if ($privateKey === false) {
+        throw new RuntimeException('Unable to generate a test RSA private key for Android push delivery coverage.');
+    }
+
+    $exportedKey = null;
+    $exportSucceeded = openssl_pkey_export($privateKey, $exportedKey);
+
+    if (! $exportSucceeded || ! is_string($exportedKey) || trim($exportedKey) === '') {
+        throw new RuntimeException('Unable to export the generated Android push delivery private key.');
+    }
+
+    return $exportedKey;
+}
+
+test('service sends android push through customer owned firebase credentials', function (): void {
+    $registration = createAndroidPushRegistration($this->tenant, $this->user);
+
+    Http::fake([
+        'https://oauth2.googleapis.com/token' => Http::response([
+            'access_token' => 'google-access-token',
+            'token_type' => 'Bearer',
+            'expires_in' => 3600,
+        ], 200),
+        'https://fcm.googleapis.com/v1/projects/customer-owned-project/messages:send' => Http::response([
+            'name' => 'projects/customer-owned-project/messages/0:1710000000000000%1234abcd1234abcd',
+        ], 200),
+    ]);
+
+    $result = app(AndroidPushDeliveryService::class)->send(
+        $registration,
+        'Compliance alert',
+        'Permit expires soon.',
+        ['category' => 'compliance_alert'],
+    );
+
+    expect($result)->toBe([
+        'delivered' => true,
+        'provider_message_id' => 'projects/customer-owned-project/messages/0:1710000000000000%1234abcd1234abcd',
+        'invalid_token' => false,
+        'provider_error_code' => null,
+    ]);
+
+    Http::assertSent(function (Request $request): bool {
+        if ($request->url() !== 'https://oauth2.googleapis.com/token') {
+            return false;
+        }
+
+        parse_str($request->body(), $body);
+
+        return ($body['grant_type'] ?? null) === 'urn:ietf:params:oauth:grant-type:jwt-bearer'
+            && is_string($body['assertion'] ?? null)
+            && $body['assertion'] !== '';
+    });
+
+    Http::assertSent(function (Request $request): bool {
+        if ($request->url() !== 'https://fcm.googleapis.com/v1/projects/customer-owned-project/messages:send') {
+            return false;
+        }
+
+        $payload = $request->data();
+
+        return $request->hasHeader('Authorization', 'Bearer google-access-token')
+            && data_get($payload, 'message.token') === 'e6pGmJq4Yk12:APA91bH8mP7rQ6sT5uV4wX3yZ2aBcDeFgHiJkLmNoPqRsTuVwXyZ1234567890abcdef'
+            && data_get($payload, 'message.notification.title') === 'Compliance alert'
+            && data_get($payload, 'message.notification.body') === 'Permit expires soon.'
+            && data_get($payload, 'message.data.category') === 'compliance_alert';
+    });
+
+    $this->assertDatabaseHas('push_device_registrations', [
+        'id' => $registration->id,
+        'tenant_id' => $this->tenant->id,
+        'user_id' => $this->user->id,
+    ]);
+});
+
+test('service fails closed when customer owned firebase credentials are incomplete', function (): void {
+    $registration = createAndroidPushRegistration($this->tenant, $this->user);
+
+    config(['services.fcm.private_key' => null]);
+
+    Http::fake();
+
+    expect(fn () => app(AndroidPushDeliveryService::class)->send(
+        $registration,
+        'Compliance alert',
+        'Permit expires soon.',
+        ['category' => 'compliance_alert'],
+    ))->toThrow(RuntimeException::class, 'Android push delivery is not configured for this deployment.');
+
+    Http::assertNothingSent();
+});
+
+test('service deletes stale registrations when firebase reports an unregistered token', function (): void {
+    $registration = createAndroidPushRegistration($this->tenant, $this->user);
+
+    Http::fake([
+        'https://oauth2.googleapis.com/token' => Http::response([
+            'access_token' => 'google-access-token',
+            'token_type' => 'Bearer',
+            'expires_in' => 3600,
+        ], 200),
+        'https://fcm.googleapis.com/v1/projects/customer-owned-project/messages:send' => Http::response([
+            'error' => [
+                'code' => 404,
+                'message' => 'Requested entity was not found.',
+                'status' => 'NOT_FOUND',
+                'details' => [
+                    [
+                        '@type' => 'type.googleapis.com/google.firebase.fcm.v1.FcmError',
+                        'errorCode' => 'UNREGISTERED',
+                    ],
+                ],
+            ],
+        ], 404),
+    ]);
+
+    $result = app(AndroidPushDeliveryService::class)->send(
+        $registration,
+        'Compliance alert',
+        'Permit expires soon.',
+        ['category' => 'compliance_alert'],
+    );
+
+    expect($result)->toBe([
+        'delivered' => false,
+        'provider_message_id' => null,
+        'invalid_token' => true,
+        'provider_error_code' => 'UNREGISTERED',
+    ]);
+
+    $this->assertDatabaseMissing('push_device_registrations', [
+        'id' => $registration->id,
+    ]);
+});

--- a/tests/Unit/Services/AndroidPushDeliveryServiceTest.php
+++ b/tests/Unit/Services/AndroidPushDeliveryServiceTest.php
@@ -40,20 +40,6 @@ afterEach(function (): void {
     TenantKey::setKekPath(null);
 });
 
-/**
- * @return array{tenant: TenantKey, user: User}
- */
-function createAndroidPushDeliveryContext(): array
-{
-    $tenant = TenantKey::create(TenantKey::generateEnvelopeKeys());
-    $user = User::factory()->create(['tenant_id' => $tenant->id]);
-
-    return [
-        'tenant' => $tenant,
-        'user' => $user,
-    ];
-}
-
 function createAndroidPushRegistration(TenantKey $tenant, User $user): PushDeviceRegistration
 {
     return PushDeviceRegistration::query()->create([

--- a/tests/Unit/Services/AndroidPushDeliveryServiceTest.php
+++ b/tests/Unit/Services/AndroidPushDeliveryServiceTest.php
@@ -163,6 +163,74 @@ test('service fails closed when customer owned firebase credentials are incomple
     Http::assertNothingSent();
 });
 
+test('service deletes registration and returns invalid token when device token decryption fails', function (): void {
+    $registration = createAndroidPushRegistration($this->tenant, $this->user);
+
+    // Corrupt the stored ciphertext so the EncryptedWithDek cast throws on get.
+    $registration->getConnection()
+        ->table('push_device_registrations')
+        ->where('id', $registration->id)
+        ->update(['push_token_enc' => 'not-valid-json']);
+
+    $freshRegistration = PushDeviceRegistration::query()->findOrFail($registration->id);
+
+    Http::fake();
+
+    $result = app(AndroidPushDeliveryService::class)->send(
+        $freshRegistration,
+        'Compliance alert',
+        'Permit expires soon.',
+        ['category' => 'compliance_alert'],
+    );
+
+    expect($result)->toBe([
+        'delivered' => false,
+        'provider_message_id' => null,
+        'invalid_token' => true,
+        'provider_error_code' => 'DECRYPTION_FAILURE',
+    ]);
+
+    $this->assertDatabaseMissing('push_device_registrations', [
+        'id' => $registration->id,
+    ]);
+
+    Http::assertNothingSent();
+});
+
+test('service deletes registration and returns invalid token when device token is absent', function (): void {
+    $registration = createAndroidPushRegistration($this->tenant, $this->user);
+
+    // Force the in-memory cast to return null by wiping the raw attribute value.
+    // The column is NOT NULL in the DB, so we simulate a partially-hydrated model
+    // where the attribute is unset after hydration (e.g. via setRawAttributes).
+    $registration->setRawAttributes(array_merge(
+        $registration->getRawOriginal(),
+        ['push_token_enc' => null],
+    ));
+
+    Http::fake();
+
+    $result = app(AndroidPushDeliveryService::class)->send(
+        $registration,
+        'Compliance alert',
+        'Permit expires soon.',
+        ['category' => 'compliance_alert'],
+    );
+
+    expect($result)->toBe([
+        'delivered' => false,
+        'provider_message_id' => null,
+        'invalid_token' => true,
+        'provider_error_code' => 'MISSING_TOKEN',
+    ]);
+
+    $this->assertDatabaseMissing('push_device_registrations', [
+        'id' => $registration->id,
+    ]);
+
+    Http::assertNothingSent();
+});
+
 test('service deletes stale registrations when firebase reports an unregistered token', function (): void {
     $registration = createAndroidPushRegistration($this->tenant, $this->user);
 

--- a/tests/Unit/Services/AndroidPushDeliveryServiceTest.php
+++ b/tests/Unit/Services/AndroidPushDeliveryServiceTest.php
@@ -239,6 +239,47 @@ test('service deletes registration and returns invalid token when device token d
     Http::assertNothingSent();
 });
 
+test('service deletes registration and returns invalid token when encrypted token payload is well formed but tampered', function (): void {
+    $registration = createAndroidPushRegistration($this->tenant, $this->user);
+
+    $storedPayload = json_decode((string) $registration->getRawOriginal('push_token_enc'), true, flags: JSON_THROW_ON_ERROR);
+    $originalCiphertext = base64_decode($storedPayload['ciphertext'], true);
+
+    expect($originalCiphertext)->toBeString();
+
+    $registration->getConnection()
+        ->table('push_device_registrations')
+        ->where('id', $registration->id)
+        ->update(['push_token_enc' => json_encode([
+            'ciphertext' => base64_encode(str_repeat("\x00", strlen($originalCiphertext))),
+            'nonce' => $storedPayload['nonce'],
+        ], JSON_THROW_ON_ERROR)]);
+
+    $freshRegistration = PushDeviceRegistration::query()->findOrFail($registration->id);
+
+    Http::fake();
+
+    $result = app(AndroidPushDeliveryService::class)->send(
+        $freshRegistration,
+        'Compliance alert',
+        'Permit expires soon.',
+        ['category' => 'compliance_alert'],
+    );
+
+    expect($result)->toBe([
+        'delivered' => false,
+        'provider_message_id' => null,
+        'invalid_token' => true,
+        'provider_error_code' => 'DECRYPTION_FAILURE',
+    ]);
+
+    $this->assertDatabaseMissing('push_device_registrations', [
+        'id' => $registration->id,
+    ]);
+
+    Http::assertNothingSent();
+});
+
 test('service surfaces tenant key runtime failures without deleting registration', function (): void {
     $registration = createAndroidPushRegistration($this->tenant, $this->user);
 

--- a/tests/Unit/Services/AndroidPushDeliveryServiceTest.php
+++ b/tests/Unit/Services/AndroidPushDeliveryServiceTest.php
@@ -12,6 +12,7 @@ use App\Services\AndroidPushDeliveryService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Http;
+use Tests\Support\TenantKeyReadabilityOverride;
 
 uses(RefreshDatabase::class);
 
@@ -38,6 +39,7 @@ beforeEach(function (): void {
 afterEach(function (): void {
     cleanupTestKekFile();
     TenantKey::setKekPath(null);
+    TenantKeyReadabilityOverride::clear();
 });
 
 function createAndroidPushRegistration(TenantKey $tenant, User $user): PushDeviceRegistration
@@ -237,7 +239,28 @@ test('service deletes registration and returns invalid token when device token d
     Http::assertNothingSent();
 });
 
-test('service deletes registration and returns invalid token when device token is absent', function (): void {
+test('service surfaces tenant key runtime failures without deleting registration', function (): void {
+    $registration = createAndroidPushRegistration($this->tenant, $this->user);
+
+    TenantKeyReadabilityOverride::markUnreadable(getTestKekPath());
+
+    Http::fake();
+
+    expect(fn () => app(AndroidPushDeliveryService::class)->send(
+        $registration,
+        'Compliance alert',
+        'Permit expires soon.',
+        ['category' => 'compliance_alert'],
+    ))->toThrow(RuntimeException::class, 'KEK file is not readable by this process');
+
+    $this->assertDatabaseHas('push_device_registrations', [
+        'id' => $registration->id,
+    ]);
+
+    Http::assertNothingSent();
+});
+
+test('service fails closed when device token is absent on the loaded model without deleting registration', function (): void {
     $registration = createAndroidPushRegistration($this->tenant, $this->user);
 
     // Force the in-memory cast to return null by wiping the raw attribute value.
@@ -250,21 +273,14 @@ test('service deletes registration and returns invalid token when device token i
 
     Http::fake();
 
-    $result = app(AndroidPushDeliveryService::class)->send(
+    expect(fn () => app(AndroidPushDeliveryService::class)->send(
         $registration,
         'Compliance alert',
         'Permit expires soon.',
         ['category' => 'compliance_alert'],
-    );
+    ))->toThrow(RuntimeException::class, 'Android push delivery requires a decryptable device token.');
 
-    expect($result)->toBe([
-        'delivered' => false,
-        'provider_message_id' => null,
-        'invalid_token' => true,
-        'provider_error_code' => 'MISSING_TOKEN',
-    ]);
-
-    $this->assertDatabaseMissing('push_device_registrations', [
+    $this->assertDatabaseHas('push_device_registrations', [
         'id' => $registration->id,
     ]);
 

--- a/tests/Unit/Services/AndroidPushDeliveryServiceTest.php
+++ b/tests/Unit/Services/AndroidPushDeliveryServiceTest.php
@@ -280,6 +280,44 @@ test('service deletes registration and returns invalid token when encrypted toke
     Http::assertNothingSent();
 });
 
+test('service deletes registration and returns invalid token when encrypted token nonce length is invalid', function (): void {
+    $registration = createAndroidPushRegistration($this->tenant, $this->user);
+
+    $storedPayload = json_decode((string) $registration->getRawOriginal('push_token_enc'), true, flags: JSON_THROW_ON_ERROR);
+
+    $registration->getConnection()
+        ->table('push_device_registrations')
+        ->where('id', $registration->id)
+        ->update(['push_token_enc' => json_encode([
+            'ciphertext' => $storedPayload['ciphertext'],
+            'nonce' => base64_encode('short'),
+        ], JSON_THROW_ON_ERROR)]);
+
+    $freshRegistration = PushDeviceRegistration::query()->findOrFail($registration->id);
+
+    Http::fake();
+
+    $result = app(AndroidPushDeliveryService::class)->send(
+        $freshRegistration,
+        'Compliance alert',
+        'Permit expires soon.',
+        ['category' => 'compliance_alert'],
+    );
+
+    expect($result)->toBe([
+        'delivered' => false,
+        'provider_message_id' => null,
+        'invalid_token' => true,
+        'provider_error_code' => 'DECRYPTION_FAILURE',
+    ]);
+
+    $this->assertDatabaseMissing('push_device_registrations', [
+        'id' => $registration->id,
+    ]);
+
+    Http::assertNothingSent();
+});
+
 test('service surfaces tenant key runtime failures without deleting registration', function (): void {
     $registration = createAndroidPushRegistration($this->tenant, $this->user);
 
@@ -367,6 +405,79 @@ test('service deletes stale registrations when firebase reports an unregistered 
     ]);
 
     $this->assertDatabaseMissing('push_device_registrations', [
+        'id' => $registration->id,
+    ]);
+});
+
+test('service deletes stale registrations when firebase reports invalid argument via status without details error code', function (): void {
+    $registration = createAndroidPushRegistration($this->tenant, $this->user);
+
+    Http::fake([
+        'https://oauth2.googleapis.com/token' => Http::response([
+            'access_token' => 'google-access-token',
+            'token_type' => 'Bearer',
+            'expires_in' => 3600,
+        ], 200),
+        'https://fcm.googleapis.com/v1/projects/customer-owned-project/messages:send' => Http::response([
+            'error' => [
+                'code' => 400,
+                'message' => 'The registration token is not a valid FCM registration token.',
+                'status' => 'INVALID_ARGUMENT',
+            ],
+        ], 400),
+    ]);
+
+    $result = app(AndroidPushDeliveryService::class)->send(
+        $registration,
+        'Compliance alert',
+        'Permit expires soon.',
+        ['category' => 'compliance_alert'],
+    );
+
+    expect($result)->toBe([
+        'delivered' => false,
+        'provider_message_id' => null,
+        'invalid_token' => true,
+        'provider_error_code' => 'INVALID_ARGUMENT',
+    ]);
+
+    $this->assertDatabaseMissing('push_device_registrations', [
+        'id' => $registration->id,
+    ]);
+});
+
+test('service preserves registrations when firebase reports sender mismatch', function (): void {
+    $registration = createAndroidPushRegistration($this->tenant, $this->user);
+
+    Http::fake([
+        'https://oauth2.googleapis.com/token' => Http::response([
+            'access_token' => 'google-access-token',
+            'token_type' => 'Bearer',
+            'expires_in' => 3600,
+        ], 200),
+        'https://fcm.googleapis.com/v1/projects/customer-owned-project/messages:send' => Http::response([
+            'error' => [
+                'code' => 403,
+                'message' => 'The authenticated sender does not match the sender for the registration token.',
+                'status' => 'PERMISSION_DENIED',
+                'details' => [
+                    [
+                        '@type' => 'type.googleapis.com/google.firebase.fcm.v1.FcmError',
+                        'errorCode' => 'SENDER_ID_MISMATCH',
+                    ],
+                ],
+            ],
+        ], 403),
+    ]);
+
+    expect(fn () => app(AndroidPushDeliveryService::class)->send(
+        $registration,
+        'Compliance alert',
+        'Permit expires soon.',
+        ['category' => 'compliance_alert'],
+    ))->toThrow(RuntimeException::class, 'Firebase push delivery failed with HTTP 403 (SENDER_ID_MISMATCH).');
+
+    $this->assertDatabaseHas('push_device_registrations', [
         'id' => $registration->id,
     ]);
 });

--- a/tests/Unit/Services/AndroidPushDeliveryServiceTest.php
+++ b/tests/Unit/Services/AndroidPushDeliveryServiceTest.php
@@ -146,6 +146,46 @@ test('service sends android push through customer owned firebase credentials', f
     ]);
 });
 
+test('service omits empty message data from firebase payload', function (): void {
+    $registration = createAndroidPushRegistration($this->tenant, $this->user);
+
+    Http::fake([
+        'https://oauth2.googleapis.com/token' => Http::response([
+            'access_token' => 'google-access-token',
+            'token_type' => 'Bearer',
+            'expires_in' => 3600,
+        ], 200),
+        'https://fcm.googleapis.com/v1/projects/customer-owned-project/messages:send' => Http::response([
+            'name' => 'projects/customer-owned-project/messages/0:1710000000000000%1234abcd1234abcd',
+        ], 200),
+    ]);
+
+    $result = app(AndroidPushDeliveryService::class)->send(
+        $registration,
+        'Compliance alert',
+        'Permit expires soon.',
+    );
+
+    expect($result)->toBe([
+        'delivered' => true,
+        'provider_message_id' => 'projects/customer-owned-project/messages/0:1710000000000000%1234abcd1234abcd',
+        'invalid_token' => false,
+        'provider_error_code' => null,
+    ]);
+
+    Http::assertSent(function (Request $request): bool {
+        if ($request->url() !== 'https://fcm.googleapis.com/v1/projects/customer-owned-project/messages:send') {
+            return false;
+        }
+
+        $payload = $request->data();
+        $message = $payload['message'] ?? null;
+
+        return is_array($message)
+            && ! array_key_exists('data', $message);
+    });
+});
+
 test('service fails closed when customer owned firebase credentials are incomplete', function (): void {
     $registration = createAndroidPushRegistration($this->tenant, $this->user);
 


### PR DESCRIPTION
## Summary
- add backend-only FCM delivery configuration plus direct Android push send and queue-job primitives for customer-hosted deployments
- fail closed on missing customer-owned delivery credentials, delete stale registrations on invalid-token outcomes, and keep private provider data out of `GET /v1/bootstrap`
- document operator setup for `ANDROID_PUSH_FCM_*` and cover the send/config/bootstrap slices with focused Pest coverage

## Issue
- Closes #1122
- Part of #1121

## Validation
- `vendor/bin/pint --dirty`
- `php artisan test tests/Unit/Services/AndroidPushDeliveryServiceTest.php tests/Feature/Jobs/DeliverAndroidPushMessageTest.php tests/Feature/Api/V1/BootstrapApiTest.php`
- `vendor/bin/phpstan analyse app/Services/AndroidPushDeliveryService.php`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Introduces handling of FCM service-account private keys, outbound auth to Google, and automatic deletion of push registrations based on delivery/decryption outcomes—security- and data-sensitive paths with broad test coverage but production misconfiguration could block or mis-route notifications.
> 
> **Overview**
> Customer-hosted deployments can send Android notifications **directly to Firebase FCM HTTP v1** using backend-only `ANDROID_PUSH_FCM_*` settings (mapped to `services.fcm`), without SecPal-operated push routing. A new **`AndroidPushDeliveryService`** obtains a service-account JWT, posts notification/data payloads, and a **`DeliverAndroidPushMessage`** queue job runs delivery with retries/backoff when FCM is configured.
> 
> **Token handling and cleanup:** `PushDeviceRegistration` gains a decrypt path for delivery; corrupt or undecryptable tokens are treated as invalid and the registration is removed without calling FCM. Provider outcomes such as **`UNREGISTERED`** and token-specific **`INVALID_ARGUMENT`** also delete stale registrations; other failures (e.g. **`SENDER_ID_MISMATCH`**) throw without deleting.
> 
> **Encryption errors:** `EncryptedWithDek` and `TenantKey` now raise dedicated exceptions (`CorruptedEncryptedAttributeException`, `TenantKeyDecryptionException`) instead of generic runtime errors, with tests updated accordingly. Shared **`positiveIntegerConfig`** moves into `InteractsWithConfigValues` for reuse by push config classes.
> 
> **Security and ops:** `.env.example` and deployment docs document that FCM credentials must never appear on **`GET /v1/bootstrap`**; a new bootstrap test asserts private project/email/key values are absent from the response body. Changelog records the feature under Unreleased **Added**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb61aec6f5068c9a99f7dc9b2d307c8bb8f440c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->