### PR TITLE
Stabilize AddressSuggestionService missing-table test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- stabilized the `AddressSuggestionService` missing-table regression under PostgreSQL by replacing the DDL-based `address_data_imports` rename test with a deterministic missing-table query failure path that no longer collides with `RefreshDatabase` migration-state teardown (fixes `api#1204`)
 - blocked direct `PATCH /v1/organizational-units/{organizational_unit}/scopes/{scope}` updates to self-owned scope assignments, so users can no longer reshuffle or narrow their own direct rank, descendant, or self-access footprint on the same organizational unit under the manage-only model (fixes `api#1197`)
 - blocked deleting any direct self-scope assignment through `DELETE /v1/organizational-units/{organizational_unit}/scopes/{scope}`, so users can no longer silently narrow their own rank coverage on the same organizational unit by removing one of multiple `manage` scopes (fixes `api#1195`)
 - captured dedicated activity causer employee snapshot columns when activity rows are created, so historical activity-log scope authorization keeps the original organizational-unit and management-level context after later employee deprovisioning

--- a/app/Services/AddressData/AddressSuggestionService.php
+++ b/app/Services/AddressData/AddressSuggestionService.php
@@ -9,6 +9,7 @@ use App\Models\AddressDataImport;
 use App\Models\AddressStreet;
 use App\Support\AddressSearchNormalizer;
 use App\Support\LikePattern;
+use Closure;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\QueryException;
 use Illuminate\Support\Collection;
@@ -20,6 +21,13 @@ final class AddressSuggestionService
 
     /** Cache integer import ids only; bump suffix if stored shape changes. */
     private const CACHE_PREFIX_IMPORT_ID = 'address_data:active_import_id:v1:';
+
+    /**
+     * @param  (Closure(string): Builder<AddressDataImport>)|null  $activeImportQueryResolver
+     */
+    public function __construct(
+        private readonly ?Closure $activeImportQueryResolver = null,
+    ) {}
 
     public function forgetActiveImportCache(string $countryCode = 'DE'): void
     {
@@ -87,6 +95,11 @@ final class AddressSuggestionService
      */
     private function activeImportQuery(string $countryCode): Builder
     {
+        if ($this->activeImportQueryResolver !== null) {
+            /** @var Builder<AddressDataImport> */
+            return ($this->activeImportQueryResolver)($countryCode);
+        }
+
         return AddressDataImport::query()
             ->where('country_code', $countryCode)
             ->where('status', AddressDataImport::STATUS_SUCCEEDED)

--- a/tests/Unit/Services/AddressSuggestionServiceResilienceTest.php
+++ b/tests/Unit/Services/AddressSuggestionServiceResilienceTest.php
@@ -1,0 +1,29 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+use App\Services\AddressData\AddressSuggestionService;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\QueryException;
+
+test('active import returns null instead of throwing when address_data_imports table is missing', function (): void {
+    $service = new AddressSuggestionService(
+        activeImportQueryResolver: function (string $countryCode): Builder {
+            throw new QueryException(
+                connectionName: 'pgsql',
+                sql: 'select * from "address_data_imports" where "country_code" = ?',
+                bindings: [$countryCode],
+                previous: new Exception('SQLSTATE[42P01]: Undefined table: 7 ERROR: relation "address_data_imports" does not exist'),
+            );
+        },
+    );
+
+    expect($service->activeImport('DE'))->toBeNull();
+});
+
+test('service no longer exposes the deprecated active import cache prefix constant', function (): void {
+    $constants = (new ReflectionClass(AddressSuggestionService::class))->getConstants();
+
+    expect($constants)->not->toHaveKey('CACHE_PREFIX');
+});

--- a/tests/Unit/Services/AddressSuggestionServiceResilienceTest.php
+++ b/tests/Unit/Services/AddressSuggestionServiceResilienceTest.php
@@ -7,14 +7,16 @@ use App\Services\AddressData\AddressSuggestionService;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\QueryException;
 
+uses()->group('unit', 'services', 'address-data');
+
 test('active import returns null instead of throwing when address_data_imports table is missing', function (): void {
     $service = new AddressSuggestionService(
         activeImportQueryResolver: function (string $countryCode): Builder {
             throw new QueryException(
-                connectionName: 'pgsql',
-                sql: 'select * from "address_data_imports" where "country_code" = ?',
-                bindings: [$countryCode],
-                previous: new Exception('SQLSTATE[42P01]: Undefined table: 7 ERROR: relation "address_data_imports" does not exist'),
+                'pgsql',
+                'select * from "address_data_imports" where "country_code" = ?',
+                [$countryCode],
+                new Exception('SQLSTATE[42P01]: Undefined table: 7 ERROR: relation "address_data_imports" does not exist'),
             );
         },
     );

--- a/tests/Unit/Services/AddressSuggestionServiceTest.php
+++ b/tests/Unit/Services/AddressSuggestionServiceTest.php
@@ -8,7 +8,6 @@ use App\Models\AddressStreet;
 use App\Services\AddressData\AddressSuggestionService;
 use App\Support\AddressSearchNormalizer;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Facades\DB;
 
 uses(RefreshDatabase::class)->group('unit', 'services', 'address-data');
 
@@ -23,19 +22,6 @@ beforeEach(function (): void {
         'status' => AddressDataImport::STATUS_SUCCEEDED,
         'activated_at' => now(),
     ]);
-});
-
-test('active import returns null instead of throwing when address_data_imports table is missing', function (): void {
-    // PostgreSQL DDL is transactional; the rename is rolled back with the test transaction.
-    DB::statement('ALTER TABLE address_data_imports RENAME TO address_data_imports_hidden');
-
-    expect((new AddressSuggestionService)->activeImport('DE'))->toBeNull();
-});
-
-test('service no longer exposes the deprecated active import cache prefix constant', function (): void {
-    $constants = (new ReflectionClass(AddressSuggestionService::class))->getConstants();
-
-    expect($constants)->not->toHaveKey('CACHE_PREFIX');
 });
 
 test('active import ignores stale cached ids for deactivated imports', function (): void {


### PR DESCRIPTION
## Summary

`php artisan test tests/Unit/Services/AddressSuggestionServiceTest.php` could fail noisily under PostgreSQL before reaching the missing-table assertion because the test renamed `address_data_imports`, which interfered with `RefreshDatabase` teardown and migration-state detection.

This change replaces that DDL-based regression with a deterministic missing-table `QueryException` path, adds a narrow query override hook in `AddressSuggestionService`, and moves the resilience assertions into a DB-free unit test file while keeping the database-backed suggestion coverage in the existing `RefreshDatabase` file.

Closes #1204.

## Validation

- `php artisan test tests/Unit/Services/AddressSuggestionServiceResilienceTest.php`
- `php artisan test tests/Unit/Services/AddressSuggestionServiceTest.php`
- `vendor/bin/pint --dirty`
- `php artisan test --group=address-data`

## Follow-up Before Ready

- Final self-review in the PR view is still pending; keep this PR in draft until that review finds zero issues.
- `php artisan test --group=address-data` now includes the new resilience file after the grouping fix, but the grouped PostgreSQL run still exposes a separate migration-lifecycle problem in DB-backed address-data tests; tracked in #1207.
- Full preflight / broader Pest coverage was not run for this change beyond the targeted address-suggestion slices and the grouped address-data check above.
- Linked workspaces: none required for this fix.
