### PR TITLE
refactor(api): cover shared positiveIntegerConfig trait helper

### DIFF
--- a/tests/Unit/Support/InteractsWithConfigValuesTest.php
+++ b/tests/Unit/Support/InteractsWithConfigValuesTest.php
@@ -31,12 +31,14 @@ test('positiveIntegerConfig returns null without a default for missing and inval
     $harness = interactsWithConfigValuesHarness();
 
     config()->set('test.positive_integer.zero', 0);
+    config()->set('test.positive_integer.zero_string', '0');
     config()->set('test.positive_integer.negative_int', -3);
     config()->set('test.positive_integer.negative_string', '-1');
     config()->set('test.positive_integer.invalid_string', 'abc');
 
     expect($harness->readPositiveIntegerConfig('test.positive_integer.missing'))->toBeNull()
         ->and($harness->readPositiveIntegerConfig('test.positive_integer.zero'))->toBeNull()
+        ->and($harness->readPositiveIntegerConfig('test.positive_integer.zero_string'))->toBeNull()
         ->and($harness->readPositiveIntegerConfig('test.positive_integer.negative_int'))->toBeNull()
         ->and($harness->readPositiveIntegerConfig('test.positive_integer.negative_string'))->toBeNull()
         ->and($harness->readPositiveIntegerConfig('test.positive_integer.invalid_string'))->toBeNull();
@@ -46,11 +48,15 @@ test('positiveIntegerConfig returns the provided default for missing and invalid
     $harness = interactsWithConfigValuesHarness();
 
     config()->set('test.positive_integer.zero_with_default', 0);
+    config()->set('test.positive_integer.zero_string_with_default', '0');
     config()->set('test.positive_integer.negative_int_with_default', -3);
     config()->set('test.positive_integer.invalid_with_default', 'abc');
+    config()->set('test.positive_integer.valid_with_default', 7);
 
     expect($harness->readPositiveIntegerConfig('test.positive_integer.missing_with_default', 5))->toBe(5)
         ->and($harness->readPositiveIntegerConfig('test.positive_integer.zero_with_default', 5))->toBe(5)
+        ->and($harness->readPositiveIntegerConfig('test.positive_integer.zero_string_with_default', 5))->toBe(5)
         ->and($harness->readPositiveIntegerConfig('test.positive_integer.negative_int_with_default', 5))->toBe(5)
-        ->and($harness->readPositiveIntegerConfig('test.positive_integer.invalid_with_default', 5))->toBe(5);
+        ->and($harness->readPositiveIntegerConfig('test.positive_integer.invalid_with_default', 5))->toBe(5)
+        ->and($harness->readPositiveIntegerConfig('test.positive_integer.valid_with_default', 5))->toBe(7);
 });

--- a/tests/Unit/Support/InteractsWithConfigValuesTest.php
+++ b/tests/Unit/Support/InteractsWithConfigValuesTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use App\Support\Concerns\InteractsWithConfigValues;
+
+function interactsWithConfigValuesHarness(): object
+{
+    return new class
+    {
+        use InteractsWithConfigValues {
+            positiveIntegerConfig as public readPositiveIntegerConfig;
+        }
+    };
+}
+
+test('positiveIntegerConfig returns positive integers from integer and numeric string config values', function (): void {
+    $harness = interactsWithConfigValuesHarness();
+
+    config()->set('test.positive_integer.int', 7);
+    config()->set('test.positive_integer.string', '11');
+
+    expect($harness->readPositiveIntegerConfig('test.positive_integer.int'))->toBe(7)
+        ->and($harness->readPositiveIntegerConfig('test.positive_integer.string'))->toBe(11);
+});
+
+test('positiveIntegerConfig returns null without a default for missing and invalid config values', function (): void {
+    $harness = interactsWithConfigValuesHarness();
+
+    config()->set('test.positive_integer.zero', 0);
+    config()->set('test.positive_integer.negative_string', '-1');
+    config()->set('test.positive_integer.invalid_string', 'abc');
+
+    expect($harness->readPositiveIntegerConfig('test.positive_integer.missing'))->toBeNull()
+        ->and($harness->readPositiveIntegerConfig('test.positive_integer.zero'))->toBeNull()
+        ->and($harness->readPositiveIntegerConfig('test.positive_integer.negative_string'))->toBeNull()
+        ->and($harness->readPositiveIntegerConfig('test.positive_integer.invalid_string'))->toBeNull();
+});
+
+test('positiveIntegerConfig returns the provided default for missing and invalid config values', function (): void {
+    $harness = interactsWithConfigValuesHarness();
+
+    config()->set('test.positive_integer.zero_with_default', 0);
+    config()->set('test.positive_integer.invalid_with_default', 'abc');
+
+    expect($harness->readPositiveIntegerConfig('test.positive_integer.missing_with_default', 5))->toBe(5)
+        ->and($harness->readPositiveIntegerConfig('test.positive_integer.zero_with_default', 5))->toBe(5)
+        ->and($harness->readPositiveIntegerConfig('test.positive_integer.invalid_with_default', 5))->toBe(5);
+});

--- a/tests/Unit/Support/InteractsWithConfigValuesTest.php
+++ b/tests/Unit/Support/InteractsWithConfigValuesTest.php
@@ -35,13 +35,15 @@ test('positiveIntegerConfig returns null without a default for missing and inval
     config()->set('test.positive_integer.negative_int', -3);
     config()->set('test.positive_integer.negative_string', '-1');
     config()->set('test.positive_integer.invalid_string', 'abc');
+    config()->set('test.positive_integer.float', 3.14);
 
     expect($harness->readPositiveIntegerConfig('test.positive_integer.missing'))->toBeNull()
         ->and($harness->readPositiveIntegerConfig('test.positive_integer.zero'))->toBeNull()
         ->and($harness->readPositiveIntegerConfig('test.positive_integer.zero_string'))->toBeNull()
         ->and($harness->readPositiveIntegerConfig('test.positive_integer.negative_int'))->toBeNull()
         ->and($harness->readPositiveIntegerConfig('test.positive_integer.negative_string'))->toBeNull()
-        ->and($harness->readPositiveIntegerConfig('test.positive_integer.invalid_string'))->toBeNull();
+        ->and($harness->readPositiveIntegerConfig('test.positive_integer.invalid_string'))->toBeNull()
+        ->and($harness->readPositiveIntegerConfig('test.positive_integer.float'))->toBeNull();
 });
 
 test('positiveIntegerConfig returns the provided default for missing and invalid config values', function (): void {
@@ -52,11 +54,13 @@ test('positiveIntegerConfig returns the provided default for missing and invalid
     config()->set('test.positive_integer.negative_int_with_default', -3);
     config()->set('test.positive_integer.invalid_with_default', 'abc');
     config()->set('test.positive_integer.valid_with_default', 7);
+    config()->set('test.positive_integer.float_with_default', 3.14);
 
     expect($harness->readPositiveIntegerConfig('test.positive_integer.missing_with_default', 5))->toBe(5)
         ->and($harness->readPositiveIntegerConfig('test.positive_integer.zero_with_default', 5))->toBe(5)
         ->and($harness->readPositiveIntegerConfig('test.positive_integer.zero_string_with_default', 5))->toBe(5)
         ->and($harness->readPositiveIntegerConfig('test.positive_integer.negative_int_with_default', 5))->toBe(5)
         ->and($harness->readPositiveIntegerConfig('test.positive_integer.invalid_with_default', 5))->toBe(5)
-        ->and($harness->readPositiveIntegerConfig('test.positive_integer.valid_with_default', 5))->toBe(7);
+        ->and($harness->readPositiveIntegerConfig('test.positive_integer.valid_with_default', 5))->toBe(7)
+        ->and($harness->readPositiveIntegerConfig('test.positive_integer.float_with_default', 5))->toBe(5);
 });

--- a/tests/Unit/Support/InteractsWithConfigValuesTest.php
+++ b/tests/Unit/Support/InteractsWithConfigValuesTest.php
@@ -31,11 +31,13 @@ test('positiveIntegerConfig returns null without a default for missing and inval
     $harness = interactsWithConfigValuesHarness();
 
     config()->set('test.positive_integer.zero', 0);
+    config()->set('test.positive_integer.negative_int', -3);
     config()->set('test.positive_integer.negative_string', '-1');
     config()->set('test.positive_integer.invalid_string', 'abc');
 
     expect($harness->readPositiveIntegerConfig('test.positive_integer.missing'))->toBeNull()
         ->and($harness->readPositiveIntegerConfig('test.positive_integer.zero'))->toBeNull()
+        ->and($harness->readPositiveIntegerConfig('test.positive_integer.negative_int'))->toBeNull()
         ->and($harness->readPositiveIntegerConfig('test.positive_integer.negative_string'))->toBeNull()
         ->and($harness->readPositiveIntegerConfig('test.positive_integer.invalid_string'))->toBeNull();
 });
@@ -44,9 +46,11 @@ test('positiveIntegerConfig returns the provided default for missing and invalid
     $harness = interactsWithConfigValuesHarness();
 
     config()->set('test.positive_integer.zero_with_default', 0);
+    config()->set('test.positive_integer.negative_int_with_default', -3);
     config()->set('test.positive_integer.invalid_with_default', 'abc');
 
     expect($harness->readPositiveIntegerConfig('test.positive_integer.missing_with_default', 5))->toBe(5)
         ->and($harness->readPositiveIntegerConfig('test.positive_integer.zero_with_default', 5))->toBe(5)
+        ->and($harness->readPositiveIntegerConfig('test.positive_integer.negative_int_with_default', 5))->toBe(5)
         ->and($harness->readPositiveIntegerConfig('test.positive_integer.invalid_with_default', 5))->toBe(5);
 });


### PR DESCRIPTION
## Summary
- add focused Pest unit coverage for `InteractsWithConfigValues::positiveIntegerConfig()`
- cover both nullable and defaulted call patterns used by the Android push configuration classes
- keep production code unchanged because the helper is already consolidated in the trait on current `main`

## Validation
- `php artisan test tests/Unit/Support/InteractsWithConfigValuesTest.php`
- `vendor/bin/pint --dirty`

Closes #1129

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change; behavior of shared config parsing is documented but not modified.
> 
> **Overview**
> Adds **Pest unit tests** for `InteractsWithConfigValues::positiveIntegerConfig()` with no production changes.
> 
> Coverage uses an anonymous harness that exposes the private helper and checks **valid** positive ints and numeric strings, **`null`** when keys are missing or values are zero, negative, non-numeric, or floats (no default), and **default fallback** for the same invalid cases while still returning the config value when it is valid.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27588b2c86ed45035cd17492884706385ccf9073. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->