### PR TITLE
Adopt provider-neutral AI instructions

### DIFF
--- a/.github/instructions/org-shared.instructions.md
+++ b/.github/instructions/org-shared.instructions.md
@@ -10,10 +10,16 @@ applyTo: "**"
 
 This file auto-applies to all files in this repo so strict SecPal governance stays always present at runtime.
 
-- `.github/copilot-instructions.md` is the authoritative runtime baseline for this repo.
-- Non-negotiable: TDD first, quality first, 1 topic = 1 PR = 1 branch, immediate GitHub issue creation for every real out-of-scope finding, and no bypass.
-- If work needs more than one PR, or probably will, create an EPIC with linked sub-issues before implementation.
+- `AGENTS.md` is the authoritative runtime baseline for this repo.
+  `.github/copilot-instructions.md` is only a compatibility mirror.
+- Non-negotiable: TDD first, quality first, 1 topic = 1 PR = 1 branch,
+  immediate GitHub issue creation for every real out-of-scope finding, and no
+  bypass.
+- If work needs more than one PR, or probably will, create an EPIC with linked
+  sub-issues before implementation.
 - Design discipline is always-on: DRY, KISS, YAGNI, SOLID, and fail fast.
 - GitHub communication stays in English and uses file and line references instead of large verbatim code quotes.
+- Do not add AI self-references, generated-by text, tool promotion, or AI
+  attribution unless the task explicitly requires documenting AI tooling.
 - Keep changes repo-local, minimal, and consistent with Laravel, Pest, and native PHP runtime conventions.
 - Apply the SecPal domain policy and immediate warning and issue triage rules from the repo baseline.

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -30,10 +30,14 @@ jobs:
   markdown-lint:
     name: Markdown Lint
     uses: SecPal/.github/.github/workflows/reusable-markdown-lint.yml@6f8e13a7a62cee356811a7f58d6b92119941652f
+    with:
+      governance-ref: "6f8e13a7a62cee356811a7f58d6b92119941652f"
 
   ai-instructions:
     name: AI Instructions
     uses: SecPal/.github/.github/workflows/reusable-ai-instructions.yml@6f8e13a7a62cee356811a7f58d6b92119941652f
+    with:
+      governance-ref: "6f8e13a7a62cee356811a7f58d6b92119941652f"
 
   pint:
     name: Laravel Pint

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -31,9 +31,9 @@ jobs:
     name: Markdown Lint
     uses: SecPal/.github/.github/workflows/reusable-markdown-lint.yml@main
 
-  copilot-instructions:
-    name: Copilot Instructions
-    uses: SecPal/.github/.github/workflows/reusable-copilot-instructions.yml@main
+  ai-instructions:
+    name: AI Instructions
+    uses: SecPal/.github/.github/workflows/reusable-ai-instructions.yml@main
 
   pint:
     name: Laravel Pint

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -17,11 +17,11 @@ permissions:
 jobs:
   reuse:
     name: Check REUSE Compliance
-    uses: SecPal/.github/.github/workflows/reusable-reuse.yml@main
+    uses: SecPal/.github/.github/workflows/reusable-reuse.yml@6f8e13a7a62cee356811a7f58d6b92119941652f
 
   license-compatibility:
     name: Check License Compatibility
-    uses: SecPal/.github/.github/workflows/reusable-license-compatibility.yml@main
+    uses: SecPal/.github/.github/workflows/reusable-license-compatibility.yml@6f8e13a7a62cee356811a7f58d6b92119941652f
 
   prettier:
     name: Formatting Check
@@ -29,21 +29,21 @@ jobs:
 
   markdown-lint:
     name: Markdown Lint
-    uses: SecPal/.github/.github/workflows/reusable-markdown-lint.yml@main
+    uses: SecPal/.github/.github/workflows/reusable-markdown-lint.yml@6f8e13a7a62cee356811a7f58d6b92119941652f
 
   ai-instructions:
     name: AI Instructions
-    uses: SecPal/.github/.github/workflows/reusable-ai-instructions.yml@main
+    uses: SecPal/.github/.github/workflows/reusable-ai-instructions.yml@6f8e13a7a62cee356811a7f58d6b92119941652f
 
   pint:
     name: Laravel Pint
-    uses: SecPal/.github/.github/workflows/reusable-php-lint.yml@main
+    uses: SecPal/.github/.github/workflows/reusable-php-lint.yml@6f8e13a7a62cee356811a7f58d6b92119941652f
     with:
       php-version: "8.4"
 
   phpstan:
     name: PHPStan
-    uses: SecPal/.github/.github/workflows/reusable-php-stan.yml@main
+    uses: SecPal/.github/.github/workflows/reusable-php-stan.yml@6f8e13a7a62cee356811a7f58d6b92119941652f
     with:
       php-version: "8.4"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,16 +3,13 @@ SPDX-FileCopyrightText: 2026 SecPal
 SPDX-License-Identifier: AGPL-3.0-or-later
 -->
 
-# SecPal/api Copilot Instructions
+# SecPal/api Agent Instructions
 
-This file mirrors the authoritative root `AGENTS.md` for tooling
-that automatically loads `.github/copilot-instructions.md`.
-Edit `AGENTS.md` first. Keep the focused overlay files aligned
-for path-specific or stack-specific rules.
+This file is the authoritative, provider-neutral runtime baseline for this repository.
+Edit this file first. Keep the focused overlay files below aligned when a rule also needs path-specific or stack-specific enforcement.
 
-## Authoritative Sources
+## Focused Overlays
 
-- `AGENTS.md`
 - `.github/instructions/org-shared.instructions.md`
 - `.github/instructions/php-laravel.instructions.md`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- hardened the governance rollout in `quality.yml` by pinning shared reusable workflows to the current `.github` commit and keeping the provider-neutral AI-instructions validation path reproducible in CI
 - `GET /v1/bootstrap?client_platform=browser` now keeps the AGPL `legal.source_url` disclosure while limiting public notification runtime metadata to the browser-relevant `web_push` channel, so browser clients no longer receive Android FCM bootstrap metadata
 - public notification runtime discovery now uses the canonical shared channel contract end-to-end: `GET /v1/bootstrap` returns exhaustive `features.notification_channels` flags plus per-channel `notification_channels.android_fcm` / `notification_channels.web_push` runtime metadata, `schema_version` is now `3`, the legacy top-level Android `android_push` bootstrap alias is removed, and authenticated installation conflicts fail closed with generic `NOTIFICATION_CHANNEL_UNSUPPORTED` / `NOTIFICATION_RUNTIME_STATE_INVALID` payloads keyed by channel (refs `api#1132`)
 - `DELETE /v1/me/notification-installations/{installationId}` no longer checks whether the push channel is enabled before revoking; revocation succeeds regardless of the channel's current deployment state, so clients can always clean up stale registrations on logout or uninstall even if the operator later disables the channel


### PR DESCRIPTION
## Summary
- add root `AGENTS.md` as the provider-neutral instruction baseline for `api`
- refresh `.github/copilot-instructions.md` into an explicit compatibility mirror of `AGENTS.md`
- align the repo-local instruction overlays and quality workflow wiring with the new AI-instructions validation path

## TDD / Validate-First Evidence
- Failing proof before implementation: `bash /home/secpal/code/SecPal/.github/scripts/validate-ai-instructions.sh /home/secpal/code/SecPal/api` on `main` failed because `AGENTS.md` was missing and the Copilot instructions did not satisfy the new mirror contract.
- Passing proof after implementation: `bash /home/secpal/code/SecPal/.github/scripts/validate-ai-instructions.sh /home/secpal/code/SecPal/api` on `ai-instructions/provider-neutral-rollout`
- Validate-first exception reference: N/A
- No executable change reason: N/A

## Testing
- bash /home/secpal/code/SecPal/.github/scripts/validate-ai-instructions.sh /home/secpal/code/SecPal/api
