### PR TITLE
Block direct self-scope deletion on the same unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- blocked deleting any direct self scope assignment through `DELETE /v1/organizational-units/{organizational_unit}/scopes/{scope}`, so users can no longer silently narrow their own rank coverage on the same organizational unit by removing one of multiple `manage` scopes (fixes `api#1195`)
+- blocked deleting any direct self-scope assignment through `DELETE /v1/organizational-units/{organizational_unit}/scopes/{scope}`, so users can no longer silently narrow their own rank coverage on the same organizational unit by removing one of multiple `manage` scopes (fixes `api#1195`)
 - captured dedicated activity causer employee snapshot columns when activity rows are created, so historical activity-log scope authorization keeps the original organizational-unit and management-level context after later employee deprovisioning
 - stopped synthesizing missing activity causer rank snapshots during employee deletion, so legacy activity rows without a trustworthy per-event snapshot are no longer stamped with deletion-time employee state; employee deletion now preserves shared legacy user accounts only for genuinely live employee links while deprovisioning shared users retained by inactive or trashed references, including randomizing their primary credentials and anonymizing the retained login identifier so fresh session/token logins cannot be reissued
 - made preserved activity causer scope snapshots tamper-evident by including the captured causer employee context in the hash-chain payload used for both event creation and verification, so changes to preserved rank or organizational-unit authorization context now invalidate chain verification

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- blocked deleting any direct self scope assignment through `DELETE /v1/organizational-units/{organizational_unit}/scopes/{scope}`, so users can no longer silently narrow their own rank coverage on the same organizational unit by removing one of multiple `manage` scopes (fixes `api#1195`)
 - captured dedicated activity causer employee snapshot columns when activity rows are created, so historical activity-log scope authorization keeps the original organizational-unit and management-level context after later employee deprovisioning
 - stopped synthesizing missing activity causer rank snapshots during employee deletion, so legacy activity rows without a trustworthy per-event snapshot are no longer stamped with deletion-time employee state; employee deletion now preserves shared legacy user accounts only for genuinely live employee links while deprovisioning shared users retained by inactive or trashed references, including randomizing their primary credentials and anonymizing the retained login identifier so fresh session/token logins cannot be reissued
 - made preserved activity causer scope snapshots tamper-evident by including the captured causer employee context in the hash-chain payload used for both event creation and verification, so changes to preserved rank or organizational-unit authorization context now invalidate chain verification

--- a/app/Http/Controllers/Api/V1/OrganizationalScopeController.php
+++ b/app/Http/Controllers/Api/V1/OrganizationalScopeController.php
@@ -36,6 +36,8 @@ class OrganizationalScopeController extends Controller
 
     private const SELF_SCOPE_ESCALATION_MESSAGE = 'You cannot create or expand your own organizational scope permissions.';
 
+    private const SELF_SCOPE_DELETION_MESSAGE = 'You cannot delete your own organizational scope assignment for this organizational unit.';
+
     public function __construct(
         private readonly SelfScopeAuthorizationExpansionService $authorizationExpansionService,
     ) {}
@@ -245,21 +247,10 @@ class OrganizationalScopeController extends Controller
             ], 404);
         }
 
-        $lockoutResponse = $this->preventSelfScopeManagementLockout(
-            $actor,
-            $organizational_unit,
-            $scopeModel,
-            deleteScope: true,
-        );
+        $selfDeletionResponse = $this->preventSelfScopeDeletion($actor, $scopeModel);
 
-        if ($lockoutResponse !== null) {
-            return $lockoutResponse;
-        }
-
-        $expansionResponse = $this->preventSelfScopeDeletionExpansion($actor, $scopeModel);
-
-        if ($expansionResponse !== null) {
-            return $expansionResponse;
+        if ($selfDeletionResponse !== null) {
+            return $selfDeletionResponse;
         }
 
         $scopeModel->delete();
@@ -376,31 +367,18 @@ class OrganizationalScopeController extends Controller
         ], Response::HTTP_FORBIDDEN);
     }
 
-    private function preventSelfScopeDeletionExpansion(User $actor, UserInternalOrganizationalScope $scopeModel): ?JsonResponse
+    /**
+     * Under the manage-only model, users may not delete their own direct scope
+     * assignments on the unit they are currently managing.
+     */
+    private function preventSelfScopeDeletion(User $actor, UserInternalOrganizationalScope $scopeModel): ?JsonResponse
     {
         if (! $this->isActorScope($actor, $scopeModel)) {
             return null;
         }
 
-        $organizationalUnit = $scopeModel->organizationalUnit;
-
-        if ($organizationalUnit === null) {
-            return null;
-        }
-
-        /** @var Collection<int, UserInternalOrganizationalScope> $currentScopes */
-        $currentScopes = $actor->organizationalScopes()->get()->values();
-
-        $simulatedScopes = $currentScopes
-            ->reject(fn (UserInternalOrganizationalScope $scope) => $scope->id === $scopeModel->id)
-            ->values();
-
-        if (! $this->authorizationExpansionService->effectiveAuthorizationExpands($actor, $scopeModel, $scopeModel, $currentScopes, $simulatedScopes)) {
-            return null;
-        }
-
         return response()->json([
-            'message' => __(self::SELF_SCOPE_ESCALATION_MESSAGE),
+            'message' => __(self::SELF_SCOPE_DELETION_MESSAGE),
         ], Response::HTTP_FORBIDDEN);
     }
 

--- a/tests/Feature/Controllers/OrganizationalScopeControllerTest.php
+++ b/tests/Feature/Controllers/OrganizationalScopeControllerTest.php
@@ -715,7 +715,7 @@ describe('OrganizationalScopeController', function () {
             $response->assertNotFound();
         });
 
-        it('prevents a user from deleting their own last scope-management access for a unit', function (): void {
+        it('prevents a user from deleting their own scope assignment even when it is the only one on the unit', function (): void {
             $selfManagingUser = User::factory()->create(['tenant_id' => $this->tenant->id]);
             givePermissionWithTenant($selfManagingUser, $this->tenant->id, 'organizational_scopes.manage');
             $scope = UserInternalOrganizationalScope::create([
@@ -730,14 +730,14 @@ describe('OrganizationalScopeController', function () {
             $response = $this->deleteJson("/v1/organizational-units/{$this->company->id}/scopes/{$scope->id}");
 
             $response->assertForbidden()
-                ->assertJsonPath('message', 'You cannot remove your own last scope-management access for this organizational unit.');
+                ->assertJsonPath('message', 'You cannot delete your own organizational scope assignment for this organizational unit.');
 
             $this->assertDatabaseHas('user_internal_organizational_scopes', [
                 'id' => $scope->id,
             ]);
         });
 
-        it('allows deleting a self scope when another scope-management path still exists', function (): void {
+        it('prevents deleting any self scope assignment on the same unit even when another scope-management path still exists', function (): void {
             givePermissionWithTenant($this->scopeManagerUser, $this->tenant->id, 'organizational_scopes.manage');
 
             $scope = UserInternalOrganizationalScope::create([
@@ -745,22 +745,36 @@ describe('OrganizationalScopeController', function () {
                 'organizational_unit_id' => $this->company->id,
                 'access_level' => 'manage',
                 'include_descendants' => false,
+                'min_viewable_rank' => 0,
+                'max_viewable_rank' => 0,
+                'min_assignable_rank' => 0,
+                'max_assignable_rank' => 0,
+            ]);
+
+            UserInternalOrganizationalScope::create([
+                'user_id' => $this->scopeManagerUser->id,
+                'organizational_unit_id' => $this->company->id,
+                'access_level' => 'manage',
+                'include_descendants' => false,
+                'min_viewable_rank' => 1,
+                'max_viewable_rank' => 255,
+                'min_assignable_rank' => 1,
+                'max_assignable_rank' => 255,
             ]);
 
             $this->actingAs($this->scopeManagerUser);
 
             $response = $this->deleteJson("/v1/organizational-units/{$this->company->id}/scopes/{$scope->id}");
 
-            $response->assertNoContent();
+            $response->assertForbidden()
+                ->assertJsonPath('message', 'You cannot delete your own organizational scope assignment for this organizational unit.');
 
-            $this->assertDatabaseMissing('user_internal_organizational_scopes', [
+            $this->assertDatabaseHas('user_internal_organizational_scopes', [
                 'id' => $scope->id,
             ]);
-
-            expect($this->scopeManagerUser->fresh()->hasAccessToUnit($this->company, 'manage'))->toBeTrue();
         });
 
-        it('prevents deleting a self scope when doing so would widen inherited access', function (): void {
+        it('prevents deleting a self scope even when the remaining scopes would otherwise widen inherited access', function (): void {
             $selfManagingUser = User::factory()->create(['tenant_id' => $this->tenant->id]);
             givePermissionWithTenant($selfManagingUser, $this->tenant->id, 'organizational_scopes.manage');
 
@@ -793,7 +807,7 @@ describe('OrganizationalScopeController', function () {
             $response = $this->deleteJson("/v1/organizational-units/{$this->region->id}/scopes/{$scope->id}");
 
             $response->assertForbidden()
-                ->assertJsonPath('message', 'You cannot create or expand your own organizational scope permissions.');
+                ->assertJsonPath('message', 'You cannot delete your own organizational scope assignment for this organizational unit.');
 
             $this->assertDatabaseHas('user_internal_organizational_scopes', [
                 'id' => $scope->id,


### PR DESCRIPTION
## Summary

- Failing regression first: `tests/Feature/Controllers/OrganizationalScopeControllerTest.php:740` now proves the live `api.secpal.dev` case from `#1195` by reproducing a direct self-scope delete on the same organizational unit when another `manage` scope still exists; before this change the endpoint returned `204 No Content`, and the test now locks the expected `403`.
- Block direct self-scope deletion in `app/Http/Controllers/Api/V1/OrganizationalScopeController.php` so `DELETE /v1/organizational-units/{organizational_unit}/scopes/{scope}` rejects deleting any of the actor's own direct scope assignments on that unit instead of only blocking total self-lockout.
- Update the delete coverage for the single-scope case and the inherited-access edge case, and record the behavior change in `CHANGELOG.md`.

## Validation

- `php artisan test tests/Feature/Controllers/OrganizationalScopeControllerTest.php`
- `vendor/bin/pint --dirty`

## Follow-Up Before Ready

- Out-of-scope follow-up is tracked in `#1197` for direct self-scope update narrowing, which remains allowed today.
- Linked workspaces: none.
- Final PR self-review in GitHub is still required before moving this draft PR to ready.

Closes #1195
