### PR TITLE
Fix inconsistent customer sites_count responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- fixed `GET /v1/customers` and `GET /v1/customers/{id}` to return a consistent `sites_count` that now matches the caller's effective site visibility, keeping customer list/detail responses aligned with `/v1/customers/{id}/sites` for both full-access and scoped users (fixes `api#1212`)
 - stopped `PHP CI` from sending the dedicated `serial` Pest group through the parallel GitHub Actions run, and now executes those PostgreSQL concurrency/lifecycle regressions in a separate step so the CI test job no longer burns its full 30-minute budget on conflicting database workflows
 - stabilized the PostgreSQL-backed `address-data` Pest slice by forcing the two DB-backed address-data unit suites to start from a fresh Laravel migration state before and after each test, so grouped runs no longer inherit stale `RefreshDatabase` state from neighboring PostgreSQL tests while keeping the fix scoped away from the full suite runtime (fixes `api#1207`)
 - stabilized the `AddressSuggestionService` missing-table regression under PostgreSQL by replacing the DDL-based `address_data_imports` rename test with a deterministic missing-table query failure path that no longer collides with `RefreshDatabase` migration-state teardown (fixes `api#1204`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- fixed `GET /v1/customers` and `GET /v1/customers/{id}` to return a consistent `sites_count` that now matches the caller's effective site visibility, keeping customer list/detail responses aligned with `/v1/customers/{id}/sites` for both full-access and scoped users (fixes `api#1212`)
+- fixed `GET /v1/customers` and `GET /v1/customers/{id}` to return a consistent `sites_count` and detail `sites` payload that now match the caller's effective site visibility, keeping customer list/detail responses aligned with `/v1/customers/{id}/sites` for both full-access and scoped users (fixes `api#1212`)
 - stopped `PHP CI` from sending the dedicated `serial` Pest group through the parallel GitHub Actions run, and now executes those PostgreSQL concurrency/lifecycle regressions in a separate step so the CI test job no longer burns its full 30-minute budget on conflicting database workflows
 - stabilized the PostgreSQL-backed `address-data` Pest slice by forcing the two DB-backed address-data unit suites to start from a fresh Laravel migration state before and after each test, so grouped runs no longer inherit stale `RefreshDatabase` state from neighboring PostgreSQL tests while keeping the fix scoped away from the full suite runtime (fixes `api#1207`)
 - stabilized the `AddressSuggestionService` missing-table regression under PostgreSQL by replacing the DDL-based `address_data_imports` rename test with a deterministic missing-table query failure path that no longer collides with `RefreshDatabase` migration-state teardown (fixes `api#1204`)

--- a/app/Http/Controllers/Api/V1/CustomerController.php
+++ b/app/Http/Controllers/Api/V1/CustomerController.php
@@ -18,6 +18,7 @@ use App\Models\TenantKey;
 use App\Models\User;
 use App\Support\LikePattern;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\DB;
@@ -180,7 +181,7 @@ class CustomerController extends Controller
 
         $customer->load([
             'assignments.user',
-            'sites' => function ($query) use ($user): void {
+            'sites' => function (HasMany $query) use ($user): void {
                 if ($user->can('customers.read')) {
                     return;
                 }

--- a/app/Http/Controllers/Api/V1/CustomerController.php
+++ b/app/Http/Controllers/Api/V1/CustomerController.php
@@ -177,7 +177,16 @@ class CustomerController extends Controller
         /** @var User $user */
         $user = request()->user();
 
-        $customer->load(['assignments.user', 'sites'])
+        $customer->load([
+            'assignments.user',
+            'sites' => function ($query) use ($user): void {
+                if ($user->can('customers.read')) {
+                    return;
+                }
+
+                $query->whereIn('sites.id', $user->visibleSitesQuery()->select('sites.id'));
+            },
+        ])
             ->loadCount($this->visibleSitesCountDefinition($user));
 
         return response()->json([

--- a/app/Http/Controllers/Api/V1/CustomerController.php
+++ b/app/Http/Controllers/Api/V1/CustomerController.php
@@ -13,6 +13,7 @@ use App\Http\Requests\Api\V1\UpdateCustomerRequest;
 use App\Http\Resources\CustomerResource;
 use App\Http\Resources\SiteResource;
 use App\Models\Customer;
+use App\Models\Site;
 use App\Models\TenantKey;
 use App\Models\User;
 use App\Support\LikePattern;
@@ -186,8 +187,8 @@ class CustomerController extends Controller
 
                 $query->whereIn('sites.id', $user->visibleSitesQuery()->select('sites.id'));
             },
-        ])
-            ->loadCount($this->visibleSitesCountDefinition($user));
+        ]);
+        $customer->loadCount($this->visibleSitesCountDefinition($user));
 
         return response()->json([
             'data' => new CustomerResource($customer),
@@ -291,7 +292,7 @@ class CustomerController extends Controller
     /**
      * Build the loadCount/withCount definition for customer sites_count.
      *
-     * @return array<int|string, string|\Closure(Builder): void>
+     * @return array<int|string, string|\Closure(Builder<Site>): void>
      */
     private function visibleSitesCountDefinition(User $user): array
     {

--- a/app/Http/Controllers/Api/V1/CustomerController.php
+++ b/app/Http/Controllers/Api/V1/CustomerController.php
@@ -14,7 +14,9 @@ use App\Http\Resources\CustomerResource;
 use App\Http\Resources\SiteResource;
 use App\Models\Customer;
 use App\Models\TenantKey;
+use App\Models\User;
 use App\Support\LikePattern;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\DB;
@@ -52,7 +54,7 @@ class CustomerController extends Controller
     {
         $this->authorize('viewAny', Customer::class);
 
-        /** @var \App\Models\User $user */
+        /** @var User $user */
         $user = $request->user();
         /** @var int $tenantId */
         $tenantId = $request->get('tenant_id');
@@ -60,6 +62,8 @@ class CustomerController extends Controller
         $query = Customer::query()
             ->where('tenant_id', $tenantId)
             ->with(['assignments.user']);
+
+        $query = $this->withVisibleSitesCount($query, $user);
 
         // Need-to-Know filtering: users reaching this branch already have scoped collection access
         if (! $user->can('customers.read')) {
@@ -170,8 +174,11 @@ class CustomerController extends Controller
     public function show(Customer $customer): JsonResponse
     {
         $this->authorize('view', $customer);
+        /** @var User $user */
+        $user = request()->user();
 
-        $customer->load(['assignments.user', 'sites']);
+        $customer->load(['assignments.user', 'sites'])
+            ->loadCount($this->visibleSitesCountDefinition($user));
 
         return response()->json([
             'data' => new CustomerResource($customer),
@@ -241,7 +248,7 @@ class CustomerController extends Controller
     {
         $this->authorize('view', $customer);
 
-        /** @var \App\Models\User $user */
+        /** @var User $user */
         $user = $request->user();
         $perPage = $request->integer('per_page', 15);
         $sites = $user->can('customers.read')
@@ -259,5 +266,34 @@ class CustomerController extends Controller
         }
 
         return SiteResource::collection($sites->paginate($perPage));
+    }
+
+    /**
+     * Attach a sites_count that matches the current caller's effective site visibility.
+     *
+     * @param  Builder<Customer>  $query
+     * @return Builder<Customer>
+     */
+    private function withVisibleSitesCount(Builder $query, User $user): Builder
+    {
+        return $query->withCount($this->visibleSitesCountDefinition($user));
+    }
+
+    /**
+     * Build the loadCount/withCount definition for customer sites_count.
+     *
+     * @return array<int|string, string|\Closure(Builder): void>
+     */
+    private function visibleSitesCountDefinition(User $user): array
+    {
+        if ($user->can('customers.read')) {
+            return ['sites'];
+        }
+
+        return [
+            'sites as sites_count' => function (Builder $query) use ($user): void {
+                $query->whereIn('sites.id', $user->visibleSitesQuery()->select('sites.id'));
+            },
+        ];
     }
 }

--- a/tests/Feature/Controllers/Api/V1/CustomerControllerTest.php
+++ b/tests/Feature/Controllers/Api/V1/CustomerControllerTest.php
@@ -80,6 +80,25 @@ describe('GET /v1/customers', function () {
             ]);
     });
 
+    test('returns linked sites_count in customer list responses', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'customers.read');
+
+        $customer = Customer::factory()->create([
+            'tenant_id' => $this->tenant->id,
+        ]);
+
+        Site::factory()->count(2)->create([
+            'tenant_id' => $this->tenant->id,
+            'customer_id' => $customer->id,
+        ]);
+
+        $response = $this->withToken($this->token)->getJson('/v1/customers');
+
+        $response->assertOk()
+            ->assertJsonPath('data.0.id', $customer->id)
+            ->assertJsonPath('data.0.sites_count', 2);
+    });
+
     test('returns preserved assignment history with null nested users in customer resources', function (): void {
         givePermissionWithTenant($this->user, $this->tenant->id, 'customers.read');
 
@@ -245,6 +264,64 @@ describe('GET /v1/customers', function () {
         $response->assertOk();
         expect($response->json('data'))->toHaveCount(1);
         expect($response->json('data')[0]['id'])->toBe($customer->id);
+    });
+
+    test('user without permission only receives visible sites_count in customer list', function (): void {
+        $customer = Customer::factory()->create(['tenant_id' => $this->tenant->id]);
+        $visibleSite = Site::factory()->create([
+            'tenant_id' => $this->tenant->id,
+            'customer_id' => $customer->id,
+        ]);
+
+        Site::factory()->create([
+            'tenant_id' => $this->tenant->id,
+            'customer_id' => $customer->id,
+        ]);
+
+        SiteAssignment::factory()->create([
+            'tenant_id' => $this->tenant->id,
+            'site_id' => $visibleSite->id,
+            'user_id' => $this->user->id,
+            'role' => 'Site Manager',
+            'valid_from' => now()->subDays(10),
+            'valid_until' => null,
+        ]);
+
+        $response = $this->withToken($this->token)->getJson('/v1/customers');
+
+        $response->assertOk()
+            ->assertJsonPath('data.0.id', $customer->id)
+            ->assertJsonPath('data.0.sites_count', 1);
+    });
+
+    test('user with sites read permission receives full customer sites_count in customer list', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'sites.read');
+
+        $customer = Customer::factory()->create(['tenant_id' => $this->tenant->id]);
+        $visibleSite = Site::factory()->create([
+            'tenant_id' => $this->tenant->id,
+            'customer_id' => $customer->id,
+        ]);
+
+        Site::factory()->create([
+            'tenant_id' => $this->tenant->id,
+            'customer_id' => $customer->id,
+        ]);
+
+        SiteAssignment::factory()->create([
+            'tenant_id' => $this->tenant->id,
+            'site_id' => $visibleSite->id,
+            'user_id' => $this->user->id,
+            'role' => 'Site Manager',
+            'valid_from' => now()->subDays(10),
+            'valid_until' => null,
+        ]);
+
+        $response = $this->withToken($this->token)->getJson('/v1/customers');
+
+        $response->assertOk()
+            ->assertJsonPath('data.0.id', $customer->id)
+            ->assertJsonPath('data.0.sites_count', 2);
     });
 
     test('supports pagination with custom per_page', function (): void {
@@ -495,6 +572,56 @@ describe('GET /v1/customers/{customer}', function () {
             ]);
 
         expect($response->json('data.id'))->toBe($customer->id);
+    });
+
+    test('returns linked sites_count in customer detail responses', function (): void {
+        $customer = Customer::factory()->create(['tenant_id' => $this->tenant->id]);
+
+        CustomerAssignment::factory()->create([
+            'tenant_id' => $this->tenant->id,
+            'customer_id' => $customer->id,
+            'user_id' => $this->user->id,
+            'role' => 'Account Manager',
+        ]);
+
+        Site::factory()->count(3)->create([
+            'tenant_id' => $this->tenant->id,
+            'customer_id' => $customer->id,
+        ]);
+
+        $response = $this->withToken($this->token)->getJson("/v1/customers/{$customer->id}");
+
+        $response->assertOk()
+            ->assertJsonPath('data.sites_count', 3);
+    });
+
+    test('user with sites read permission receives full customer sites_count in customer detail', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'sites.read');
+
+        $customer = Customer::factory()->create(['tenant_id' => $this->tenant->id]);
+        $visibleSite = Site::factory()->create([
+            'tenant_id' => $this->tenant->id,
+            'customer_id' => $customer->id,
+        ]);
+
+        Site::factory()->create([
+            'tenant_id' => $this->tenant->id,
+            'customer_id' => $customer->id,
+        ]);
+
+        SiteAssignment::factory()->create([
+            'tenant_id' => $this->tenant->id,
+            'site_id' => $visibleSite->id,
+            'user_id' => $this->user->id,
+            'role' => 'Site Manager',
+            'valid_from' => now()->subDays(10),
+            'valid_until' => null,
+        ]);
+
+        $response = $this->withToken($this->token)->getJson("/v1/customers/{$customer->id}");
+
+        $response->assertOk()
+            ->assertJsonPath('data.sites_count', 2);
     });
 
     test('includes notes when user can update customer', function (): void {

--- a/tests/Feature/Controllers/Api/V1/CustomerControllerTest.php
+++ b/tests/Feature/Controllers/Api/V1/CustomerControllerTest.php
@@ -595,6 +595,36 @@ describe('GET /v1/customers/{customer}', function () {
             ->assertJsonPath('data.sites_count', 3);
     });
 
+    test('returns only independently visible sites in customer detail for scoped users', function (): void {
+        $customer = Customer::factory()->create(['tenant_id' => $this->tenant->id]);
+        $visibleSite = Site::factory()->create([
+            'tenant_id' => $this->tenant->id,
+            'customer_id' => $customer->id,
+        ]);
+        $hiddenSite = Site::factory()->create([
+            'tenant_id' => $this->tenant->id,
+            'customer_id' => $customer->id,
+        ]);
+
+        SiteAssignment::factory()->create([
+            'tenant_id' => $this->tenant->id,
+            'site_id' => $visibleSite->id,
+            'user_id' => $this->user->id,
+            'role' => 'Site Manager',
+            'valid_from' => now()->subDays(10),
+            'valid_until' => null,
+        ]);
+
+        $response = $this->withToken($this->token)->getJson("/v1/customers/{$customer->id}");
+
+        $response->assertOk()
+            ->assertJsonPath('data.sites_count', 1)
+            ->assertJsonCount(1, 'data.sites')
+            ->assertJsonPath('data.sites.0.id', $visibleSite->id);
+
+        expect(collect($response->json('data.sites'))->pluck('id'))->not->toContain($hiddenSite->id);
+    });
+
     test('user with sites read permission receives full customer sites_count in customer detail', function (): void {
         givePermissionWithTenant($this->user, $this->tenant->id, 'sites.read');
 


### PR DESCRIPTION
## Summary

Reproduced issue `#1212`: `GET /v1/customers` and `GET /v1/customers/{id}` returned `sites_count = null`/`0` even when `GET /v1/customers/{id}/sites` returned linked sites. The regression was proven first with focused Pest coverage for list and detail responses before the controller change.

This change loads `sites_count` explicitly for customer list and detail responses and aligns the count semantics with the caller's effective site visibility:

- users with `customers.read` receive the full customer site count
- scoped users receive the same visible site count they would observe through `GET /v1/customers/{id}/sites`

It also adds regression coverage for:

- list responses with linked sites
- detail responses with linked sites
- scoped users who can only see a subset of customer sites
- users with `sites.read`, who should still receive the full count

Closes #1212.

## Validation

- Added failing-first Pest regression coverage in `tests/Feature/Controllers/Api/V1/CustomerControllerTest.php`
- Ran `php artisan test tests/Feature/Controllers/Api/V1/CustomerControllerTest.php`
- Ran `vendor/bin/pint --dirty`
- Updated `CHANGELOG.md`
- Verified the commit is GPG-signed

## Ready Review Checklist

- CI has not run yet on this draft PR
- Final PR-view self-review is still required before marking ready
- No linked workspace changes are required for this fix
