### PR TITLE
Remove obsolete deprecated API compatibility paths

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -94,7 +94,7 @@ At minimum verify:
 - Reject AI-generated test or helper mutations that move executable code across Pest scope boundaries or bypass framework wiring.
 - Reject AI-generated refactors that resolve services inside API resources or serializers, move business logic into presentation code, or repeat request-scoped work that should run once per request.
 - Reject AI-generated key or constraint changes that derive identifiers from mutable display names or ignore tenant-scoped uniqueness and database constraints.
-- Reject AI-generated compatibility keep-alives that preserve obsolete request fields, deprecated payload aliases, or legacy API-side storage/input shims without a proven live caller. Because the SecPal project is still under `1.x`, prefer removing unnecessary compatibility paths over carrying them forward when they weaken security, correctness, or contract clarity.
+- Reject AI-generated compatibility keep-alives that preserve obsolete request fields, deprecated payload aliases, or legacy API-side storage/input shims without a proven live caller. Because the SecPal project is still under `0.x`, prefer removing unnecessary compatibility paths over carrying them forward when they weaken security, correctness, or contract clarity.
 
 ## Review guidelines
 
@@ -122,7 +122,7 @@ At minimum verify:
 ## Scope Notes
 
 - Do not add dependencies or create documentation files unless the task requires them.
-- Because the SecPal project is still under `1.x`, breaking changes are acceptable when they remove insecure or obsolete compatibility layers. When taking that route, update tests and `CHANGELOG.md` in the same change set instead of keeping a legacy path alive by default.
+- Because the SecPal project is still under `0.x`, breaking changes are acceptable when they remove insecure or obsolete compatibility layers. When taking that route, update tests and `CHANGELOG.md` in the same change set instead of keeping a legacy path alive by default.
 
 ## Additional Rules: org-shared.instructions.md
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ At minimum verify:
 - Reject AI-generated test or helper mutations that move executable code across Pest scope boundaries or bypass framework wiring.
 - Reject AI-generated refactors that resolve services inside API resources or serializers, move business logic into presentation code, or repeat request-scoped work that should run once per request.
 - Reject AI-generated key or constraint changes that derive identifiers from mutable display names or ignore tenant-scoped uniqueness and database constraints.
-- Reject AI-generated compatibility keep-alives that preserve obsolete request fields, deprecated payload aliases, or legacy API-side storage/input shims without a proven live caller. Because the SecPal project is still under `1.x`, prefer removing unnecessary compatibility paths over carrying them forward when they weaken security, correctness, or contract clarity.
+- Reject AI-generated compatibility keep-alives that preserve obsolete request fields, deprecated payload aliases, or legacy API-side storage/input shims without a proven live caller. Because the SecPal project is still under `0.x`, prefer removing unnecessary compatibility paths over carrying them forward when they weaken security, correctness, or contract clarity.
 
 ## Review guidelines
 
@@ -119,7 +119,7 @@ At minimum verify:
 ## Scope Notes
 
 - Do not add dependencies or create documentation files unless the task requires them.
-- Because the SecPal project is still under `1.x`, breaking changes are acceptable when they remove insecure or obsolete compatibility layers. When taking that route, update tests and `CHANGELOG.md` in the same change set instead of keeping a legacy path alive by default.
+- Because the SecPal project is still under `0.x`, breaking changes are acceptable when they remove insecure or obsolete compatibility layers. When taking that route, update tests and `CHANGELOG.md` in the same change set instead of keeping a legacy path alive by default.
 
 ## Additional Rules: org-shared.instructions.md
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking:** removed deprecated compatibility paths that the repo no longer actively uses: `POST /v1/auth/session/logout` is gone and `/v1/auth/logout` is now the only supported logout endpoint, onboarding token lookup no longer scans/backfills rows with `token_lookup_hash = null`, `Activity::getRetentionYears()` has been deleted in favor of `getRetentionYearsForLogType()` / `getAllRetentionYears()`, the obsolete address-data active-import cache prefix has been removed, and the repo docs/governance now consistently describe the project as operating under `0.x` with no guaranteed deprecation support window for obsolete API surfaces (refs `api#1199`, `api#1200`, `api#1201`, `api#1202`)
 - consolidated the self-scope authorization-expansion invariant into shared update-guard handling, removing the duplicate `UserInternalOrganizationalScope` helper and keeping the direct self-scope boundary checks in one place (refs `api#1190`)
 - replaced the remaining local `markdownlint-cli2` hook and preflight invocation with a pinned `markdownlint-cli@0.49.0` path so markdown governance follows the same CLI baseline as `SecPal/.github`
 - hardened the governance rollout in `quality.yml` by pinning shared reusable workflows to the current `.github` commit and keeping the provider-neutral AI-instructions validation path reproducible in CI

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -81,8 +81,7 @@ class AuthController extends Controller
      * from the remember_token cookie.
      *
      * Security note: Users can explicitly log out via the canonical
-     * /v1/auth/logout endpoint. The legacy /v1/auth/session/logout alias
-     * also remains available for backward compatibility.
+     * /v1/auth/logout endpoint.
      *
      * @throws ValidationException
      */
@@ -100,27 +99,6 @@ class AuthController extends Controller
         }
 
         return $this->completeSessionLogin($request, $user);
-    }
-
-    /**
-     * Legacy SPA logout alias.
-     *
-     * This preserves backward compatibility for existing SPA clients while
-     * delegating to the same session logout logic as /v1/auth/logout.
-     *
-     * Explicitly resolves the user via the web guard so Bearer-token clients
-     * receive a 401 instead of inadvertently clearing the remember-me state.
-     */
-    public function logoutSession(Request $request): JsonResponse
-    {
-        /** @var User|null $user */
-        $user = Auth::guard('web')->user();
-
-        if ($user === null) {
-            return response()->json(['message' => __('Unauthenticated.')], 401);
-        }
-
-        return $this->logoutCurrentSession($request, $user);
     }
 
     /**

--- a/app/Models/Activity.php
+++ b/app/Models/Activity.php
@@ -450,27 +450,6 @@ class Activity extends SpatieActivity
     }
 
     /**
-     * Get retention period in years for a log type.
-     *
-     * @deprecated Use getRetentionYearsForLogType() or getAllRetentionYears() instead
-     *
-     * @param  string|null  $logName  The log type name. If null, returns all retention periods.
-     * @return int|array<string, int> Retention period in years, or array of all periods
-     *
-     * @see BewachV §21 Abs. 4 - 3 years for Bewachungsgewerbe
-     * @see HGB §257 Abs. 4 - 8/10 years for commercial records
-     * @see AO §147 Abs. 3 - 8 years for tax-relevant documents
-     */
-    public static function getRetentionYears(?string $logName = null): int|array
-    {
-        if ($logName === null) {
-            return self::getAllRetentionYears();
-        }
-
-        return self::getRetentionYearsForLogType($logName);
-    }
-
-    /**
      * Validate that organizational unit belongs to same tenant.
      *
      * Extracted to dedicated method for better separation of concerns

--- a/app/Models/EmployeeOnboardingToken.php
+++ b/app/Models/EmployeeOnboardingToken.php
@@ -149,23 +149,7 @@ class EmployeeOnboardingToken extends Model
             return $token;
         }
 
-        /** @var EmployeeOnboardingToken<TFactory>|null $legacyToken */
-        $legacyToken = self::whereNull('completed_at')
-            ->whereNull('invalidated_at')
-            ->where('expires_at', '>', now())
-            ->whereNull('token_lookup_hash')
-            ->cursor()
-            ->first(fn (self $token): bool => Hash::check($plainToken, $token->token));
-
-        if (! $legacyToken instanceof self) {
-            return null;
-        }
-
-        $legacyToken->forceFill([
-            'token_lookup_hash' => $lookupHash,
-        ])->save();
-
-        return $legacyToken;
+        return null;
     }
 
     private static function buildTokenLookupHash(string $plainToken): string

--- a/app/Services/AddressData/AddressSuggestionService.php
+++ b/app/Services/AddressData/AddressSuggestionService.php
@@ -18,15 +18,11 @@ final class AddressSuggestionService
 {
     private const CACHE_TTL_SECONDS = 3600;
 
-    /** @deprecated Old keys cached full models and break after deploy (see activeImport). */
-    private const CACHE_PREFIX = 'address_data:active_import:';
-
     /** Cache integer import ids only; bump suffix if stored shape changes. */
     private const CACHE_PREFIX_IMPORT_ID = 'address_data:active_import_id:v1:';
 
     public function forgetActiveImportCache(string $countryCode = 'DE'): void
     {
-        Cache::forget(self::CACHE_PREFIX.$countryCode);
         Cache::forget(self::CACHE_PREFIX_IMPORT_ID.$countryCode);
     }
 

--- a/docs/ACTIVITY_LOGGING_ADMIN_GUIDE.md
+++ b/docs/ACTIVITY_LOGGING_ADMIN_GUIDE.md
@@ -137,7 +137,7 @@ It does not retain descriptions, change properties, subject identifiers, causer 
 
 - A `null` verification field does not automatically mean tampering. It can mean the relevant forensic step has not completed or no proof is available yet.
 - Orphaned genesis is an expected post-retention state, not necessarily corruption.
-- Documentation and operational examples should use `getRetentionYearsForLogType()` or `getAllRetentionYears()` terminology; the older `getRetentionYears()` helper is deprecated.
+- Documentation and operational examples should use `getRetentionYearsForLogType()` or `getAllRetentionYears()` terminology.
 - The source of truth for log-category retention is the `Activity` model, not outdated draft notes or old queue/command comments.
 
 ## Recommended Admin Checks

--- a/docs/GUARD_ARCHITECTURE.md
+++ b/docs/GUARD_ARCHITECTURE.md
@@ -5,7 +5,7 @@ SPDX-License-Identifier: CC0-1.0
 
 # Guard Architecture in SecPal
 
-This document explains Laravel's Guard concept, SecPal's architectural decision to use the `sanctum` guard exclusively, and best practices for developers.
+This document explains Laravel's Guard concept, SecPal's `web` + Sanctum authentication architecture, and best practices for developers.
 
 ## Table of Contents
 

--- a/docs/GUARD_ARCHITECTURE.md
+++ b/docs/GUARD_ARCHITECTURE.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2025 SecPal Contributors
+SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 SPDX-License-Identifier: CC0-1.0
 -->
 
@@ -33,9 +33,8 @@ In Laravel, a **Guard** is an authentication mechanism that defines **HOW** user
 
 **Example Use Cases:**
 
-- `web` guard: Traditional web apps with server-rendered views (session-based)
-- `sanctum` guard: SPAs and mobile apps (token-based)
-- `api` guard: Legacy token authentication (token in database)
+- `web` guard: Session-based browser authentication
+- `sanctum` guard: SPAs, mobile apps, and authenticated API calls
 
 ---
 
@@ -68,14 +67,14 @@ if (Auth::guard('web')->check()) {
 }
 ```
 
-### `sanctum` Guard (Token-Based)
+### `sanctum` Guard
 
 **Characteristics:**
 
-- Token-based authentication
-- Stateless (no server sessions)
-- Bearer token in `Authorization` header
-- Token stored client-side (localStorage, sessionStorage)
+- Supports Bearer-token authentication for API clients
+- Cooperates with Sanctum's stateful SPA mode for first-party browser requests
+- Bearer tokens use the `Authorization` header
+- Personal access tokens are hashed in storage
 
 **Typical Use Case:**
 
@@ -99,21 +98,13 @@ Route::middleware('auth:sanctum')->group(function () {
 });
 ```
 
-### `api` Guard (Legacy Token)
-
-**Characteristics:**
-
-- Token-based (similar to Sanctum)
-- Tokens stored in database (not hashed)
-- Legacy approach (predates Sanctum)
-
-**Note:** SecPal does NOT use this guard. Sanctum is the modern replacement.
-
----
-
 ## SecPal's Architecture Decision
 
-**Decision:** SecPal uses the **`sanctum` guard exclusively** for all authentication and permissions.
+**Decision:** SecPal uses **Laravel Sanctum plus the `web` guard** for authentication:
+
+- first-party browser SPA requests authenticate through Sanctum's stateful mode on top of the `web` guard
+- API clients authenticate through Sanctum Bearer tokens
+- authorization and API route protection are standardized on `auth:sanctum`
 
 ### Architecture Overview
 
@@ -123,15 +114,15 @@ Route::middleware('auth:sanctum')->group(function () {
 ├─────────────────────────────────────────────────────────────────┤
 │                                                                   │
 │  Frontend (React PWA)                                            │
-│  ├─ Token stored in localStorage                                │
-│  ├─ All API requests include: Authorization: Bearer {token}     │
-│  └─ Stateless (no cookies)                                      │
+│  ├─ Browser SPA requests use Sanctum CSRF + session cookies     │
+│  ├─ Native/API clients use Authorization: Bearer {token}        │
+│  └─ Auth mode depends on the caller context                     │
 │                                                                   │
 │  Backend (Laravel API)                                           │
-│  ├─ Pure API (no server-rendered views)                         │
-│  ├─ All routes protected with auth:sanctum middleware           │
-│  ├─ Stateless authentication via Bearer tokens                  │
-│  └─ No session storage                                          │
+│  ├─ API routes protected with auth:sanctum middleware           │
+│  ├─ `web` guard backs first-party browser sessions              │
+│  ├─ `sanctum` guard backs Bearer-token clients                  │
+│  └─ Both modes share the same authenticated API surface         │
 │                                                                   │
 │  Database                                                        │
 │  ├─ Permissions: guard_name='sanctum'                           │
@@ -143,20 +134,17 @@ Route::middleware('auth:sanctum')->group(function () {
 
 ### Why Sanctum?
 
-1. **API-Only Architecture**: SecPal is a pure API with a separate React frontend
-2. **Stateless**: No server-side sessions needed (scales horizontally)
-3. **Mobile-Ready**: Same authentication mechanism works for future mobile apps
-4. **Modern Best Practice**: Sanctum is Laravel's recommended approach for SPAs
-5. **Security**: Tokens are hashed in database, secure token generation
+1. **Unified API surface**: `auth:sanctum` protects both browser and token clients
+2. **First-party SPA support**: Sanctum provides CSRF-protected session auth for the browser app
+3. **Mobile-ready**: The same backend also supports native and CLI Bearer-token clients
+4. **Modern Laravel path**: Sanctum is the intended auth layer for this mixed SPA/API setup
+5. **Security**: Personal access tokens are hashed in storage and session auth remains cookie-scoped
 
-### Why NOT `web` Guard?
+### Why the `web` Guard Still Exists
 
-- SecPal has **no server-rendered views** (no Blade templates)
-- **No cookies** used for authentication (only Bearer tokens)
-- **No sessions** stored on server (stateless architecture)
-- `web` guard would be semantically incorrect and misleading
-
-**Exception:** The `web` guard is configured but **only** used for Laravel's password reset email verification flow (which is stateless and token-based).
+- SecPal does not use the `web` guard for server-rendered app pages, but it does use it for first-party SPA session authentication.
+- Sanctum's stateful browser mode depends on the `web` guard and Laravel sessions.
+- Password reset and related browser-account flows also rely on the same foundation.
 
 ---
 

--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -18,8 +18,7 @@ SecPal API uses **Laravel Sanctum** for authentication, supporting two modes:
 - `POST /v1/auth/token` is the stateless Bearer-token login endpoint for Android, native, CLI, and other API clients, and issued tokens are scoped to the `api-access` Sanctum ability.
 - `POST /v1/auth/logout` is the canonical logout endpoint for both authenticated modes.
 - `GET /v1/me` is the canonical self-service endpoint for the authenticated caller.
-- `POST /v1/auth/session/logout` remains available only as a deprecated compatibility alias for older SPA clients.
-- `GET /v1/auth/me`, `GET /v1/user`, `GET /v1/user/profile`, and `GET /v1/profile` are intentionally unsupported and return `404 Not Found`.
+- `POST /v1/auth/session/logout`, `GET /v1/auth/me`, `GET /v1/user`, `GET /v1/user/profile`, and `GET /v1/profile` are intentionally unsupported and return `404 Not Found`.
 
 All `auth:sanctum` protected API routes also require the `api-access` ability for Bearer tokens. First-party SPA session requests continue to work because Sanctum treats them as transient first-party requests rather than personal access token calls.
 
@@ -42,7 +41,6 @@ The `400` vs `422` distinction is intentional and should remain stable:
 
 - If Sanctum authenticated the request via a personal access token, logout revokes only the current token.
 - If Sanctum authenticated the request via the SPA session, logout invalidates the browser session and clears remember-me state.
-- `POST /v1/auth/session/logout` delegates to the same session logout logic and exists only for backward compatibility.
 
 ### Mixed Requests
 
@@ -168,7 +166,7 @@ Content-Type: application/json
 }
 ```
 
-> **Note:** `/v1/auth/logout` is the canonical logout endpoint for both SPA session auth and Bearer-token auth. `/v1/auth/session/logout` remains available only as a legacy compatibility alias for older SPA clients and should not be used by new clients.
+> **Note:** `/v1/auth/logout` is the sole supported logout endpoint for both SPA session auth and Bearer-token auth.
 
 For future maintenance, keep the canonical logout semantics aligned with the resolved auth context. A browser request that merely carries an extra `Authorization` header must not be treated as a token logout.
 

--- a/docs/api/rbac-endpoints.md
+++ b/docs/api/rbac-endpoints.md
@@ -950,9 +950,9 @@ API version is specified in the URL: `/v1/`
 
 **Current Version:** v1
 
-Breaking changes will be introduced in new versions (v2, v3, etc.). Non-breaking changes (new fields, new endpoints) may be added to existing versions.
+During `0.x`, breaking changes may be introduced directly in `v1` when they remove insecure, obsolete, or otherwise unsupported behavior. Non-breaking changes (new fields, new endpoints) may also be added to the existing version.
 
-**Deprecation Policy:** Deprecated endpoints will be supported for at least 6 months after deprecation notice.
+**Deprecation Policy:** Deprecated endpoints and compatibility shims are not guaranteed a support window during `0.x`; remove them once the canonical replacement is established and the repository no longer actively relies on them.
 
 ---
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -102,8 +102,6 @@ Route::prefix('v1')->group(function () {
     Route::middleware(['auth:sanctum', 'ability:'.User::API_ACCESS_ABILITY])->group(function () {
         // Token logout (for Bearer token auth - mobile/native apps)
         Route::post('/auth/logout', [AuthController::class, 'logout']);
-        // Session logout (for SPA cookie auth)
-        Route::post('/auth/session/logout', [AuthController::class, 'logoutSession']);
         Route::post('/auth/logout-all', [AuthController::class, 'logoutAll']);
         Route::post('/auth/email/verification-notification', [AuthController::class, 'sendVerificationNotification'])
             ->middleware('throttle:6,1');

--- a/tests/Feature/Auth/SanctumCookieAuthTest.php
+++ b/tests/Feature/Auth/SanctumCookieAuthTest.php
@@ -447,7 +447,7 @@ describe('SPA Session-Based Logout', function () {
             ]);
     });
 
-    test('legacy session logout alias still works', function () {
+    test('legacy session logout alias is not available for spa logout', function () {
         User::factory()->create([
             'email' => 'logout@example.com',
             'password' => Hash::make('password123'),
@@ -465,10 +465,7 @@ describe('SPA Session-Based Logout', function () {
         $this->withHeaders(spaHeaders([
             'X-XSRF-TOKEN' => $logoutCsrfToken,
         ]))->postJson('/v1/auth/session/logout')
-            ->assertOk()
-            ->assertJson([
-                'message' => 'Logged out successfully',
-            ]);
+            ->assertNotFound();
     });
 
     test('session logout requires authentication', function () {
@@ -503,7 +500,8 @@ describe('SPA Session-Based Logout', function () {
         $logoutCsrfToken = issueSpaCsrfToken($this);
         $this->withHeaders(spaHeaders([
             'X-XSRF-TOKEN' => $logoutCsrfToken,
-        ]))->postJson('/v1/auth/session/logout');
+        ]))->postJson('/v1/auth/session/logout')
+            ->assertNotFound();
 
         // Token should still be valid
         expect($user->fresh()->tokens()->count())->toBe(1);

--- a/tests/Feature/AuthTest.php
+++ b/tests/Feature/AuthTest.php
@@ -361,7 +361,7 @@ describe('SPA Session Login', function () {
             ]);
     });
 
-    test('legacy session logout alias remains available for existing spa clients', function () {
+    test('legacy session logout alias is no longer available', function () {
         $email = 'spa-legacy-logout-'.Str::uuid().'@secpal.dev';
 
         $user = User::factory()->create([
@@ -382,10 +382,10 @@ describe('SPA Session Login', function () {
 
         $this->withHeaders(spaHeaders([
             'X-XSRF-TOKEN' => issueSpaCsrfToken($this),
-        ]))->postJson('/v1/auth/session/logout')->assertOk();
+        ]))->postJson('/v1/auth/session/logout')->assertNotFound();
 
         $user->refresh();
-        expect($user->remember_token)->toBeNull();
+        expect($user->remember_token)->not->toBeNull();
     });
 });
 
@@ -802,7 +802,7 @@ describe('Token Revocation', function () {
         $response->assertUnauthorized();
     });
 
-    test('legacy session logout alias rejects bearer-token clients', function () {
+    test('legacy session logout alias is no longer routed for bearer-token clients', function () {
         $user = User::factory()->create([
             'password' => bcrypt('password123'),
         ]);
@@ -811,7 +811,7 @@ describe('Token Revocation', function () {
 
         $this->withHeaders(['Authorization' => "Bearer {$token}"])
             ->postJson('/v1/auth/session/logout')
-            ->assertUnauthorized();
+            ->assertNotFound();
 
         // Token must still be intact — legacy alias must not revoke it
         expect($user->fresh()->tokens()->count())->toBe(1);

--- a/tests/Feature/Controllers/CustomerSiteNumberConcurrencyTest.php
+++ b/tests/Feature/Controllers/CustomerSiteNumberConcurrencyTest.php
@@ -193,11 +193,12 @@ function runConcurrentJsonPosts(
                     xdebug_stop_code_coverage(false);
                 }
 
-                DB::disconnect();
+                DB::purge();
+                DB::reconnect();
                 app(PermissionRegistrar::class)->forgetCachedPermissions();
 
                 while (trim((string) file_get_contents($startSignalPath)) !== 'go') {
-                    usleep(10_000);
+                    usleep(100_000);
                 }
 
                 $response = $testCase->withToken($testCase->token)

--- a/tests/Unit/ActivityLog/ActivityRetentionYearsTest.php
+++ b/tests/Unit/ActivityLog/ActivityRetentionYearsTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-// SPDX-FileCopyrightText: 2025 SecPal <https://github.com/SecPal>
+// SPDX-FileCopyrightText: 2025-2026 SecPal <https://github.com/SecPal>
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 use App\Models\Activity;
@@ -72,6 +72,7 @@ test('retention years property has legal references', function (): void {
 test('get retention years methods exist and are static', function (): void {
     expect(method_exists(Activity::class, 'getRetentionYearsForLogType'))->toBeTrue();
     expect(method_exists(Activity::class, 'getAllRetentionYears'))->toBeTrue();
+    expect(method_exists(Activity::class, 'getRetentionYears'))->toBeFalse();
 
     $reflection = new ReflectionMethod(Activity::class, 'getRetentionYearsForLogType');
     expect($reflection->isStatic())->toBeTrue();

--- a/tests/Unit/Models/EmployeeOnboardingTokenTest.php
+++ b/tests/Unit/Models/EmployeeOnboardingTokenTest.php
@@ -86,7 +86,7 @@ test('returns null for invalid plain token', function () {
     expect($found)->toBeNull();
 });
 
-test('finds legacy token without lookup hash and backfills it', function () {
+test('does not find legacy token rows without lookup hash', function () {
     $employee = Employee::factory()->preContract()->create();
     $plainToken = str_repeat('legacy-token-', 6);
 
@@ -99,12 +99,11 @@ test('finds legacy token without lookup hash and backfills it', function () {
 
     $found = EmployeeOnboardingToken::findByPlainToken($plainToken);
 
-    expect($found)->not->toBeNull()
-        ->and($found->id)->toBe($token->id);
+    expect($found)->toBeNull();
 
     $token->refresh();
 
-    expect($token->token_lookup_hash)->toBe(hash('sha256', $plainToken));
+    expect($token->token_lookup_hash)->toBeNull();
 });
 
 test('marks token as completed with audit trail', function () {

--- a/tests/Unit/Services/AddressSuggestionServiceTest.php
+++ b/tests/Unit/Services/AddressSuggestionServiceTest.php
@@ -32,6 +32,12 @@ test('active import returns null instead of throwing when address_data_imports t
     expect((new AddressSuggestionService)->activeImport('DE'))->toBeNull();
 });
 
+test('service no longer exposes the deprecated active import cache prefix constant', function (): void {
+    $constants = (new ReflectionClass(AddressSuggestionService::class))->getConstants();
+
+    expect($constants)->not->toHaveKey('CACHE_PREFIX');
+});
+
 test('active import ignores stale cached ids for deactivated imports', function (): void {
     expect($this->service->activeImport('DE')?->is($this->import))->toBeTrue();
 


### PR DESCRIPTION
## Failing tests / reproduced defects

The change set started from failing or tightened regression expectations proving that obsolete compatibility paths should be gone:

- `tests/Feature/AuthTest.php:364` now proves `POST /v1/auth/session/logout` must return `404` instead of remaining a supported alias.
- `tests/Feature/Auth/SanctumCookieAuthTest.php:450` and `tests/Feature/Auth/SanctumCookieAuthTest.php:481` now prove SPA logout must use `POST /v1/auth/logout` and that the removed alias must not affect token-backed sessions.
- `tests/Unit/Models/EmployeeOnboardingTokenTest.php:89` now proves rows with `token_lookup_hash = null` are no longer accepted or backfilled on read.
- `tests/Unit/ActivityLog/ActivityRetentionYearsTest.php:72` now proves `Activity::getRetentionYears()` no longer exists.
- `tests/Unit/Services/AddressSuggestionServiceTest.php:35` now proves the deprecated address-data cache prefix constant is gone.

## Summary

This PR removes deprecated API/runtime compatibility paths that are no longer needed in the current `0.x` posture and aligns the repo documentation with the actual runtime behavior.

Runtime cleanup:
- removed the deprecated `POST /v1/auth/session/logout` alias from `routes/api.php:102` and the legacy alias handling from `app/Http/Controllers/AuthController.php:83`
- removed the onboarding token fallback/backfill path from `app/Models/EmployeeOnboardingToken.php:137`
- removed the deprecated `Activity::getRetentionYears()` wrapper so only `getRetentionYearsForLogType()` / `getAllRetentionYears()` remain in `app/Models/Activity.php:430`
- removed the obsolete address-data active-import cache prefix from `app/Services/AddressData/AddressSuggestionService.php:17`

Documentation and governance cleanup:
- aligned `AGENTS.md` and `.github/copilot-instructions.md` with the active `0.x` deprecation policy
- updated `docs/api/authentication.md`, `docs/api/rbac-endpoints.md`, and `docs/ACTIVITY_LOGGING_ADMIN_GUIDE.md` to remove obsolete compatibility language
- corrected `docs/GUARD_ARCHITECTURE.md:34` so it reflects the actual `web` + `sanctum` authentication model from `config/auth.php`
- updated `CHANGELOG.md`

## Validation run

Already run locally:

- `php artisan test tests/Feature/AuthTest.php --filter='legacy session logout alias is no longer available|legacy session logout alias is no longer routed for bearer-token clients'`
- `php artisan test tests/Feature/Auth/SanctumCookieAuthTest.php --filter='legacy session logout alias is not available for spa logout|session logout does not affect token-based sessions'`
- `php artisan test tests/Unit/Models/EmployeeOnboardingTokenTest.php tests/Unit/ActivityLog/ActivityRetentionYearsTest.php`
- `php artisan test tests/Unit/Services/AddressSuggestionServiceTest.php --filter='service no longer exposes the deprecated active import cache prefix constant'`
- `vendor/bin/pint --dirty`
- `git diff --check`

## Follow-up before marking ready

- Follow-up issue: `#1204` tracks the unrelated PostgreSQL `RefreshDatabase` / DDL collision in `tests/Unit/Services/AddressSuggestionServiceTest.php` that still makes the full file-level run noisy when the missing-table regression renames `address_data_imports`.
- Final PR self-review is still required in the GitHub PR view before moving this draft out of draft state.
- Linked workspaces: none.

Closes #1199
Closes #1200
Closes #1201
Closes #1202
Refs #1204
