### PR TITLE
Add SecPal attribution terms to AGPL licensing

### DIFF
--- a/.github/workflows/php-ci.yml
+++ b/.github/workflows/php-ci.yml
@@ -1,5 +1,5 @@
 ---
-# SPDX-FileCopyrightText: 2025-2026 SecPal
+# SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 # SPDX-License-Identifier: CC0-1.0
 
 name: PHP CI
@@ -110,6 +110,7 @@ jobs:
           DB_DATABASE: testing
           DB_USERNAME: testing
           DB_PASSWORD: testing
+          SECPAL_TEST_SCHEMA: public
           XDEBUG_MODE: coverage
         run: php artisan test --parallel --exclude-group=serial --coverage-clover coverage.xml
 
@@ -122,6 +123,7 @@ jobs:
           DB_DATABASE: testing
           DB_USERNAME: testing
           DB_PASSWORD: testing
+          SECPAL_TEST_SCHEMA: public
           XDEBUG_MODE: coverage
         run: php artisan test --group=serial --coverage-clover coverage-serial.xml
 
@@ -134,6 +136,7 @@ jobs:
           DB_DATABASE: testing
           DB_USERNAME: testing
           DB_PASSWORD: testing
+          SECPAL_TEST_SCHEMA: public
         run: |
           # Verify the validate-setup command exists and runs
           # Expected to fail (no KEK/tenant keys) but command must be callable

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,5 +1,5 @@
 ---
-# SPDX-FileCopyrightText: 2025-2026 SecPal
+# SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 # SPDX-License-Identifier: CC0-1.0
 
 name: Quality Checks
@@ -21,7 +21,67 @@ jobs:
 
   license-compatibility:
     name: Check License Compatibility
-    uses: SecPal/.github/.github/workflows/reusable-license-compatibility.yml@084b2ab764a6e6b0a865f66853e7421ff4c02434
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+
+      - name: Install REUSE tooling
+        run: pip install reuse
+
+      - name: Generate REUSE SPDX document
+        run: |
+          echo "Checking for AGPL-3.0-or-later compatibility..."
+          reuse spdx -o reuse.spdx
+
+      - name: Check license compatibility
+        run: |
+          licenses=$(grep "LicenseInfoInFile" reuse.spdx | cut -d':' -f2 | sort -u | tr -d ' ')
+
+          echo "Found licenses: $licenses"
+
+          compatible_licenses=(
+            "AGPL-3.0-or-later"
+            "GPL-3.0-or-later"
+            "LGPL-3.0-or-later"
+            "MIT"
+            "BSD-2-Clause"
+            "BSD-3-Clause"
+            "Apache-2.0"
+            "CC0-1.0"
+            "ISC"
+            "OFL-1.1"
+            "ODbL-1.0"
+            "LicenseRef-SecPal-Attribution"
+          )
+
+          incompatible_found=0
+          for license in $licenses; do
+            found=0
+            for compatible in "${compatible_licenses[@]}"; do
+              if [[ "$license" == "$compatible" ]]; then
+                found=1
+                break
+              fi
+            done
+            if [ $found -eq 0 ]; then
+              echo "ERROR: Incompatible license found: $license"
+              incompatible_found=1
+            fi
+          done
+
+          if [ $incompatible_found -eq 1 ]; then
+            echo "ERROR: Found licenses incompatible with AGPL-3.0-or-later"
+            exit 1
+          fi
+
+          echo "All licenses are compatible with AGPL-3.0-or-later"
 
   prettier:
     name: Formatting Check

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Generate REUSE SPDX document
         run: |
           echo "Checking for AGPL-3.0-or-later compatibility..."
-          reuse spdx -o reuse.spdx
+          reuse spdx --add-license-concluded --creator-person "SecPal Contributors" -o reuse.spdx
 
       - name: Check license compatibility
         run: bash scripts/check-license-compatibility.sh reuse.spdx

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -41,47 +41,7 @@ jobs:
           reuse spdx -o reuse.spdx
 
       - name: Check license compatibility
-        run: |
-          licenses=$(grep "LicenseInfoInFile" reuse.spdx | cut -d':' -f2 | sort -u | tr -d ' ')
-
-          echo "Found licenses: $licenses"
-
-          compatible_licenses=(
-            "AGPL-3.0-or-later"
-            "GPL-3.0-or-later"
-            "LGPL-3.0-or-later"
-            "MIT"
-            "BSD-2-Clause"
-            "BSD-3-Clause"
-            "Apache-2.0"
-            "CC0-1.0"
-            "ISC"
-            "OFL-1.1"
-            "ODbL-1.0"
-            "LicenseRef-SecPal-Attribution"
-          )
-
-          incompatible_found=0
-          for license in $licenses; do
-            found=0
-            for compatible in "${compatible_licenses[@]}"; do
-              if [[ "$license" == "$compatible" ]]; then
-                found=1
-                break
-              fi
-            done
-            if [ $found -eq 0 ]; then
-              echo "ERROR: Incompatible license found: $license"
-              incompatible_found=1
-            fi
-          done
-
-          if [ $incompatible_found -eq 1 ]; then
-            echo "ERROR: Found licenses incompatible with AGPL-3.0-or-later"
-            exit 1
-          fi
-
-          echo "All licenses are compatible with AGPL-3.0-or-later"
+        run: bash scripts/check-license-compatibility.sh reuse.spdx
 
   prettier:
     name: Formatting Check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 <!--
-SPDX-FileCopyrightText: 2026 SecPal
-SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-FileCopyrightText: 2026 SecPal Contributors
+SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 -->
 
 # SecPal/api Agent Instructions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- fixed PR CI for the SecPal attribution licensing rollout by allowing `LicenseRef-SecPal-Attribution` in the repository license compatibility check and by pinning GitHub Actions PostgreSQL Pest runs to the precreated worker database `public` schema instead of creating PID-based schemas in the base `testing` database (refs `api#1219`)
+- fixed PR CI for the SecPal attribution licensing rollout by allowing `LicenseRef-SecPal-Attribution` in the repository license compatibility check, by validating strict-path SPDX combinations through `scripts/check-license-compatibility.sh` instead of a raw atom grep, and by pinning GitHub Actions PostgreSQL Pest runs to the precreated worker database `public` schema instead of creating PID-based schemas in the base `testing` database (refs `api#1219`)
+- fixed the public bootstrap/source legal metadata to expose the SecPal attribution terms as the effective license document while retaining the AGPL base-license URL separately, keeping the new SPDX expression aligned with the URLs returned to clients (refs `api#1219`)
 - kept reparented organizational units pinned to the actor's pre-move access level even when the destination hierarchy still grants inherited read access, so inherited destination scopes can no longer silently escalate or downgrade the moved unit's effective access
 - blocked reparenting a directly scoped organizational subtree under a destination `include_descendants` scope when that move would newly expose future descendants the actor did not previously inherit
 - fixed `GET /v1/customers` and `GET /v1/customers/{id}` to return a consistent `sites_count` and detail `sites` payload that now match the caller's effective site visibility, keeping customer list/detail responses aligned with `/v1/customers/{id}/sites` for both full-access and scoped users (fixes `api#1212`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2026 SecPal
+SPDX-FileCopyrightText: 2026 SecPal Contributors
 SPDX-License-Identifier: CC0-1.0
 -->
 
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- added the SecPal AGPL attribution additional terms in `LICENSES/LicenseRef-SecPal-Attribution.txt`, updated project-owned AGPL SPDX metadata to `AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution`, standardized touched AGPL copyright headers to `SecPal Contributors`, and documented the section 7(b)/(c) attribution requirements in the licensing/contributor guides (refs `api#1219`)
 - added a public unauthenticated `GET /v1/release` endpoint that returns only the currently deployed API release version plus immutable corresponding-source URL, so the frontend can identify the active backend release without widening the existing AGPL/source-offer metadata surface
 - added a public unauthenticated `GET /v1/source` AGPL source-offer endpoint that keeps the canonical license, repository, copyright, and warranty payload while also returning explicit network-use source-offer notices for SecPal users
 - added the public `GET /v1/bootstrap` runtime-discovery endpoint for Android pre-login instance validation, deriving the canonical `api_base_url` from `APP_URL`, failing closed with documented `500`/`503`/`426` bootstrap responses when deployment metadata is incomplete or incompatible, and covering the success/failure slices with focused Pest tests plus operator bootstrap configuration docs (refs `api#1115`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- fixed PR CI for the SecPal attribution licensing rollout by allowing `LicenseRef-SecPal-Attribution` in the repository license compatibility check and by pinning GitHub Actions PostgreSQL Pest runs to the precreated worker database `public` schema instead of creating PID-based schemas in the base `testing` database (refs `api#1219`)
 - kept reparented organizational units pinned to the actor's pre-move access level even when the destination hierarchy still grants inherited read access, so inherited destination scopes can no longer silently escalate or downgrade the moved unit's effective access
 - blocked reparenting a directly scoped organizational subtree under a destination `include_descendants` scope when that move would newly expose future descendants the actor did not previously inherit
 - fixed `GET /v1/customers` and `GET /v1/customers/{id}` to return a consistent `sites_count` and detail `sites` payload that now match the caller's effective site visibility, keeping customer list/detail responses aligned with `/v1/customers/{id}/sites` for both full-access and scoped users (fixes `api#1212`)

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-FileCopyrightText: 2025 SecPal Contributors
 
 # SPDX-License-Identifier: CC0-1.0
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,6 +1,6 @@
 <!--
-SPDX-FileCopyrightText: 2025 SecPal
-SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-FileCopyrightText: 2025 SecPal Contributors
+SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 -->
 
 # Contributor Covenant Code of Conduct

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 <!--
-SPDX-FileCopyrightText: 2025-2026 SecPal
-SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
+SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 -->
 
 # Contributing to SecPal
@@ -414,31 +414,31 @@ All files must include SPDX license headers. **SecPal uses different licenses de
 
 ### License Selection Guide
 
-| File Type            | License             | Use For                                         |
-| -------------------- | ------------------- | ----------------------------------------------- |
-| **Application Code** | `AGPL-3.0-or-later` | PHP, TypeScript, JavaScript, React components   |
-| **Configuration**    | `CC0-1.0`           | YAML, JSON, TOML, `.gitignore`, `.editorconfig` |
-| **Helper Scripts**   | `MIT`               | Standalone bash/shell scripts, build utilities  |
-| **Documentation**    | `CC0-1.0`           | Markdown files (except LICENSE itself)          |
+| File Type            | License                                               | Use For                                         |
+| -------------------- | ----------------------------------------------------- | ----------------------------------------------- |
+| **Application Code** | `AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution` | PHP, TypeScript, JavaScript, React components   |
+| **Configuration**    | `CC0-1.0`                                             | YAML, JSON, TOML, `.gitignore`, `.editorconfig` |
+| **Helper Scripts**   | `MIT`                                                 | Standalone bash/shell scripts, build utilities  |
+| **Documentation**    | `CC0-1.0`                                             | Markdown files (except LICENSE itself)          |
 
 ### SPDX Header Examples
 
-**For application code (AGPL-3.0-or-later):**
+**For application code (`AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution`):**
 
 ```php
 <?php
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 ```
 
 ```javascript
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 ```
 
 ```typescript
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 ```
 
 **For configuration files (CC0-1.0):**
@@ -485,7 +485,7 @@ Run `reuse lint` before committing to verify compliance:
 reuse lint
 
 # Add headers to new files automatically
-reuse annotate --license AGPL-3.0-or-later --copyright "SecPal Contributors" path/to/file.php
+reuse annotate --license "AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution" --copyright "SecPal Contributors" path/to/file.php
 ```
 
 ### Bulk Licensing with REUSE.toml
@@ -544,6 +544,6 @@ If you have questions or need help:
 
 ## License
 
-By contributing to SecPal, you agree that your contributions will be licensed under the [AGPL-3.0-or-later](https://spdx.org/licenses/AGPL-3.0-or-later.html) license.
+By contributing to SecPal, you agree that your contributions will be licensed under `AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution`; see [AGPL-3.0-or-later](https://spdx.org/licenses/AGPL-3.0-or-later.html) and [LICENSES/LicenseRef-SecPal-Attribution.txt](LICENSES/LicenseRef-SecPal-Attribution.txt).
 
 Thank you for contributing to SecPal! 🎉

--- a/LICENSES/LicenseRef-SecPal-Attribution.txt
+++ b/LICENSES/LicenseRef-SecPal-Attribution.txt
@@ -1,0 +1,66 @@
+SecPal Attribution Terms
+
+These additional terms apply to SecPal under section 7(b) and section 7(c) of
+the GNU Affero General Public License version 3 or later.
+
+1. Attribution notices
+
+The following attribution notices are specified reasonable legal notices and
+author attribution notices for SecPal:
+
+  Powered by SecPal
+  Based on SecPal
+
+Covered works that display Appropriate Legal Notices in an interactive user
+interface must preserve an appropriate SecPal attribution notice in those
+Appropriate Legal Notices, or in a comparable, reasonably visible legal-notices,
+credits, or about section.
+
+Unmodified versions should use:
+
+  Powered by SecPal
+
+Modified versions must be marked in a reasonable way as different from the
+original SecPal version and should use an attribution notice such as:
+
+  Based on SecPal
+
+or:
+
+  Based on SecPal - modified by [name/entity]
+
+A modified version must not use "Powered by SecPal" in a way that implies that
+the modified version is the original SecPal version or is endorsed by the
+SecPal project maintainers.
+
+2. Project tagline and website
+
+The preferred full attribution notice is:
+
+  Powered by SecPal - A guard's best friend
+
+For modified versions, the preferred attribution notice is:
+
+  Based on SecPal - A guard's best friend
+
+The SecPal project website is:
+
+  https://secpal.app
+
+Including the tagline "A guard's best friend" and including or linking to
+https://secpal.app are requested, but they are not required as license
+conditions.
+
+3. No endorsement
+
+Modified versions must not misrepresent their origin or imply endorsement by
+the SecPal project maintainers. Modified versions may add a clear modification
+notice next to the SecPal attribution.
+
+4. Scope
+
+These additional terms do not require preservation of a specific footer layout,
+visual design, logo, hyperlink, or exact placement. A covered work may satisfy
+these terms by preserving the required SecPal attribution notice in its
+Appropriate Legal Notices or in a comparable, reasonably visible legal-notices,
+credits, or about section.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2025-2026 SecPal
+SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 SPDX-License-Identifier: CC0-1.0
 -->
 
@@ -543,7 +543,10 @@ This project uses a dual-licensing model:
 
 ### Open Source License
 
-Licensed under [AGPL-3.0-or-later](LICENSES/AGPL-3.0-or-later.txt) for:
+Licensed under `AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution`, which combines the
+[AGPL-3.0-or-later](LICENSES/AGPL-3.0-or-later.txt) license with the
+[SecPal attribution additional terms](LICENSES/LicenseRef-SecPal-Attribution.txt)
+under AGPLv3 section 7(b) and 7(c), for:
 
 - Open source projects compliant with AGPL
 - Personal use and experimentation

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 SecPal
+# SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 # SPDX-License-Identifier: CC0-1.0
 
 version = 1
@@ -6,31 +6,31 @@ SPDX-FileCopyrightText = "SecPal Contributors"
 
 [[annotations]]
 path = "app/**"
-SPDX-License-Identifier = "AGPL-3.0-or-later"
+SPDX-License-Identifier = "AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution"
 
 [[annotations]]
 path = "config/**"
-SPDX-License-Identifier = "AGPL-3.0-or-later"
+SPDX-License-Identifier = "AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution"
 
 [[annotations]]
 path = "database/**"
-SPDX-License-Identifier = "AGPL-3.0-or-later"
+SPDX-License-Identifier = "AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution"
 
 [[annotations]]
 path = "routes/**"
-SPDX-License-Identifier = "AGPL-3.0-or-later"
+SPDX-License-Identifier = "AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution"
 
 [[annotations]]
 path = "tests/**"
-SPDX-License-Identifier = "AGPL-3.0-or-later"
+SPDX-License-Identifier = "AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution"
 
 [[annotations]]
 path = "public/**"
-SPDX-License-Identifier = "AGPL-3.0-or-later"
+SPDX-License-Identifier = "AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution"
 
 [[annotations]]
 path = "bootstrap/**"
-SPDX-License-Identifier = "AGPL-3.0-or-later"
+SPDX-License-Identifier = "AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution"
 
 [[annotations]]
 path = "composer.json"
@@ -129,4 +129,4 @@ SPDX-License-Identifier = "MIT"
 
 [[annotations]]
 path = "artisan"
-SPDX-License-Identifier = "AGPL-3.0-or-later"
+SPDX-License-Identifier = "AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,4 +1,4 @@
-<!-- SPDX-FileCopyrightText: 2025 SecPal -->
+<!-- SPDX-FileCopyrightText: 2025 SecPal Contributors -->
 <!-- SPDX-License-Identifier: CC0-1.0 -->
 
 # Security Policy

--- a/app/Casts/Binary.php
+++ b/app/Casts/Binary.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 namespace App\Casts;

--- a/app/Casts/EncryptedWithDek.php
+++ b/app/Casts/EncryptedWithDek.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 namespace App\Casts;

--- a/app/Console/Commands/ApplyRetentionPolicies.php
+++ b/app/Console/Commands/ApplyRetentionPolicies.php
@@ -2,7 +2,7 @@
 
 /**
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/app/Console/Commands/CheckAddressDataCommand.php
+++ b/app/Console/Commands/CheckAddressDataCommand.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Console\Commands;
 

--- a/app/Console/Commands/CheckOpenTimestampStatus.php
+++ b/app/Console/Commands/CheckOpenTimestampStatus.php
@@ -2,7 +2,7 @@
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 //
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Console/Commands/DeleteExpiredEmployees.php
+++ b/app/Console/Commands/DeleteExpiredEmployees.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Console\Commands;
 

--- a/app/Console/Commands/ExpireRoles.php
+++ b/app/Console/Commands/ExpireRoles.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 namespace App\Console\Commands;

--- a/app/Console/Commands/GenerateKekCommand.php
+++ b/app/Console/Commands/GenerateKekCommand.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2026 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 namespace App\Console\Commands;

--- a/app/Console/Commands/GenerateTenantCommand.php
+++ b/app/Console/Commands/GenerateTenantCommand.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 namespace App\Console\Commands;

--- a/app/Console/Commands/ImportAddressDataCommand.php
+++ b/app/Console/Commands/ImportAddressDataCommand.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Console\Commands;
 

--- a/app/Console/Commands/MonitorOpenTimestamp.php
+++ b/app/Console/Commands/MonitorOpenTimestamp.php
@@ -2,7 +2,7 @@
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
 //
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Console/Commands/RebuildIndexCommand.php
+++ b/app/Console/Commands/RebuildIndexCommand.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 namespace App\Console\Commands;

--- a/app/Console/Commands/RotateDekCommand.php
+++ b/app/Console/Commands/RotateDekCommand.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 namespace App\Console\Commands;

--- a/app/Console/Commands/RotateKekCommand.php
+++ b/app/Console/Commands/RotateKekCommand.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 namespace App\Console\Commands;

--- a/app/Console/Commands/SendContractEndingNotifications.php
+++ b/app/Console/Commands/SendContractEndingNotifications.php
@@ -2,7 +2,7 @@
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
 //
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Console/Commands/SendEmployeeComplianceAlertNotifications.php
+++ b/app/Console/Commands/SendEmployeeComplianceAlertNotifications.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Console/Commands/TenantSetupCommand.php
+++ b/app/Console/Commands/TenantSetupCommand.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 namespace App\Console\Commands;

--- a/app/Console/Commands/UpdateEmployeeStatus.php
+++ b/app/Console/Commands/UpdateEmployeeStatus.php
@@ -2,7 +2,7 @@
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 //
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Console/Commands/UpdateOpenTimestamp.php
+++ b/app/Console/Commands/UpdateOpenTimestamp.php
@@ -2,7 +2,7 @@
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
 //
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Console/Commands/UpdateQualificationStatus.php
+++ b/app/Console/Commands/UpdateQualificationStatus.php
@@ -2,7 +2,7 @@
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
 //
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Console/Commands/ValidateSetupCommand.php
+++ b/app/Console/Commands/ValidateSetupCommand.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 namespace App\Console\Commands;

--- a/app/Contracts/ProcessExecutor.php
+++ b/app/Contracts/ProcessExecutor.php
@@ -2,7 +2,7 @@
 
 /**
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/app/Contracts/WebPushDeliveryServiceInterface.php
+++ b/app/Contracts/WebPushDeliveryServiceInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Contracts/WebPushTransportInterface.php
+++ b/app/Contracts/WebPushTransportInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Exceptions/BewacherregisterExportNotReadyException.php
+++ b/app/Exceptions/BewacherregisterExportNotReadyException.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Exceptions/CorruptedEncryptedAttributeException.php
+++ b/app/Exceptions/CorruptedEncryptedAttributeException.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Exceptions/EmployeeDocumentFileNotFoundException.php
+++ b/app/Exceptions/EmployeeDocumentFileNotFoundException.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Exceptions;
 

--- a/app/Exceptions/TenantKeyDecryptionException.php
+++ b/app/Exceptions/TenantKeyDecryptionException.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Http/Controllers/Api/V1/ActivityLogController.php
+++ b/app/Http/Controllers/Api/V1/ActivityLogController.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Controllers\Api\V1;
 

--- a/app/Http/Controllers/Api/V1/AddressController.php
+++ b/app/Http/Controllers/Api/V1/AddressController.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Controllers\Api\V1;
 

--- a/app/Http/Controllers/Api/V1/AndroidEnrollmentSessionController.php
+++ b/app/Http/Controllers/Api/V1/AndroidEnrollmentSessionController.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Http/Controllers/Api/V1/AssignmentController.php
+++ b/app/Http/Controllers/Api/V1/AssignmentController.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Http/Controllers/Api/V1/BootstrapController.php
+++ b/app/Http/Controllers/Api/V1/BootstrapController.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Http/Controllers/Api/V1/CostCenterController.php
+++ b/app/Http/Controllers/Api/V1/CostCenterController.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/app/Http/Controllers/Api/V1/CustomerAssignmentController.php
+++ b/app/Http/Controllers/Api/V1/CustomerAssignmentController.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Http/Controllers/Api/V1/CustomerController.php
+++ b/app/Http/Controllers/Api/V1/CustomerController.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Controllers\Api\V1;
 

--- a/app/Http/Controllers/Api/V1/EmployeeController.php
+++ b/app/Http/Controllers/Api/V1/EmployeeController.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Controllers\Api\V1;
 

--- a/app/Http/Controllers/Api/V1/EmployeeDocumentController.php
+++ b/app/Http/Controllers/Api/V1/EmployeeDocumentController.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Controllers\Api\V1;
 

--- a/app/Http/Controllers/Api/V1/EmployeeQualificationController.php
+++ b/app/Http/Controllers/Api/V1/EmployeeQualificationController.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Controllers\Api\V1;
 

--- a/app/Http/Controllers/Api/V1/OnboardingController.php
+++ b/app/Http/Controllers/Api/V1/OnboardingController.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Controllers\Api\V1;
 

--- a/app/Http/Controllers/Api/V1/OrganizationalScopeController.php
+++ b/app/Http/Controllers/Api/V1/OrganizationalScopeController.php
@@ -2,7 +2,7 @@
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 //
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Controllers\Api\V1;
 

--- a/app/Http/Controllers/Api/V1/OrganizationalUnitController.php
+++ b/app/Http/Controllers/Api/V1/OrganizationalUnitController.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Controllers\Api\V1;
 

--- a/app/Http/Controllers/Api/V1/PushDeviceRegistrationController.php
+++ b/app/Http/Controllers/Api/V1/PushDeviceRegistrationController.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Http/Controllers/Api/V1/QualificationController.php
+++ b/app/Http/Controllers/Api/V1/QualificationController.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Controllers\Api\V1;
 

--- a/app/Http/Controllers/Api/V1/ReleaseController.php
+++ b/app/Http/Controllers/Api/V1/ReleaseController.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Http/Controllers/Api/V1/RoleManagementController.php
+++ b/app/Http/Controllers/Api/V1/RoleManagementController.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 namespace App\Http\Controllers\Api\V1;

--- a/app/Http/Controllers/Api/V1/SiteAssignmentController.php
+++ b/app/Http/Controllers/Api/V1/SiteAssignmentController.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Http/Controllers/Api/V1/SiteController.php
+++ b/app/Http/Controllers/Api/V1/SiteController.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Controllers\Api\V1;
 

--- a/app/Http/Controllers/Api/V1/SourceController.php
+++ b/app/Http/Controllers/Api/V1/SourceController.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Http/Controllers/Api/V1/UserAssignmentController.php
+++ b/app/Http/Controllers/Api/V1/UserAssignmentController.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Http/Controllers/Api/V1/UserPermissionController.php
+++ b/app/Http/Controllers/Api/V1/UserPermissionController.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2026 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 namespace App\Http\Controllers\Api\V1;

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Controllers;
 

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Controllers;
 

--- a/app/Http/Controllers/HealthController.php
+++ b/app/Http/Controllers/HealthController.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Controllers;
 

--- a/app/Http/Controllers/PersonController.php
+++ b/app/Http/Controllers/PersonController.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 namespace App\Http\Controllers;

--- a/app/Http/Controllers/RoleController.php
+++ b/app/Http/Controllers/RoleController.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2026 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 namespace App\Http\Controllers;

--- a/app/Http/Middleware/CheckOrganizationalScope.php
+++ b/app/Http/Middleware/CheckOrganizationalScope.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 namespace App\Http\Middleware;

--- a/app/Http/Middleware/DisablePolyglotUi.php
+++ b/app/Http/Middleware/DisablePolyglotUi.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Http/Middleware/EnsureBrowserSessionLoginContext.php
+++ b/app/Http/Middleware/EnsureBrowserSessionLoginContext.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Middleware;
 

--- a/app/Http/Middleware/EnsureNotPreContract.php
+++ b/app/Http/Middleware/EnsureNotPreContract.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Middleware;
 

--- a/app/Http/Middleware/EnsurePreContract.php
+++ b/app/Http/Middleware/EnsurePreContract.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Middleware;
 

--- a/app/Http/Middleware/ForceJsonResponse.php
+++ b/app/Http/Middleware/ForceJsonResponse.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Middleware;
 

--- a/app/Http/Middleware/InjectTenantId.php
+++ b/app/Http/Middleware/InjectTenantId.php
@@ -2,7 +2,7 @@
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
 //
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Middleware;
 

--- a/app/Http/Middleware/RestoreSessionFromRememberToken.php
+++ b/app/Http/Middleware/RestoreSessionFromRememberToken.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Middleware;
 

--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Middleware;
 

--- a/app/Http/Middleware/SetLocaleFromHeader.php
+++ b/app/Http/Middleware/SetLocaleFromHeader.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Middleware;
 

--- a/app/Http/Middleware/SetTenant.php
+++ b/app/Http/Middleware/SetTenant.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 namespace App\Http\Middleware;

--- a/app/Http/Requests/Api/GenerateGuardBookReportRequest.php
+++ b/app/Http/Requests/Api/GenerateGuardBookReportRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Requests\Api;
 

--- a/app/Http/Requests/Api/IndexOrganizationalUnitRequest.php
+++ b/app/Http/Requests/Api/IndexOrganizationalUnitRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Requests\Api;
 

--- a/app/Http/Requests/Api/StoreObjectAreaRequest.php
+++ b/app/Http/Requests/Api/StoreObjectAreaRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Requests\Api;
 

--- a/app/Http/Requests/Api/StoreOrganizationalUnitRequest.php
+++ b/app/Http/Requests/Api/StoreOrganizationalUnitRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Requests\Api;
 

--- a/app/Http/Requests/Api/UpdateGuardBookRequest.php
+++ b/app/Http/Requests/Api/UpdateGuardBookRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Requests\Api;
 

--- a/app/Http/Requests/Api/UpdateObjectAreaRequest.php
+++ b/app/Http/Requests/Api/UpdateObjectAreaRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Requests\Api;
 

--- a/app/Http/Requests/Api/UpdateOrganizationalUnitRequest.php
+++ b/app/Http/Requests/Api/UpdateOrganizationalUnitRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Requests\Api;
 

--- a/app/Http/Requests/Api/V1/Address/IndexAddressLocalityRequest.php
+++ b/app/Http/Requests/Api/V1/Address/IndexAddressLocalityRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Requests\Api\V1\Address;
 

--- a/app/Http/Requests/Api/V1/Address/IndexAddressStreetRequest.php
+++ b/app/Http/Requests/Api/V1/Address/IndexAddressStreetRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Requests\Api\V1\Address;
 

--- a/app/Http/Requests/Api/V1/Assignment/IndexCustomerAssignmentRequest.php
+++ b/app/Http/Requests/Api/V1/Assignment/IndexCustomerAssignmentRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Http/Requests/Api/V1/Assignment/IndexSiteAssignmentRequest.php
+++ b/app/Http/Requests/Api/V1/Assignment/IndexSiteAssignmentRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Http/Requests/Api/V1/Assignment/StoreCustomerAssignmentRequest.php
+++ b/app/Http/Requests/Api/V1/Assignment/StoreCustomerAssignmentRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Http/Requests/Api/V1/Assignment/StoreSiteAssignmentRequest.php
+++ b/app/Http/Requests/Api/V1/Assignment/StoreSiteAssignmentRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Http/Requests/Api/V1/Assignment/UpdateAssignmentRequest.php
+++ b/app/Http/Requests/Api/V1/Assignment/UpdateAssignmentRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Http/Requests/Api/V1/CreateRoleRequest.php
+++ b/app/Http/Requests/Api/V1/CreateRoleRequest.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 namespace App\Http\Requests\Api\V1;

--- a/app/Http/Requests/Api/V1/IndexActivityLogRequest.php
+++ b/app/Http/Requests/Api/V1/IndexActivityLogRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Requests\Api\V1;
 

--- a/app/Http/Requests/Api/V1/IndexCustomerRequest.php
+++ b/app/Http/Requests/Api/V1/IndexCustomerRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Requests\Api\V1;
 

--- a/app/Http/Requests/Api/V1/IndexCustomerSitesRequest.php
+++ b/app/Http/Requests/Api/V1/IndexCustomerSitesRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Requests\Api\V1;
 

--- a/app/Http/Requests/Api/V1/IndexSiteRequest.php
+++ b/app/Http/Requests/Api/V1/IndexSiteRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Requests\Api\V1;
 

--- a/app/Http/Requests/Api/V1/StoreCostCenterRequest.php
+++ b/app/Http/Requests/Api/V1/StoreCostCenterRequest.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/app/Http/Requests/Api/V1/StoreCustomerRequest.php
+++ b/app/Http/Requests/Api/V1/StoreCustomerRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Requests\Api\V1;
 

--- a/app/Http/Requests/Api/V1/StoreSiteRequest.php
+++ b/app/Http/Requests/Api/V1/StoreSiteRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Requests\Api\V1;
 

--- a/app/Http/Requests/Api/V1/UpdateCostCenterRequest.php
+++ b/app/Http/Requests/Api/V1/UpdateCostCenterRequest.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/app/Http/Requests/Api/V1/UpdateCustomerRequest.php
+++ b/app/Http/Requests/Api/V1/UpdateCustomerRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Requests\Api\V1;
 

--- a/app/Http/Requests/Api/V1/UpdateRoleRequest.php
+++ b/app/Http/Requests/Api/V1/UpdateRoleRequest.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 namespace App\Http\Requests\Api\V1;

--- a/app/Http/Requests/Api/V1/UpdateSiteRequest.php
+++ b/app/Http/Requests/Api/V1/UpdateSiteRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Requests\Api\V1;
 

--- a/app/Http/Requests/AssignRoleRequest.php
+++ b/app/Http/Requests/AssignRoleRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Requests;
 

--- a/app/Http/Requests/AssignUserPermissionRequest.php
+++ b/app/Http/Requests/AssignUserPermissionRequest.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 namespace App\Http\Requests;

--- a/app/Http/Requests/AttachQualificationRequest.php
+++ b/app/Http/Requests/AttachQualificationRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Requests;
 

--- a/app/Http/Requests/Concerns/InteractsWithAddressLimit.php
+++ b/app/Http/Requests/Concerns/InteractsWithAddressLimit.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Requests\Concerns;
 

--- a/app/Http/Requests/Concerns/InteractsWithCertificationValidation.php
+++ b/app/Http/Requests/Concerns/InteractsWithCertificationValidation.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Requests\Concerns;
 

--- a/app/Http/Requests/Concerns/InteractsWithEmployeeAddressValidation.php
+++ b/app/Http/Requests/Concerns/InteractsWithEmployeeAddressValidation.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Requests\Concerns;
 

--- a/app/Http/Requests/Concerns/InteractsWithWorkPermitValidation.php
+++ b/app/Http/Requests/Concerns/InteractsWithWorkPermitValidation.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Requests\Concerns;
 

--- a/app/Http/Requests/ExchangeAndroidBootstrapTokenRequest.php
+++ b/app/Http/Requests/ExchangeAndroidBootstrapTokenRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Http/Requests/ExportEmployeeBwrRequest.php
+++ b/app/Http/Requests/ExportEmployeeBwrRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Http/Requests/ExtendRoleRequest.php
+++ b/app/Http/Requests/ExtendRoleRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Requests;
 

--- a/app/Http/Requests/GetBootstrapConfigurationRequest.php
+++ b/app/Http/Requests/GetBootstrapConfigurationRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Http/Requests/IndexEmployeeRequest.php
+++ b/app/Http/Requests/IndexEmployeeRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Requests;
 

--- a/app/Http/Requests/IndexQualificationRequest.php
+++ b/app/Http/Requests/IndexQualificationRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Requests;
 

--- a/app/Http/Requests/LoginRequest.php
+++ b/app/Http/Requests/LoginRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Requests;
 

--- a/app/Http/Requests/MfaVerificationCodeRequest.php
+++ b/app/Http/Requests/MfaVerificationCodeRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Requests;
 

--- a/app/Http/Requests/PasskeyAuthenticationChallengeRequest.php
+++ b/app/Http/Requests/PasskeyAuthenticationChallengeRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Requests;
 

--- a/app/Http/Requests/PasskeyAuthenticationVerificationRequest.php
+++ b/app/Http/Requests/PasskeyAuthenticationVerificationRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Requests;
 

--- a/app/Http/Requests/PasskeyCurrentPasswordStepUpRequest.php
+++ b/app/Http/Requests/PasskeyCurrentPasswordStepUpRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Requests;
 

--- a/app/Http/Requests/PasskeyRegistrationVerificationRequest.php
+++ b/app/Http/Requests/PasskeyRegistrationVerificationRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Requests;
 

--- a/app/Http/Requests/PasswordResetRequest.php
+++ b/app/Http/Requests/PasswordResetRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Requests;
 

--- a/app/Http/Requests/PasswordResetRequestRequest.php
+++ b/app/Http/Requests/PasswordResetRequestRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Requests;
 

--- a/app/Http/Requests/RevokeAndroidEnrollmentSessionRequest.php
+++ b/app/Http/Requests/RevokeAndroidEnrollmentSessionRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Http/Requests/StoreAndroidEnrollmentSessionRequest.php
+++ b/app/Http/Requests/StoreAndroidEnrollmentSessionRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Http/Requests/StoreEmployeeRequest.php
+++ b/app/Http/Requests/StoreEmployeeRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Requests;
 

--- a/app/Http/Requests/StoreOrganizationalScopeRequest.php
+++ b/app/Http/Requests/StoreOrganizationalScopeRequest.php
@@ -2,7 +2,7 @@
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
 //
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Requests;
 

--- a/app/Http/Requests/StorePersonRequest.php
+++ b/app/Http/Requests/StorePersonRequest.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 namespace App\Http\Requests;

--- a/app/Http/Requests/StoreQualificationRequest.php
+++ b/app/Http/Requests/StoreQualificationRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Requests;
 

--- a/app/Http/Requests/SubmitOnboardingFormRequest.php
+++ b/app/Http/Requests/SubmitOnboardingFormRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Requests;
 

--- a/app/Http/Requests/TokenPasskeyAuthenticationChallengeRequest.php
+++ b/app/Http/Requests/TokenPasskeyAuthenticationChallengeRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Requests;
 

--- a/app/Http/Requests/TokenRequest.php
+++ b/app/Http/Requests/TokenRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Requests;
 

--- a/app/Http/Requests/TotpCodeRequest.php
+++ b/app/Http/Requests/TotpCodeRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Requests;
 

--- a/app/Http/Requests/UpdateEmployeeBwrStatusRequest.php
+++ b/app/Http/Requests/UpdateEmployeeBwrStatusRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Http/Requests/UpdateEmployeeQualificationRequest.php
+++ b/app/Http/Requests/UpdateEmployeeQualificationRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Requests;
 

--- a/app/Http/Requests/UpdateEmployeeRequest.php
+++ b/app/Http/Requests/UpdateEmployeeRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Requests;
 

--- a/app/Http/Requests/UpdateOnboardingSubmissionRequest.php
+++ b/app/Http/Requests/UpdateOnboardingSubmissionRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Requests;
 

--- a/app/Http/Requests/UpdateOrganizationalScopeRequest.php
+++ b/app/Http/Requests/UpdateOrganizationalScopeRequest.php
@@ -2,7 +2,7 @@
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
 //
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Requests;
 

--- a/app/Http/Requests/UpdateQualificationRequest.php
+++ b/app/Http/Requests/UpdateQualificationRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Requests;
 

--- a/app/Http/Requests/UpdateUserLanguageRequest.php
+++ b/app/Http/Requests/UpdateUserLanguageRequest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Requests;
 

--- a/app/Http/Requests/UploadEmployeeDocumentRequest.php
+++ b/app/Http/Requests/UploadEmployeeDocumentRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Requests;
 

--- a/app/Http/Requests/UploadOnboardingSubmissionFileRequest.php
+++ b/app/Http/Requests/UploadOnboardingSubmissionFileRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Requests;
 

--- a/app/Http/Requests/UpsertPushDeviceRegistrationRequest.php
+++ b/app/Http/Requests/UpsertPushDeviceRegistrationRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Http/Requests/UserMfaResetRequest.php
+++ b/app/Http/Requests/UserMfaResetRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Requests;
 

--- a/app/Http/Resources/ActivityResource.php
+++ b/app/Http/Resources/ActivityResource.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Resources;
 

--- a/app/Http/Resources/Api/V1/CustomerAssignmentResource.php
+++ b/app/Http/Resources/Api/V1/CustomerAssignmentResource.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Http/Resources/Api/V1/CustomerResource.php
+++ b/app/Http/Resources/Api/V1/CustomerResource.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Http/Resources/Api/V1/SiteAssignmentResource.php
+++ b/app/Http/Resources/Api/V1/SiteAssignmentResource.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Http/Resources/Api/V1/SiteResource.php
+++ b/app/Http/Resources/Api/V1/SiteResource.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Http/Resources/Api/V1/UserResource.php
+++ b/app/Http/Resources/Api/V1/UserResource.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Resources\Api\V1;
 

--- a/app/Http/Resources/CostCenterResource.php
+++ b/app/Http/Resources/CostCenterResource.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/app/Http/Resources/CustomerAssignmentResource.php
+++ b/app/Http/Resources/CustomerAssignmentResource.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Resources;
 

--- a/app/Http/Resources/CustomerResource.php
+++ b/app/Http/Resources/CustomerResource.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Resources;
 

--- a/app/Http/Resources/EmployeeAddressResource.php
+++ b/app/Http/Resources/EmployeeAddressResource.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Resources;
 

--- a/app/Http/Resources/EmployeeDocumentResource.php
+++ b/app/Http/Resources/EmployeeDocumentResource.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Resources;
 

--- a/app/Http/Resources/EmployeeQualificationResource.php
+++ b/app/Http/Resources/EmployeeQualificationResource.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Resources;
 

--- a/app/Http/Resources/EmployeeResource.php
+++ b/app/Http/Resources/EmployeeResource.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Resources;
 

--- a/app/Http/Resources/OnboardingFormSubmissionResource.php
+++ b/app/Http/Resources/OnboardingFormSubmissionResource.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Resources;
 

--- a/app/Http/Resources/OnboardingFormTemplateResource.php
+++ b/app/Http/Resources/OnboardingFormTemplateResource.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Resources;
 

--- a/app/Http/Resources/OrganizationalUnitResource.php
+++ b/app/Http/Resources/OrganizationalUnitResource.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Resources;
 

--- a/app/Http/Resources/PersonResource.php
+++ b/app/Http/Resources/PersonResource.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 namespace App\Http\Resources;

--- a/app/Http/Resources/QualificationResource.php
+++ b/app/Http/Resources/QualificationResource.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Resources;
 

--- a/app/Http/Resources/SiteAssignmentResource.php
+++ b/app/Http/Resources/SiteAssignmentResource.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Resources;
 

--- a/app/Http/Resources/SiteResource.php
+++ b/app/Http/Resources/SiteResource.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Resources;
 

--- a/app/Http/Resources/UserResource.php
+++ b/app/Http/Resources/UserResource.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Resources;
 

--- a/app/Jobs/BuildMerkleTreeBatch.php
+++ b/app/Jobs/BuildMerkleTreeBatch.php
@@ -2,7 +2,7 @@
 
 /**
  * SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/app/Jobs/DeliverAndroidPushMessage.php
+++ b/app/Jobs/DeliverAndroidPushMessage.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Jobs/DeliverWebPushMessage.php
+++ b/app/Jobs/DeliverWebPushMessage.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Jobs/ProcessActivityHashChain.php
+++ b/app/Jobs/ProcessActivityHashChain.php
@@ -2,7 +2,7 @@
 
 /**
  * SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/app/Jobs/SubmitMerkleRootToOpenTimestamp.php
+++ b/app/Jobs/SubmitMerkleRootToOpenTimestamp.php
@@ -2,7 +2,7 @@
 
 /**
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/app/Jobs/UpgradeOpenTimestampProofs.php
+++ b/app/Jobs/UpgradeOpenTimestampProofs.php
@@ -2,7 +2,7 @@
 
 /**
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/app/Mail/AccountDeactivatedMail.php
+++ b/app/Mail/AccountDeactivatedMail.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Mail;
 

--- a/app/Mail/BwrIdDocumentAutoDeletedMail.php
+++ b/app/Mail/BwrIdDocumentAutoDeletedMail.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Mail/ContractEndingSoonMail.php
+++ b/app/Mail/ContractEndingSoonMail.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Mail;
 

--- a/app/Mail/EmployeeComplianceAlertMail.php
+++ b/app/Mail/EmployeeComplianceAlertMail.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Mail/OnboardingInvitationMail.php
+++ b/app/Mail/OnboardingInvitationMail.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Mail;
 

--- a/app/Mail/OnboardingNameChangedMail.php
+++ b/app/Mail/OnboardingNameChangedMail.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Mail;
 

--- a/app/Mail/PasswordResetMail.php
+++ b/app/Mail/PasswordResetMail.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/app/Mail/QualificationExpiringMail.php
+++ b/app/Mail/QualificationExpiringMail.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Mail;
 

--- a/app/Mail/WelcomeActiveMail.php
+++ b/app/Mail/WelcomeActiveMail.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Mail;
 

--- a/app/Models/Activity.php
+++ b/app/Models/Activity.php
@@ -2,7 +2,7 @@
 
 /**
  * SPDX-FileCopyrightText: 2026 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/app/Models/ActivityArchive.php
+++ b/app/Models/ActivityArchive.php
@@ -2,7 +2,7 @@
 
 /**
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/app/Models/AddressDataImport.php
+++ b/app/Models/AddressDataImport.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Models;
 

--- a/app/Models/AddressStreet.php
+++ b/app/Models/AddressStreet.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Models;
 

--- a/app/Models/AndroidEnrollmentSession.php
+++ b/app/Models/AndroidEnrollmentSession.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Models/Concerns/EnforcesTenantRouteBinding.php
+++ b/app/Models/Concerns/EnforcesTenantRouteBinding.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Models\Concerns;
 

--- a/app/Models/CostCenter.php
+++ b/app/Models/CostCenter.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Models/Customer.php
+++ b/app/Models/Customer.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Models;
 

--- a/app/Models/CustomerAssignment.php
+++ b/app/Models/CustomerAssignment.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Models/Employee.php
+++ b/app/Models/Employee.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Models;
 

--- a/app/Models/EmployeeAddress.php
+++ b/app/Models/EmployeeAddress.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Models;
 

--- a/app/Models/EmployeeDocument.php
+++ b/app/Models/EmployeeDocument.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Models;
 

--- a/app/Models/EmployeeOnboardingToken.php
+++ b/app/Models/EmployeeOnboardingToken.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Models/EmployeeQualification.php
+++ b/app/Models/EmployeeQualification.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Models;
 

--- a/app/Models/OnboardingFormSubmission.php
+++ b/app/Models/OnboardingFormSubmission.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Models;
 

--- a/app/Models/OnboardingFormTemplate.php
+++ b/app/Models/OnboardingFormTemplate.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Models;
 

--- a/app/Models/OnboardingSubmissionFile.php
+++ b/app/Models/OnboardingSubmissionFile.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Models;
 

--- a/app/Models/OrganizationalUnit.php
+++ b/app/Models/OrganizationalUnit.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Models;
 

--- a/app/Models/OrganizationalUnitClosure.php
+++ b/app/Models/OrganizationalUnitClosure.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Models;
 

--- a/app/Models/PasskeyCredential.php
+++ b/app/Models/PasskeyCredential.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Models;
 

--- a/app/Models/Permission.php
+++ b/app/Models/Permission.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 namespace App\Models;

--- a/app/Models/Person.php
+++ b/app/Models/Person.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 namespace App\Models;

--- a/app/Models/PushDeviceRegistration.php
+++ b/app/Models/PushDeviceRegistration.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Models/Qualification.php
+++ b/app/Models/Qualification.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Models;
 

--- a/app/Models/RoleAssignmentLog.php
+++ b/app/Models/RoleAssignmentLog.php
@@ -1,7 +1,7 @@
 <?php
 
-// SPDX-FileCopyrightText: 2025-2026 SecPal
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Models;
 

--- a/app/Models/Site.php
+++ b/app/Models/Site.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Models;
 

--- a/app/Models/SiteAssignment.php
+++ b/app/Models/SiteAssignment.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Models/TemporalRoleUser.php
+++ b/app/Models/TemporalRoleUser.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/app/Models/TenantKey.php
+++ b/app/Models/TenantKey.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 namespace App\Models;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Models;
 

--- a/app/Models/UserInternalOrganizationalScope.php
+++ b/app/Models/UserInternalOrganizationalScope.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Models;
 

--- a/app/Observers/EmployeeObserver.php
+++ b/app/Observers/EmployeeObserver.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Observers;
 

--- a/app/Observers/PersonObserver.php
+++ b/app/Observers/PersonObserver.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 namespace App\Observers;

--- a/app/Policies/ActivityPolicy.php
+++ b/app/Policies/ActivityPolicy.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Policies/CostCenterPolicy.php
+++ b/app/Policies/CostCenterPolicy.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Policies;
 

--- a/app/Policies/CustomerAssignmentPolicy.php
+++ b/app/Policies/CustomerAssignmentPolicy.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Policies;
 

--- a/app/Policies/CustomerPolicy.php
+++ b/app/Policies/CustomerPolicy.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Policies;
 

--- a/app/Policies/EmployeeDocumentPolicy.php
+++ b/app/Policies/EmployeeDocumentPolicy.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Policies;
 

--- a/app/Policies/EmployeePolicy.php
+++ b/app/Policies/EmployeePolicy.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Policies;
 

--- a/app/Policies/EmployeeQualificationPolicy.php
+++ b/app/Policies/EmployeeQualificationPolicy.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Policies;
 

--- a/app/Policies/OnboardingFormSubmissionPolicy.php
+++ b/app/Policies/OnboardingFormSubmissionPolicy.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Policies;
 

--- a/app/Policies/OnboardingFormTemplatePolicy.php
+++ b/app/Policies/OnboardingFormTemplatePolicy.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Policies;
 

--- a/app/Policies/OrganizationalUnitPolicy.php
+++ b/app/Policies/OrganizationalUnitPolicy.php
@@ -2,7 +2,7 @@
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 //
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Policies;
 

--- a/app/Policies/QualificationPolicy.php
+++ b/app/Policies/QualificationPolicy.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Policies;
 

--- a/app/Policies/RoleManagementPolicy.php
+++ b/app/Policies/RoleManagementPolicy.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 namespace App\Policies;

--- a/app/Policies/SiteAssignmentPolicy.php
+++ b/app/Policies/SiteAssignmentPolicy.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Policies;
 

--- a/app/Policies/SitePolicy.php
+++ b/app/Policies/SitePolicy.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Policies;
 

--- a/app/Policies/UserMfaPolicy.php
+++ b/app/Policies/UserMfaPolicy.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2026 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 namespace App\Policies;

--- a/app/Policies/UserPermissionPolicy.php
+++ b/app/Policies/UserPermissionPolicy.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2026 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 namespace App\Policies;

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Providers;
 

--- a/app/Providers/PolyglotServiceProvider.php
+++ b/app/Providers/PolyglotServiceProvider.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Repositories/PersonRepository.php
+++ b/app/Repositories/PersonRepository.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 namespace App\Repositories;

--- a/app/Services/ActivityCauserContextService.php
+++ b/app/Services/ActivityCauserContextService.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Services;
 

--- a/app/Services/ActivityLogService.php
+++ b/app/Services/ActivityLogService.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Services;
 

--- a/app/Services/AddressData/AddressDataDownloader.php
+++ b/app/Services/AddressData/AddressDataDownloader.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Services\AddressData;
 

--- a/app/Services/AddressData/AddressDataImportService.php
+++ b/app/Services/AddressData/AddressDataImportService.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Services\AddressData;
 

--- a/app/Services/AddressData/AddressStreetCsvImporter.php
+++ b/app/Services/AddressData/AddressStreetCsvImporter.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Services\AddressData;
 

--- a/app/Services/AddressData/AddressSuggestionService.php
+++ b/app/Services/AddressData/AddressSuggestionService.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Services\AddressData;
 

--- a/app/Services/AndroidPushDeliveryService.php
+++ b/app/Services/AndroidPushDeliveryService.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Services/BewacherregisterExportService.php
+++ b/app/Services/BewacherregisterExportService.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Services/EmployeeComplianceService.php
+++ b/app/Services/EmployeeComplianceService.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Services;
 

--- a/app/Services/EmployeeDocumentStorageService.php
+++ b/app/Services/EmployeeDocumentStorageService.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Services;
 

--- a/app/Services/EmployeeLifecycleService.php
+++ b/app/Services/EmployeeLifecycleService.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Services;
 

--- a/app/Services/EmployeeOnboardingInvitationService.php
+++ b/app/Services/EmployeeOnboardingInvitationService.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Services;
 

--- a/app/Services/ExpiredEmployeeDeletionService.php
+++ b/app/Services/ExpiredEmployeeDeletionService.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Services;
 

--- a/app/Services/LoginMfaChallengeService.php
+++ b/app/Services/LoginMfaChallengeService.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Services;
 

--- a/app/Services/MfaService.php
+++ b/app/Services/MfaService.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Services;
 

--- a/app/Services/OnboardingCompletionService.php
+++ b/app/Services/OnboardingCompletionService.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Services;
 

--- a/app/Services/OnboardingFormDataSchemaValidationService.php
+++ b/app/Services/OnboardingFormDataSchemaValidationService.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Services;
 

--- a/app/Services/OnboardingResidentialAddressHistorySyncService.php
+++ b/app/Services/OnboardingResidentialAddressHistorySyncService.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Services;
 

--- a/app/Services/OnboardingSchemaLocalizationService.php
+++ b/app/Services/OnboardingSchemaLocalizationService.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Services;
 

--- a/app/Services/OnboardingSubmissionFileStorageService.php
+++ b/app/Services/OnboardingSubmissionFileStorageService.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Services;
 

--- a/app/Services/OnboardingTaxIdentificationSyncService.php
+++ b/app/Services/OnboardingTaxIdentificationSyncService.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Services;
 

--- a/app/Services/OpenTimestampService.php
+++ b/app/Services/OpenTimestampService.php
@@ -2,7 +2,7 @@
 
 /**
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/app/Services/OrganizationalUnitAccessService.php
+++ b/app/Services/OrganizationalUnitAccessService.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Services/PasskeyChallengeService.php
+++ b/app/Services/PasskeyChallengeService.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Services;
 

--- a/app/Services/PasskeyService.php
+++ b/app/Services/PasskeyService.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Services;
 

--- a/app/Services/PushDeviceRegistrationService.php
+++ b/app/Services/PushDeviceRegistrationService.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Services/QueueWebPushDeliveryService.php
+++ b/app/Services/QueueWebPushDeliveryService.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Services/RuntimeHeartbeatService.php
+++ b/app/Services/RuntimeHeartbeatService.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Services;
 

--- a/app/Services/SystemProcessExecutor.php
+++ b/app/Services/SystemProcessExecutor.php
@@ -2,7 +2,7 @@
 
 /**
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/app/Services/UserDeviceAccessCleanupService.php
+++ b/app/Services/UserDeviceAccessCleanupService.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Services/WebPushDeliveryService.php
+++ b/app/Services/WebPushDeliveryService.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Services/WebPushTransport.php
+++ b/app/Services/WebPushTransport.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Support/AddressDataConfig.php
+++ b/app/Support/AddressDataConfig.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Support;
 

--- a/app/Support/AddressHistoryLookback.php
+++ b/app/Support/AddressHistoryLookback.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Support;
 

--- a/app/Support/AddressSearchNormalizer.php
+++ b/app/Support/AddressSearchNormalizer.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Support;
 

--- a/app/Support/AndroidPushDeliveryConfiguration.php
+++ b/app/Support/AndroidPushDeliveryConfiguration.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Support/ApiTimestamp.php
+++ b/app/Support/ApiTimestamp.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Support/BootstrapContract.php
+++ b/app/Support/BootstrapContract.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Support/Concerns/InteractsWithConfigValues.php
+++ b/app/Support/Concerns/InteractsWithConfigValues.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Support/LikePattern.php
+++ b/app/Support/LikePattern.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Support;
 

--- a/app/Support/NotificationChannelRuntimeConfiguration.php
+++ b/app/Support/NotificationChannelRuntimeConfiguration.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Support/PublicApiRelease.php
+++ b/app/Support/PublicApiRelease.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Support/PublicSourceOffer.php
+++ b/app/Support/PublicSourceOffer.php
@@ -61,7 +61,7 @@ class PublicSourceOffer
 
     /**
      * @return array{
-     *     license: array{spdx_id: string, name: string, url: string},
+     *     license: array{spdx_id: string, name: string, url: string, base_license_url: string},
      *     source_url: string
      * }
      */
@@ -78,7 +78,7 @@ class PublicSourceOffer
      *     source_url: string,
      *     notice: string,
      *     source_offer: string,
-     *     license: array{spdx_id: string, name: string, url: string},
+     *     license: array{spdx_id: string, name: string, url: string, base_license_url: string},
      *     repositories: array<int, array{name: string, url: string, description: string}>,
      *     copyright_notice: string,
      *     warranty_notice: string
@@ -114,6 +114,10 @@ class PublicSourceOffer
 
         if ($this->httpUrlConfig('bootstrap.legal.license_url') === null) {
             $missingFields[] = 'legal.license.url';
+        }
+
+        if ($this->httpUrlConfig('bootstrap.legal.license_base_url') === null) {
+            $missingFields[] = 'legal.license.base_license_url';
         }
 
         if ($this->trimmedStringConfig('bootstrap.legal.copyright_notice') === null) {
@@ -160,7 +164,7 @@ class PublicSourceOffer
     }
 
     /**
-     * @return array{spdx_id: string, name: string, url: string}
+     * @return array{spdx_id: string, name: string, url: string, base_license_url: string}
      */
     private function licenseMetadata(): array
     {
@@ -168,6 +172,7 @@ class PublicSourceOffer
             'spdx_id' => (string) $this->trimmedStringConfig('bootstrap.legal.license_spdx_id'),
             'name' => (string) $this->trimmedStringConfig('bootstrap.legal.license_name'),
             'url' => (string) $this->httpUrlConfig('bootstrap.legal.license_url'),
+            'base_license_url' => (string) $this->httpUrlConfig('bootstrap.legal.license_base_url'),
         ];
     }
 

--- a/app/Support/PublicSourceOffer.php
+++ b/app/Support/PublicSourceOffer.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Support/PushMessageDataNormalizer.php
+++ b/app/Support/PushMessageDataNormalizer.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Support/ResidentialAddressHistorySchema.php
+++ b/app/Support/ResidentialAddressHistorySchema.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Support;
 

--- a/app/Support/WebPushDeliveryConfiguration.php
+++ b/app/Support/WebPushDeliveryConfiguration.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Support/WebPushTransportResult.php
+++ b/app/Support/WebPushTransportResult.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/app/Traits/NormalizesPersonFields.php
+++ b/app/Traits/NormalizesPersonFields.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 namespace App\Traits;

--- a/artisan
+++ b/artisan
@@ -3,7 +3,7 @@
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
 //
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Illuminate\Foundation\Application;
 use Symfony\Component\Console\Input\ArgvInput;

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Auth\AuthenticationException;

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 return [
     App\Providers\AppServiceProvider::class,

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "laravel",
     "framework"
   ],
-  "license": "AGPL-3.0-or-later",
+  "license": "AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution",
   "require": {
     "php": "^8.4",
     "codewiser/polyglot": "^2.1",

--- a/config/activitylog.php
+++ b/config/activitylog.php
@@ -2,7 +2,7 @@
 
 /**
  * SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/config/address_data.php
+++ b/config/address_data.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 return [
 

--- a/config/android.php
+++ b/config/android.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 return [
     'device_admin_component_name' => (string) env('ANDROID_DEVICE_ADMIN_COMPONENT_NAME', 'app.secpal/.SecPalDeviceAdminReceiver'),

--- a/config/app.php
+++ b/config/app.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 return [
 

--- a/config/attachments.php
+++ b/config/attachments.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 return [

--- a/config/auth.php
+++ b/config/auth.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 return [
 

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -16,8 +16,9 @@ return [
     ],
     'legal' => [
         'license_spdx_id' => env('BOOTSTRAP_LICENSE_SPDX_ID', 'AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution'),
-        'license_name' => env('BOOTSTRAP_LICENSE_NAME', 'GNU Affero General Public License v3.0 or later'),
-        'license_url' => env('BOOTSTRAP_LICENSE_URL', 'https://www.gnu.org/licenses/agpl-3.0.html'),
+        'license_name' => env('BOOTSTRAP_LICENSE_NAME', 'GNU Affero General Public License v3.0 or later with SecPal attribution additional terms'),
+        'license_url' => env('BOOTSTRAP_LICENSE_URL', 'https://github.com/SecPal/api/blob/main/LICENSES/LicenseRef-SecPal-Attribution.txt'),
+        'license_base_url' => env('BOOTSTRAP_LICENSE_BASE_URL', 'https://www.gnu.org/licenses/agpl-3.0.html'),
         'copyright_notice' => env('BOOTSTRAP_COPYRIGHT_NOTICE', 'Copyright SecPal and contributors.'),
         'warranty_notice' => env(
             'BOOTSTRAP_WARRANTY_NOTICE',

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 return [
     'public_enabled' => filter_var(env('BOOTSTRAP_PUBLIC_ENABLED', false), FILTER_VALIDATE_BOOL),
@@ -15,7 +15,7 @@ return [
         'source_url' => env('BOOTSTRAP_API_RELEASE_SOURCE_URL'),
     ],
     'legal' => [
-        'license_spdx_id' => env('BOOTSTRAP_LICENSE_SPDX_ID', 'AGPL-3.0-or-later'),
+        'license_spdx_id' => env('BOOTSTRAP_LICENSE_SPDX_ID', 'AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution'),
         'license_name' => env('BOOTSTRAP_LICENSE_NAME', 'GNU Affero General Public License v3.0 or later'),
         'license_url' => env('BOOTSTRAP_LICENSE_URL', 'https://www.gnu.org/licenses/agpl-3.0.html'),
         'copyright_notice' => env('BOOTSTRAP_COPYRIGHT_NOTICE', 'Copyright SecPal and contributors.'),

--- a/config/cache.php
+++ b/config/cache.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Illuminate\Support\Str;
 

--- a/config/cors.php
+++ b/config/cors.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 $parseCorsAllowedOrigins = static function (string $configuredOrigins): array {
     $allowedOrigins = array_values(array_unique(array_filter(

--- a/config/database.php
+++ b/config/database.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Illuminate\Support\Str;
 

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 return [
 

--- a/config/logging.php
+++ b/config/logging.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Monolog\Handler\NullHandler;
 use Monolog\Handler\StreamHandler;

--- a/config/mail.php
+++ b/config/mail.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 return [
 

--- a/config/onboarding_nationalities.php
+++ b/config/onboarding_nationalities.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 return [
     // Source: Destatis Staats- und Gebietssystematik (Sheet: 2. Staatsangehoerigkeit),

--- a/config/opentimestamp.php
+++ b/config/opentimestamp.php
@@ -2,7 +2,7 @@
 
 /**
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/config/passkeys.php
+++ b/config/passkeys.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 $frontendUrl = (string) env('FRONTEND_URL', 'https://app.secpal.dev');
 $frontendOriginEntries = array_values(array_filter(array_map(

--- a/config/polyglot.php
+++ b/config/polyglot.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 return [
 

--- a/config/queue.php
+++ b/config/queue.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 return [
 

--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 return [
 

--- a/config/services.php
+++ b/config/services.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 return [
 

--- a/config/session.php
+++ b/config/session.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Illuminate\Support\Str;
 

--- a/config/two-factor.php
+++ b/config/two-factor.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 return [
     /*

--- a/database/factories/ActivityArchiveFactory.php
+++ b/database/factories/ActivityArchiveFactory.php
@@ -2,7 +2,7 @@
 
 /**
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/database/factories/ActivityFactory.php
+++ b/database/factories/ActivityFactory.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace Database\Factories;
 

--- a/database/factories/AndroidEnrollmentSessionFactory.php
+++ b/database/factories/AndroidEnrollmentSessionFactory.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/database/factories/CostCenterFactory.php
+++ b/database/factories/CostCenterFactory.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/database/factories/CustomerAssignmentFactory.php
+++ b/database/factories/CustomerAssignmentFactory.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/database/factories/CustomerFactory.php
+++ b/database/factories/CustomerFactory.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace Database\Factories;
 

--- a/database/factories/EmployeeAddressFactory.php
+++ b/database/factories/EmployeeAddressFactory.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace Database\Factories;
 

--- a/database/factories/EmployeeDocumentFactory.php
+++ b/database/factories/EmployeeDocumentFactory.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace Database\Factories;
 

--- a/database/factories/EmployeeFactory.php
+++ b/database/factories/EmployeeFactory.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace Database\Factories;
 

--- a/database/factories/EmployeeOnboardingTokenFactory.php
+++ b/database/factories/EmployeeOnboardingTokenFactory.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace Database\Factories;
 

--- a/database/factories/EmployeeQualificationFactory.php
+++ b/database/factories/EmployeeQualificationFactory.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace Database\Factories;
 

--- a/database/factories/OnboardingFormSubmissionFactory.php
+++ b/database/factories/OnboardingFormSubmissionFactory.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace Database\Factories;
 

--- a/database/factories/OnboardingFormTemplateFactory.php
+++ b/database/factories/OnboardingFormTemplateFactory.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace Database\Factories;
 

--- a/database/factories/OrganizationalUnitFactory.php
+++ b/database/factories/OrganizationalUnitFactory.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace Database\Factories;
 

--- a/database/factories/PasskeyCredentialFactory.php
+++ b/database/factories/PasskeyCredentialFactory.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace Database\Factories;
 

--- a/database/factories/PersonFactory.php
+++ b/database/factories/PersonFactory.php
@@ -1,7 +1,7 @@
 <?php
 
-// SPDX-FileCopyrightText: 2025-2026 SecPal
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/database/factories/QualificationFactory.php
+++ b/database/factories/QualificationFactory.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace Database\Factories;
 

--- a/database/factories/SiteAssignmentFactory.php
+++ b/database/factories/SiteAssignmentFactory.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/database/factories/SiteFactory.php
+++ b/database/factories/SiteFactory.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace Database\Factories;
 

--- a/database/factories/TenantKeyFactory.php
+++ b/database/factories/TenantKeyFactory.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace Database\Factories;
 

--- a/database/factories/UserInternalOrganizationalScopeFactory.php
+++ b/database/factories/UserInternalOrganizationalScopeFactory.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace Database\Factories;
 

--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;

--- a/database/migrations/0001_01_01_000001_create_cache_table.php
+++ b/database/migrations/0001_01_01_000001_create_cache_table.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;

--- a/database/migrations/0001_01_01_000002_create_jobs_table.php
+++ b/database/migrations/0001_01_01_000002_create_jobs_table.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;

--- a/database/migrations/2025_11_01_165633_create_tenant_keys_table.php
+++ b/database/migrations/2025_11_01_165633_create_tenant_keys_table.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 use Illuminate\Database\Migrations\Migration;

--- a/database/migrations/2025_11_01_165901_create_person_table.php
+++ b/database/migrations/2025_11_01_165901_create_person_table.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 use Illuminate\Database\Migrations\Migration;

--- a/database/migrations/2025_11_01_185152_create_permission_tables.php
+++ b/database/migrations/2025_11_01_185152_create_permission_tables.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 use Illuminate\Database\Migrations\Migration;

--- a/database/migrations/2025_11_01_195727_create_personal_access_tokens_table.php
+++ b/database/migrations/2025_11_01_195727_create_personal_access_tokens_table.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;

--- a/database/migrations/2025_11_01_210213_change_bytea_columns_to_varchar.php
+++ b/database/migrations/2025_11_01_210213_change_bytea_columns_to_varchar.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 use Illuminate\Database\Migrations\Migration;

--- a/database/migrations/2025_11_08_143609_add_temporal_columns_to_model_has_roles_table.php
+++ b/database/migrations/2025_11_08_143609_add_temporal_columns_to_model_has_roles_table.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 use Illuminate\Database\Migrations\Migration;

--- a/database/migrations/2025_11_08_215807_create_role_assignments_log_table.php
+++ b/database/migrations/2025_11_08_215807_create_role_assignments_log_table.php
@@ -1,7 +1,7 @@
 <?php
 
-// SPDX-FileCopyrightText: 2025 SecPal
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;

--- a/database/migrations/2025_11_12_193139_add_description_to_permissions_table.php
+++ b/database/migrations/2025_11_12_193139_add_description_to_permissions_table.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 use Illuminate\Database\Migrations\Migration;

--- a/database/migrations/2025_11_14_213406_add_temporal_columns_to_model_has_permissions_table.php
+++ b/database/migrations/2025_11_14_213406_add_temporal_columns_to_model_has_permissions_table.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 use Illuminate\Database\Migrations\Migration;

--- a/database/migrations/2025_11_16_192506_add_preferred_locale_to_users_table.php
+++ b/database/migrations/2025_11_16_192506_add_preferred_locale_to_users_table.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;

--- a/database/migrations/2025_11_29_100000_create_organizational_units_table.php
+++ b/database/migrations/2025_11_29_100000_create_organizational_units_table.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 use Illuminate\Database\Migrations\Migration;

--- a/database/migrations/2025_11_29_100001_create_organizational_unit_closures_table.php
+++ b/database/migrations/2025_11_29_100001_create_organizational_unit_closures_table.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 use Illuminate\Database\Migrations\Migration;

--- a/database/migrations/2025_11_29_100002_create_user_internal_organizational_scopes_table.php
+++ b/database/migrations/2025_11_29_100002_create_user_internal_organizational_scopes_table.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 use Illuminate\Database\Migrations\Migration;

--- a/database/migrations/2025_12_07_235838_create_employees_table.php
+++ b/database/migrations/2025_12_07_235838_create_employees_table.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;

--- a/database/migrations/2025_12_07_235840_create_qualifications_table.php
+++ b/database/migrations/2025_12_07_235840_create_qualifications_table.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;

--- a/database/migrations/2025_12_07_235843_create_employee_qualifications_table.php
+++ b/database/migrations/2025_12_07_235843_create_employee_qualifications_table.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;

--- a/database/migrations/2025_12_07_235846_create_employee_documents_table.php
+++ b/database/migrations/2025_12_07_235846_create_employee_documents_table.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;

--- a/database/migrations/2025_12_07_235850_create_onboarding_form_templates_table.php
+++ b/database/migrations/2025_12_07_235850_create_onboarding_form_templates_table.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;

--- a/database/migrations/2025_12_07_235853_create_onboarding_form_submissions_table.php
+++ b/database/migrations/2025_12_07_235853_create_onboarding_form_submissions_table.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;

--- a/database/migrations/2025_12_14_100001_create_customers_table.php
+++ b/database/migrations/2025_12_14_100001_create_customers_table.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/database/migrations/2025_12_14_100002_create_sites_table.php
+++ b/database/migrations/2025_12_14_100002_create_sites_table.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/database/migrations/2025_12_14_100003_create_customer_assignments_table.php
+++ b/database/migrations/2025_12_14_100003_create_customer_assignments_table.php
@@ -2,7 +2,7 @@
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
 //
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/database/migrations/2025_12_14_100004_create_site_assignments_table.php
+++ b/database/migrations/2025_12_14_100004_create_site_assignments_table.php
@@ -2,7 +2,7 @@
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
 //
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/database/migrations/2025_12_14_100005_create_cost_centers_table.php
+++ b/database/migrations/2025_12_14_100005_create_cost_centers_table.php
@@ -2,7 +2,7 @@
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
 //
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/database/migrations/2025_12_18_193721_add_tenant_id_to_users_table.php
+++ b/database/migrations/2025_12_18_193721_add_tenant_id_to_users_table.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;

--- a/database/migrations/2025_12_18_193745_backfill_user_tenant_ids.php
+++ b/database/migrations/2025_12_18_193745_backfill_user_tenant_ids.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\TenantKey;
 use Illuminate\Database\Migrations\Migration;

--- a/database/migrations/2025_12_18_193808_make_user_tenant_id_not_nullable.php
+++ b/database/migrations/2025_12_18_193808_make_user_tenant_id_not_nullable.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;

--- a/database/migrations/2025_12_21_160224_create_activity_log_table.php
+++ b/database/migrations/2025_12_21_160224_create_activity_log_table.php
@@ -2,7 +2,7 @@
 
 /**
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/database/migrations/2025_12_21_160227_create_activity_log_archive_table.php
+++ b/database/migrations/2025_12_21_160227_create_activity_log_archive_table.php
@@ -2,7 +2,7 @@
 
 /**
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/database/migrations/2025_12_21_201417_add_event_column_to_activity_log_table.php
+++ b/database/migrations/2025_12_21_201417_add_event_column_to_activity_log_table.php
@@ -2,7 +2,7 @@
 
 /**
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/database/migrations/2025_12_24_162643_make_activity_log_event_hash_nullable.php
+++ b/database/migrations/2025_12_24_162643_make_activity_log_event_hash_nullable.php
@@ -2,7 +2,7 @@
 
 /**
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 use Illuminate\Database\Migrations\Migration;

--- a/database/migrations/2025_12_25_152110_add_leadership_rank_filters_to_user_internal_organizational_scopes_table.php
+++ b/database/migrations/2025_12_25_152110_add_leadership_rank_filters_to_user_internal_organizational_scopes_table.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 use Illuminate\Database\Migrations\Migration;

--- a/database/migrations/2025_12_25_190415_add_assignable_rank_and_self_access_to_user_internal_organizational_scopes_table.php
+++ b/database/migrations/2025_12_25_190415_add_assignable_rank_and_self_access_to_user_internal_organizational_scopes_table.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 use Illuminate\Database\Migrations\Migration;

--- a/database/migrations/2025_12_25_190944_remove_unique_constraint_from_user_internal_organizational_scopes_table.php
+++ b/database/migrations/2025_12_25_190944_remove_unique_constraint_from_user_internal_organizational_scopes_table.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 use Illuminate\Database\Migrations\Migration;

--- a/database/migrations/2025_12_27_040629_change_activity_log_archive_id_to_bigint.php
+++ b/database/migrations/2025_12_27_040629_change_activity_log_archive_id_to_bigint.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/database/migrations/2025_12_28_182202_add_merkle_batch_count_to_activity_log_table.php
+++ b/database/migrations/2025_12_28_182202_add_merkle_batch_count_to_activity_log_table.php
@@ -2,7 +2,7 @@
 
 /**
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/database/migrations/2026_01_04_183934_add_bewachv_fields_to_employees_table.php
+++ b/database/migrations/2026_01_04_183934_add_bewachv_fields_to_employees_table.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;

--- a/database/migrations/2026_01_04_190847_remove_sachkunde_expiry_from_employees_table.php
+++ b/database/migrations/2026_01_04_190847_remove_sachkunde_expiry_from_employees_table.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;

--- a/database/migrations/2026_01_08_194352_create_employee_onboarding_tokens_table.php
+++ b/database/migrations/2026_01_08_194352_create_employee_onboarding_tokens_table.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;

--- a/database/migrations/2026_01_11_120000_remove_deleted_at_from_activity_log.php
+++ b/database/migrations/2026_01_11_120000_remove_deleted_at_from_activity_log.php
@@ -2,7 +2,7 @@
 
 /**
  * SPDX-FileCopyrightText: 2026 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/database/migrations/2026_03_23_190000_add_onboarding_invitation_tracking_to_employees_table.php
+++ b/database/migrations/2026_03_23_190000_add_onboarding_invitation_tracking_to_employees_table.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;

--- a/database/migrations/2026_03_26_120000_add_attribute_changes_to_activity_log_table.php
+++ b/database/migrations/2026_03_26_120000_add_attribute_changes_to_activity_log_table.php
@@ -2,7 +2,7 @@
 
 /**
  * SPDX-FileCopyrightText: 2026 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/database/migrations/2026_03_29_160000_add_onboarding_workflow_status_to_employees_table.php
+++ b/database/migrations/2026_03_29_160000_add_onboarding_workflow_status_to_employees_table.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\Employee;
 use Illuminate\Database\Migrations\Migration;

--- a/database/migrations/2026_04_01_093957_create_two_factor_authentications_table.php
+++ b/database/migrations/2026_04_01_093957_create_two_factor_authentications_table.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Illuminate\Database\Schema\Blueprint;
 use Laragear\TwoFactor\Models\TwoFactorAuthentication;

--- a/database/migrations/2026_04_03_130000_add_token_lookup_hash_to_employee_onboarding_tokens_table.php
+++ b/database/migrations/2026_04_03_130000_add_token_lookup_hash_to_employee_onboarding_tokens_table.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;

--- a/database/migrations/2026_04_03_231500_add_authorization_lookup_indexes.php
+++ b/database/migrations/2026_04_03_231500_add_authorization_lookup_indexes.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2026 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/database/migrations/2026_04_04_120000_encrypt_employee_phone_column.php
+++ b/database/migrations/2026_04_04_120000_encrypt_employee_phone_column.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\TenantKey;
 use App\Traits\NormalizesPersonFields;

--- a/database/migrations/2026_04_04_130000_add_runtime_access_snapshot_to_employees_table.php
+++ b/database/migrations/2026_04_04_130000_add_runtime_access_snapshot_to_employees_table.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;

--- a/database/migrations/2026_04_04_160000_add_pending_jobs_index_to_jobs_table.php
+++ b/database/migrations/2026_04_04_160000_add_pending_jobs_index_to_jobs_table.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;

--- a/database/migrations/2026_04_05_220000_create_onboarding_submission_files_table.php
+++ b/database/migrations/2026_04_05_220000_create_onboarding_submission_files_table.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;

--- a/database/migrations/2026_04_05_230000_create_passkey_credentials_table.php
+++ b/database/migrations/2026_04_05_230000_create_passkey_credentials_table.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;

--- a/database/migrations/2026_04_06_100007_create_android_enrollment_sessions_table.php
+++ b/database/migrations/2026_04_06_100007_create_android_enrollment_sessions_table.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/database/migrations/2026_04_12_150000_add_non_eu_work_permit_core_to_employees_table.php
+++ b/database/migrations/2026_04_12_150000_add_non_eu_work_permit_core_to_employees_table.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\TenantKey;
 use Illuminate\Database\Migrations\Migration;

--- a/database/migrations/2026_04_12_160000_add_employee_certification_expiry_fields_to_employees_table.php
+++ b/database/migrations/2026_04_12_160000_add_employee_certification_expiry_fields_to_employees_table.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;

--- a/database/migrations/2026_04_18_100000_add_template_key_to_onboarding_form_templates_table.php
+++ b/database/migrations/2026_04_18_100000_add_template_key_to_onboarding_form_templates_table.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Query\Builder;

--- a/database/migrations/2026_04_18_140000_scope_employee_number_uniqueness_to_tenant.php
+++ b/database/migrations/2026_04_18_140000_scope_employee_number_uniqueness_to_tenant.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;

--- a/database/migrations/2026_04_29_215500_backfill_missing_organizational_unit_self_closures.php
+++ b/database/migrations/2026_04_29_215500_backfill_missing_organizational_unit_self_closures.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\DB;

--- a/database/migrations/2026_04_30_120000_remove_admin_access_level_from_user_internal_organizational_scopes.php
+++ b/database/migrations/2026_04_30_120000_remove_admin_access_level_from_user_internal_organizational_scopes.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\DB;

--- a/database/migrations/2026_05_05_000100_add_emergency_contacts_to_employees_table.php
+++ b/database/migrations/2026_05_05_000100_add_emergency_contacts_to_employees_table.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;

--- a/database/migrations/2026_05_05_200000_split_nationality_residence_onboarding_step.php
+++ b/database/migrations/2026_05_05_200000_split_nationality_residence_onboarding_step.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\Employee;
 use App\Models\OnboardingFormSubmission;

--- a/database/migrations/2026_05_09_120000_add_document_subtype_to_onboarding_submission_files_table.php
+++ b/database/migrations/2026_05_09_120000_add_document_subtype_to_onboarding_submission_files_table.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;

--- a/database/migrations/2026_05_10_120000_create_employee_addresses_table.php
+++ b/database/migrations/2026_05_10_120000_create_employee_addresses_table.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;

--- a/database/migrations/2026_05_10_120001_drop_legacy_employee_address_columns_from_employees_table.php
+++ b/database/migrations/2026_05_10_120001_drop_legacy_employee_address_columns_from_employees_table.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\TenantKey;
 use Illuminate\Database\Migrations\Migration;

--- a/database/migrations/2026_05_10_140000_create_address_data_tables.php
+++ b/database/migrations/2026_05_10_140000_create_address_data_tables.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;

--- a/database/migrations/2026_05_11_120000_drop_state_from_employee_addresses_table.php
+++ b/database/migrations/2026_05_11_120000_drop_state_from_employee_addresses_table.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;

--- a/database/migrations/2026_05_11_130000_drop_birth_state_from_employees_table.php
+++ b/database/migrations/2026_05_11_130000_drop_birth_state_from_employees_table.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;

--- a/database/migrations/2026_05_12_120000_add_residential_address_history_onboarding_step.php
+++ b/database/migrations/2026_05_12_120000_add_residential_address_history_onboarding_step.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\Employee;
 use App\Support\ResidentialAddressHistorySchema;

--- a/database/migrations/2026_05_15_120000_update_residential_address_history_resided_from_label.php
+++ b/database/migrations/2026_05_15_120000_update_residential_address_history_resided_from_label.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Carbon;

--- a/database/migrations/2026_05_22_120000_add_invalidation_to_employee_onboarding_tokens_table.php
+++ b/database/migrations/2026_05_22_120000_add_invalidation_to_employee_onboarding_tokens_table.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;

--- a/database/migrations/2026_05_23_130000_create_push_device_registrations_table.php
+++ b/database/migrations/2026_05_23_130000_create_push_device_registrations_table.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/database/migrations/2026_05_26_120000_add_web_push_fields_to_push_device_registrations_table.php
+++ b/database/migrations/2026_05_26_120000_add_web_push_fields_to_push_device_registrations_table.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/database/migrations/2026_06_29_120000_allow_employee_audit_records_to_survive_user_deletion.php
+++ b/database/migrations/2026_06_29_120000_allow_employee_audit_records_to_survive_user_deletion.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\DB;

--- a/database/migrations/2026_06_29_130000_preserve_assignment_history_on_user_delete.php
+++ b/database/migrations/2026_06_29_130000_preserve_assignment_history_on_user_delete.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/database/migrations/2026_06_29_160000_preserve_android_enrollment_history_on_user_delete.php
+++ b/database/migrations/2026_06_29_160000_preserve_android_enrollment_history_on_user_delete.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/database/migrations/2026_06_30_100000_add_causer_employee_context_to_activity_log.php
+++ b/database/migrations/2026_06_30_100000_add_causer_employee_context_to_activity_log.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/database/seeders/AddressDataSeeder.php
+++ b/database/seeders/AddressDataSeeder.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace Database\Seeders;
 

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace Database\Seeders;
 

--- a/database/seeders/OnboardingDemoUserSeeder.php
+++ b/database/seeders/OnboardingDemoUserSeeder.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace Database\Seeders;
 

--- a/database/seeders/OnboardingFormTemplatesSeeder.php
+++ b/database/seeders/OnboardingFormTemplatesSeeder.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace Database\Seeders;
 

--- a/database/seeders/OrganizationalUnitSeeder.php
+++ b/database/seeders/OrganizationalUnitSeeder.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace Database\Seeders;
 

--- a/database/seeders/QualificationsSeeder.php
+++ b/database/seeders/QualificationsSeeder.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace Database\Seeders;
 

--- a/database/seeders/RolesAndPermissionsSeeder.php
+++ b/database/seeders/RolesAndPermissionsSeeder.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace Database\Seeders;
 

--- a/docs/ACTIVITY_LOGGING_ADMIN_GUIDE.md
+++ b/docs/ACTIVITY_LOGGING_ADMIN_GUIDE.md
@@ -1,6 +1,6 @@
 <!--
-SPDX-FileCopyrightText: 2026 SecPal
-SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-FileCopyrightText: 2026 SecPal Contributors
+SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 -->
 
 # Activity Logging Admin Guide

--- a/docs/ACTIVITY_LOGGING_LEGAL_GUIDE.md
+++ b/docs/ACTIVITY_LOGGING_LEGAL_GUIDE.md
@@ -1,6 +1,6 @@
 <!--
-SPDX-FileCopyrightText: 2026 SecPal
-SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-FileCopyrightText: 2026 SecPal Contributors
+SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 -->
 
 # Activity Logging Legal Guide

--- a/docs/ACTIVITY_LOGGING_USER_GUIDE.md
+++ b/docs/ACTIVITY_LOGGING_USER_GUIDE.md
@@ -1,6 +1,6 @@
 <!--
-SPDX-FileCopyrightText: 2026 SecPal
-SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-FileCopyrightText: 2026 SecPal Contributors
+SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 -->
 
 # Activity Logging User Guide

--- a/docs/BEWACHV_COMPLIANCE.md
+++ b/docs/BEWACHV_COMPLIANCE.md
@@ -1,7 +1,7 @@
 <!--
 SPDX-FileCopyrightText: 2024-2026 SecPal Contributors
 
-SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 -->
 
 # BewachV Compliance Documentation
@@ -813,4 +813,4 @@ For production deployment, verify:
 **Document Version:** 1.0
 **Last Updated:** 2026-01-04
 **Author:** SecPal Contributors
-**License:** AGPL-3.0-or-later
+**License:** AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution

--- a/docs/MAIL_SYSTEM.md
+++ b/docs/MAIL_SYSTEM.md
@@ -1,6 +1,6 @@
 <!--
-SPDX-FileCopyrightText: 2025-2026 SecPal
-SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
+SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 -->
 
 # Mail System Documentation

--- a/docs/OPENTIMESTAMP_INTEGRATION.md
+++ b/docs/OPENTIMESTAMP_INTEGRATION.md
@@ -440,4 +440,4 @@ This documentation is licensed under CC-BY-4.0.
 
 The OpenTimestamp client is licensed under LGPL-3.0.
 
-SecPal integration code is licensed under AGPL-3.0-or-later.
+SecPal integration code is licensed under AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution.

--- a/docs/api/rbac-endpoints.md
+++ b/docs/api/rbac-endpoints.md
@@ -1,5 +1,5 @@
-<!-- SPDX-FileCopyrightText: 2025-2026 SecPal -->
-<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- SPDX-FileCopyrightText: 2025-2026 SecPal Contributors -->
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution -->
 
 # RBAC API Endpoints Reference
 

--- a/docs/guides/direct-permissions.md
+++ b/docs/guides/direct-permissions.md
@@ -1,5 +1,5 @@
-<!-- SPDX-FileCopyrightText: 2025 SecPal Authors -->
-<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- SPDX-FileCopyrightText: 2025 SecPal Contributors -->
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution -->
 
 # Developer Guide: Direct Permissions
 

--- a/docs/guides/firebase-push-bootstrap-audit.md
+++ b/docs/guides/firebase-push-bootstrap-audit.md
@@ -1,5 +1,5 @@
 <!-- SPDX-FileCopyrightText: 2026 SecPal Contributors -->
-<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution -->
 
 # Firebase Push Bootstrap Audit
 

--- a/docs/guides/multi-tenant-deployment.md
+++ b/docs/guides/multi-tenant-deployment.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2025 SecPal
+SPDX-FileCopyrightText: 2025 SecPal Contributors
 SPDX-License-Identifier: CC0-1.0
 -->
 

--- a/docs/guides/permission-system.md
+++ b/docs/guides/permission-system.md
@@ -1,5 +1,5 @@
-<!-- SPDX-FileCopyrightText: 2025-2026 SecPal -->
-<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- SPDX-FileCopyrightText: 2025-2026 SecPal Contributors -->
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution -->
 
 # Permission System Guide
 

--- a/docs/guides/production-deployment.md
+++ b/docs/guides/production-deployment.md
@@ -1,5 +1,5 @@
 <!-- SPDX-FileCopyrightText: 2025 SecPal Contributors -->
-<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution -->
 
 # Production Deployment Guide
 

--- a/docs/guides/role-management.md
+++ b/docs/guides/role-management.md
@@ -1,5 +1,5 @@
-<!-- SPDX-FileCopyrightText: 2025-2026 SecPal -->
-<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- SPDX-FileCopyrightText: 2025-2026 SecPal Contributors -->
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution -->
 
 # Role Management Guide
 

--- a/docs/guides/sanctum-spa-auth.md
+++ b/docs/guides/sanctum-spa-auth.md
@@ -1,5 +1,5 @@
 <!-- SPDX-FileCopyrightText: 2025-2026 SecPal Contributors -->
-<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution -->
 
 # Sanctum SPA Authentication with httpOnly Cookies
 

--- a/docs/guides/temporal-roles.md
+++ b/docs/guides/temporal-roles.md
@@ -1,5 +1,5 @@
-<!-- SPDX-FileCopyrightText: 2025 SecPal Authors -->
-<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- SPDX-FileCopyrightText: 2025 SecPal Contributors -->
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution -->
 
 # Developer Guide: Temporal Roles
 

--- a/docs/guides/tenant-provisioning.md
+++ b/docs/guides/tenant-provisioning.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2025 SecPal
+SPDX-FileCopyrightText: 2025 SecPal Contributors
 SPDX-License-Identifier: CC0-1.0
 -->
 

--- a/docs/migration-guides/single-to-multi-tenant.md
+++ b/docs/migration-guides/single-to-multi-tenant.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2025 SecPal
+SPDX-FileCopyrightText: 2025 SecPal Contributors
 SPDX-License-Identifier: CC0-1.0
 -->
 

--- a/docs/rbac-architecture.md
+++ b/docs/rbac-architecture.md
@@ -1,5 +1,5 @@
-<!-- SPDX-FileCopyrightText: 2025-2026 SecPal -->
-<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!-- SPDX-FileCopyrightText: 2025-2026 SecPal Contributors -->
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution -->
 
 # RBAC Architecture
 

--- a/lang/de/LC_MESSAGES/messages.mo.license
+++ b/lang/de/LC_MESSAGES/messages.mo.license
@@ -1,2 +1,2 @@
 SPDX-FileCopyrightText: 2026 SecPal Contributors
-SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution

--- a/lang/de/LC_MESSAGES/messages.po
+++ b/lang/de/LC_MESSAGES/messages.po
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2026 SecPal Contributors
-# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 msgid ""
 msgstr ""

--- a/lang/de/bwr_export.php
+++ b/lang/de/bwr_export.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 return [
     'missing_fields' => [

--- a/lang/de/emails.php
+++ b/lang/de/emails.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 return [
     'account_deactivated' => [

--- a/lang/de/onboarding_schemas.php
+++ b/lang/de/onboarding_schemas.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 return [
     'templates' => [

--- a/lang/en/LC_MESSAGES/messages.mo.license
+++ b/lang/en/LC_MESSAGES/messages.mo.license
@@ -1,2 +1,2 @@
 SPDX-FileCopyrightText: 2026 SecPal Contributors
-SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution

--- a/lang/en/LC_MESSAGES/messages.po
+++ b/lang/en/LC_MESSAGES/messages.po
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: 2026 SecPal Contributors
-# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 msgid ""
 msgstr ""

--- a/lang/en/bwr_export.php
+++ b/lang/en/bwr_export.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 return [
     'missing_fields' => [

--- a/lang/en/emails.php
+++ b/lang/en/emails.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 return [
     'account_deactivated' => [

--- a/lang/en/onboarding_schemas.php
+++ b/lang/en/onboarding_schemas.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 return [
     'templates' => [

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-FileCopyrightText: 2025 SecPal Contributors
 # SPDX-License-Identifier: CC0-1.0
 
 includes:

--- a/public/index.php
+++ b/public/index.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Illuminate\Foundation\Application;
 use Illuminate\Http\Request;

--- a/public/secpal-logo-dark.png.license
+++ b/public/secpal-logo-dark.png.license
@@ -1,3 +1,3 @@
 SPDX-FileCopyrightText: 2026 SecPal Contributors
 
-SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution

--- a/public/secpal-logo-light.png.license
+++ b/public/secpal-logo-light.png.license
@@ -1,3 +1,3 @@
 SPDX-FileCopyrightText: 2026 SecPal Contributors
 
-SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution

--- a/resources/views/emails/employees/account-deactivated.blade.php
+++ b/resources/views/emails/employees/account-deactivated.blade.php
@@ -1,5 +1,5 @@
 {{-- SPDX-FileCopyrightText: 2025 SecPal Contributors --}}
-{{-- SPDX-License-Identifier: AGPL-3.0-or-later --}}
+{{-- SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution --}}
 
 <x-mail::message>
 # {{ __('Account Deactivated') }}

--- a/resources/views/emails/employees/compliance-alert.blade.php
+++ b/resources/views/emails/employees/compliance-alert.blade.php
@@ -1,5 +1,5 @@
 {{-- SPDX-FileCopyrightText: 2026 SecPal Contributors --}}
-{{-- SPDX-License-Identifier: AGPL-3.0-or-later --}}
+{{-- SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution --}}
 
 @php
     $headline = match ($severity) {

--- a/resources/views/emails/employees/contract-ending-soon.blade.php
+++ b/resources/views/emails/employees/contract-ending-soon.blade.php
@@ -1,5 +1,5 @@
 {{-- SPDX-FileCopyrightText: 2025 SecPal Contributors --}}
-{{-- SPDX-License-Identifier: AGPL-3.0-or-later --}}
+{{-- SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution --}}
 
 <x-mail::message>
 # {{ __('Your Contract Ends Soon') }}

--- a/resources/views/emails/employees/onboarding-invitation.blade.php
+++ b/resources/views/emails/employees/onboarding-invitation.blade.php
@@ -1,5 +1,5 @@
 {{-- SPDX-FileCopyrightText: 2025-2026 SecPal Contributors --}}
-{{-- SPDX-License-Identifier: AGPL-3.0-or-later --}}
+{{-- SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution --}}
 
 <x-mail::message>
 # {{ __('Welcome to :app_name!', ['app_name' => config('app.name')]) }}

--- a/resources/views/emails/employees/qualification-expiring.blade.php
+++ b/resources/views/emails/employees/qualification-expiring.blade.php
@@ -1,5 +1,5 @@
 {{-- SPDX-FileCopyrightText: 2025 SecPal Contributors --}}
-{{-- SPDX-License-Identifier: AGPL-3.0-or-later --}}
+{{-- SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution --}}
 
 <x-mail::message>
 # {{ __('Qualification Expiring Soon') }}

--- a/resources/views/emails/employees/welcome-active.blade.php
+++ b/resources/views/emails/employees/welcome-active.blade.php
@@ -1,5 +1,5 @@
 {{-- SPDX-FileCopyrightText: 2025 SecPal Contributors --}}
-{{-- SPDX-License-Identifier: AGPL-3.0-or-later --}}
+{{-- SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution --}}
 
 <x-mail::message>
 # {{ __('Welcome to the Team!') }}

--- a/resources/views/emails/hr/bwr-id-document-auto-deleted.blade.php
+++ b/resources/views/emails/hr/bwr-id-document-auto-deleted.blade.php
@@ -1,5 +1,5 @@
 {{-- SPDX-FileCopyrightText: 2026 SecPal Contributors --}}
-{{-- SPDX-License-Identifier: AGPL-3.0-or-later --}}
+{{-- SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution --}}
 
 @php($frontendUrl = rtrim((string) config('app.frontend_url', ''), '/'))
 

--- a/resources/views/emails/hr/onboarding-name-changed.blade.php
+++ b/resources/views/emails/hr/onboarding-name-changed.blade.php
@@ -1,5 +1,5 @@
 {{-- SPDX-FileCopyrightText: 2025 SecPal Contributors --}}
-{{-- SPDX-License-Identifier: AGPL-3.0-or-later --}}
+{{-- SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution --}}
 
 <x-mail::message>
 # {{ __('HR Alert: Name Change During Onboarding') }}

--- a/resources/views/emails/password-reset.blade.php
+++ b/resources/views/emails/password-reset.blade.php
@@ -1,6 +1,6 @@
 {{--
 SPDX-FileCopyrightText: 2025 SecPal Contributors
-SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 --}}
 
 <x-mail::message>

--- a/resources/views/errors/403.blade.php
+++ b/resources/views/errors/403.blade.php
@@ -1,5 +1,5 @@
 {{-- SPDX-FileCopyrightText: 2026 SecPal Contributors --}}
-{{-- SPDX-License-Identifier: AGPL-3.0-or-later --}}
+{{-- SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution --}}
 
 @include('errors.partials.simple-error-page', [
     'status' => '403',

--- a/resources/views/errors/404.blade.php
+++ b/resources/views/errors/404.blade.php
@@ -1,5 +1,5 @@
 {{-- SPDX-FileCopyrightText: 2026 SecPal Contributors --}}
-{{-- SPDX-License-Identifier: AGPL-3.0-or-later --}}
+{{-- SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution --}}
 
 @include('errors.partials.simple-error-page', [
     'status' => '404',

--- a/resources/views/errors/500.blade.php
+++ b/resources/views/errors/500.blade.php
@@ -1,5 +1,5 @@
 {{-- SPDX-FileCopyrightText: 2026 SecPal Contributors --}}
-{{-- SPDX-License-Identifier: AGPL-3.0-or-later --}}
+{{-- SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution --}}
 
 @include('errors.partials.simple-error-page', [
     'status' => '500',

--- a/resources/views/errors/503.blade.php
+++ b/resources/views/errors/503.blade.php
@@ -1,5 +1,5 @@
 {{-- SPDX-FileCopyrightText: 2026 SecPal Contributors --}}
-{{-- SPDX-License-Identifier: AGPL-3.0-or-later --}}
+{{-- SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution --}}
 
 @include('errors.partials.simple-error-page', [
     'status' => '503',

--- a/resources/views/errors/partials/simple-error-page.blade.php
+++ b/resources/views/errors/partials/simple-error-page.blade.php
@@ -1,5 +1,5 @@
 {{-- SPDX-FileCopyrightText: 2026 SecPal Contributors --}}
-{{-- SPDX-License-Identifier: AGPL-3.0-or-later --}}
+{{-- SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution --}}
 
 <!DOCTYPE html>
 <html lang="en">

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Http\Controllers\Api\V1\ActivityLogController;
 use App\Http\Controllers\Api\V1\AddressController;

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;

--- a/scripts/add-pest-property-annotations.php
+++ b/scripts/add-pest-property-annotations.php
@@ -3,7 +3,7 @@
 
 /**
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/scripts/check-domains.sh
+++ b/scripts/check-domains.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# SPDX-FileCopyrightText: 2025-2026 SecPal
+# SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 # SPDX-License-Identifier: MIT
 
 # Domain Policy Enforcement Script

--- a/scripts/check-license-compatibility.sh
+++ b/scripts/check-license-compatibility.sh
@@ -44,6 +44,10 @@ is_strict_path() {
 
   path="${path#./}"
 
+  if is_strict_exception "$path"; then
+    return 1
+  fi
+
   [[ "$path" == app/* ]] \
     || [[ "$path" == bootstrap/* ]] \
     || [[ "$path" == config/* ]] \
@@ -52,6 +56,18 @@ is_strict_path() {
     || [[ "$path" == routes/* ]] \
     || [[ "$path" == tests/* ]] \
     || [[ "$path" == artisan ]]
+}
+
+is_strict_exception() {
+  local path="$1"
+
+  case "$path" in
+    bootstrap/cache/.gitignore|config/permission.php|database/.gitignore|public/.htaccess|public/robots.txt|tests/fixtures/address_data/sample_streets.csv)
+      return 0
+      ;;
+  esac
+
+  return 1
 }
 
 validate_current_file() {

--- a/scripts/check-license-compatibility.sh
+++ b/scripts/check-license-compatibility.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: MIT
+
+set -euo pipefail
+
+SPDX_PATH="${1:-reuse.spdx}"
+
+if [[ ! -f "$SPDX_PATH" ]]; then
+  echo "SPDX document not found: $SPDX_PATH" >&2
+  exit 1
+fi
+
+compatible_licenses=(
+  "AGPL-3.0-or-later"
+  "GPL-3.0-or-later"
+  "LGPL-3.0-or-later"
+  "MIT"
+  "BSD-2-Clause"
+  "BSD-3-Clause"
+  "Apache-2.0"
+  "CC0-1.0"
+  "ISC"
+  "OFL-1.1"
+  "ODbL-1.0"
+  "LicenseRef-SecPal-Attribution"
+)
+
+is_allowed_atom() {
+  local atom="$1"
+  local compatible
+
+  for compatible in "${compatible_licenses[@]}"; do
+    if [[ "$atom" == "$compatible" ]]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+is_strict_path() {
+  local path="$1"
+
+  path="${path#./}"
+
+  [[ "$path" == app/* ]] \
+    || [[ "$path" == bootstrap/* ]] \
+    || [[ "$path" == config/* ]] \
+    || [[ "$path" == database/* ]] \
+    || [[ "$path" == public/* ]] \
+    || [[ "$path" == routes/* ]] \
+    || [[ "$path" == tests/* ]] \
+    || [[ "$path" == artisan ]]
+}
+
+validate_current_file() {
+  local path="$1"
+  local concluded="$2"
+  shift 2
+  local licenses=("$@")
+
+  if [[ -z "$path" ]]; then
+    return 0
+  fi
+
+  local license
+
+  for license in "${licenses[@]}"; do
+    if ! is_allowed_atom "$license"; then
+      echo "ERROR: incompatible license atom in $path: $license" >&2
+      return 1
+    fi
+  done
+
+  if ! is_strict_path "$path"; then
+    return 0
+  fi
+
+  if [[ "$concluded" != "NOASSERTION" && "$concluded" == *" OR "* ]]; then
+    echo "ERROR: incompatible license expression in $path: $concluded" >&2
+    return 1
+  fi
+
+  if printf '%s\n' "${licenses[@]}" | grep -Fxq 'LicenseRef-SecPal-Attribution'; then
+    if [[ "${#licenses[@]}" -ne 2 ]] \
+      || ! printf '%s\n' "${licenses[@]}" | grep -Fxq 'AGPL-3.0-or-later'; then
+      echo "ERROR: strict-path attribution licensing must be exactly AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution in $path" >&2
+      return 1
+    fi
+  fi
+
+  return 0
+}
+
+current_path=''
+current_concluded='NOASSERTION'
+declare -a current_licenses=()
+
+while IFS= read -r line || [[ -n "$line" ]]; do
+  if [[ -z "$line" ]]; then
+    validate_current_file "$current_path" "$current_concluded" "${current_licenses[@]}"
+    current_path=''
+    current_concluded='NOASSERTION'
+    current_licenses=()
+    continue
+  fi
+
+  case "$line" in
+    FileName:*)
+      current_path="${line#FileName: }"
+      ;;
+    LicenseConcluded:*)
+      current_concluded="${line#LicenseConcluded: }"
+      ;;
+    LicenseInfoInFile:*)
+      current_licenses+=("${line#LicenseInfoInFile: }")
+      ;;
+  esac
+done < "$SPDX_PATH"
+
+validate_current_file "$current_path" "$current_concluded" "${current_licenses[@]}"
+
+echo 'All licenses are compatible with AGPL-3.0-or-later'

--- a/scripts/check-license-compatibility.sh
+++ b/scripts/check-license-compatibility.sh
@@ -82,12 +82,18 @@ validate_current_file() {
     return 1
   fi
 
-  if printf '%s\n' "${licenses[@]}" | grep -Fxq 'LicenseRef-SecPal-Attribution'; then
-    if [[ "${#licenses[@]}" -ne 2 ]] \
-      || ! printf '%s\n' "${licenses[@]}" | grep -Fxq 'AGPL-3.0-or-later'; then
-      echo "ERROR: strict-path attribution licensing must be exactly AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution in $path" >&2
-      return 1
-    fi
+  if [[ "${#licenses[@]}" -ne 2 ]] \
+    || ! printf '%s\n' "${licenses[@]}" | grep -Fxq 'AGPL-3.0-or-later' \
+    || ! printf '%s\n' "${licenses[@]}" | grep -Fxq 'LicenseRef-SecPal-Attribution'; then
+    echo "ERROR: strict-path files must use exactly AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution in $path" >&2
+    return 1
+  fi
+
+  if [[ "$concluded" != "NOASSERTION" ]] \
+    && [[ "$concluded" != 'AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution' ]] \
+    && [[ "$concluded" != 'LicenseRef-SecPal-Attribution AND AGPL-3.0-or-later' ]]; then
+    echo "ERROR: incompatible license expression in $path: $concluded" >&2
+    return 1
   fi
 
   return 0

--- a/scripts/check-live-cors-health.sh
+++ b/scripts/check-live-cors-health.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# SPDX-FileCopyrightText: 2026 SecPal
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
 # SPDX-License-Identifier: MIT
 
 set -euo pipefail

--- a/scripts/setup-pre-commit.sh
+++ b/scripts/setup-pre-commit.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-FileCopyrightText: 2025 SecPal Contributors
 # SPDX-License-Identifier: MIT
 
 set -euo pipefail

--- a/tests/Feature/ActivityLog/ActivityLogConcurrencyTest.php
+++ b/tests/Feature/ActivityLog/ActivityLogConcurrencyTest.php
@@ -2,7 +2,7 @@
 
 /**
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/tests/Feature/ActivityLog/ActivityLogIntegrationTest.php
+++ b/tests/Feature/ActivityLog/ActivityLogIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\Activity;
 use App\Models\TenantKey;

--- a/tests/Feature/ActivityLog/ActivityLogSchemaTest.php
+++ b/tests/Feature/ActivityLog/ActivityLogSchemaTest.php
@@ -2,7 +2,7 @@
 
 /**
  * SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/tests/Feature/AddressDataImportCommandTest.php
+++ b/tests/Feature/AddressDataImportCommandTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\AddressDataImport;
 use App\Models\AddressStreet;

--- a/tests/Feature/AddressDataMigrationTest.php
+++ b/tests/Feature/AddressDataMigrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;

--- a/tests/Feature/AddressScheduleRegistrationTest.php
+++ b/tests/Feature/AddressScheduleRegistrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Illuminate\Console\Scheduling\Schedule;
 

--- a/tests/Feature/Api/OnboardingCompletionTest.php
+++ b/tests/Feature/Api/OnboardingCompletionTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\Employee;
 use App\Models\OnboardingFormSubmission;

--- a/tests/Feature/Api/V1/AddressApiTest.php
+++ b/tests/Feature/Api/V1/AddressApiTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\AddressDataImport;
 use App\Models\AddressStreet;

--- a/tests/Feature/Api/V1/AndroidEnrollmentSessionApiTest.php
+++ b/tests/Feature/Api/V1/AndroidEnrollmentSessionApiTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/tests/Feature/Api/V1/BootstrapApiTest.php
+++ b/tests/Feature/Api/V1/BootstrapApiTest.php
@@ -52,8 +52,9 @@ test('public bootstrap returns deployment-derived runtime metadata for a support
                 'legal' => [
                     'license' => [
                         'spdx_id' => 'AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution',
-                        'name' => 'GNU Affero General Public License v3.0 or later',
-                        'url' => 'https://www.gnu.org/licenses/agpl-3.0.html',
+                        'name' => 'GNU Affero General Public License v3.0 or later with SecPal attribution additional terms',
+                        'url' => 'https://github.com/SecPal/api/blob/main/LICENSES/LicenseRef-SecPal-Attribution.txt',
+                        'base_license_url' => 'https://www.gnu.org/licenses/agpl-3.0.html',
                     ],
                     'source_url' => 'https://api.secpal.dev/v1/source',
                 ],
@@ -105,6 +106,8 @@ test('public bootstrap returns web push runtime metadata for browser clients wit
         ->assertJsonPath('data.compatibility.schema_version', 3)
         ->assertJsonPath('data.legal.source_url', 'https://api.secpal.dev/v1/source')
         ->assertJsonPath('data.legal.license.spdx_id', 'AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution')
+        ->assertJsonPath('data.legal.license.url', 'https://github.com/SecPal/api/blob/main/LICENSES/LicenseRef-SecPal-Attribution.txt')
+        ->assertJsonPath('data.legal.license.base_license_url', 'https://www.gnu.org/licenses/agpl-3.0.html')
         ->assertJsonPath('data.features.notification_channels.android_fcm', true)
         ->assertJsonPath('data.features.notification_channels.web_push', true)
         ->assertJsonPath('data.notification_channels.web_push.channel', 'web_push')

--- a/tests/Feature/Api/V1/BootstrapApiTest.php
+++ b/tests/Feature/Api/V1/BootstrapApiTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 
@@ -51,7 +51,7 @@ test('public bootstrap returns deployment-derived runtime metadata for a support
                 ],
                 'legal' => [
                     'license' => [
-                        'spdx_id' => 'AGPL-3.0-or-later',
+                        'spdx_id' => 'AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution',
                         'name' => 'GNU Affero General Public License v3.0 or later',
                         'url' => 'https://www.gnu.org/licenses/agpl-3.0.html',
                     ],
@@ -104,7 +104,7 @@ test('public bootstrap returns web push runtime metadata for browser clients wit
         ->assertJsonPath('data.compatibility.bootstrap_version', 'v1')
         ->assertJsonPath('data.compatibility.schema_version', 3)
         ->assertJsonPath('data.legal.source_url', 'https://api.secpal.dev/v1/source')
-        ->assertJsonPath('data.legal.license.spdx_id', 'AGPL-3.0-or-later')
+        ->assertJsonPath('data.legal.license.spdx_id', 'AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution')
         ->assertJsonPath('data.features.notification_channels.android_fcm', true)
         ->assertJsonPath('data.features.notification_channels.web_push', true)
         ->assertJsonPath('data.notification_channels.web_push.channel', 'web_push')

--- a/tests/Feature/Api/V1/PushDeviceRegistrationApiTest.php
+++ b/tests/Feature/Api/V1/PushDeviceRegistrationApiTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/tests/Feature/Api/V1/ReleaseApiTest.php
+++ b/tests/Feature/Api/V1/ReleaseApiTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/tests/Feature/Api/V1/SourceApiTest.php
+++ b/tests/Feature/Api/V1/SourceApiTest.php
@@ -24,8 +24,9 @@ beforeEach(function (): void {
         'bootstrap.minimum_supported_app_version' => '1.4.0',
         'bootstrap.minimum_supported_app_build' => 10400,
         'bootstrap.legal.license_spdx_id' => 'AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution',
-        'bootstrap.legal.license_name' => 'GNU Affero General Public License v3.0 or later',
-        'bootstrap.legal.license_url' => 'https://www.gnu.org/licenses/agpl-3.0.html',
+        'bootstrap.legal.license_name' => 'GNU Affero General Public License v3.0 or later with SecPal attribution additional terms',
+        'bootstrap.legal.license_url' => 'https://github.com/SecPal/api/blob/main/LICENSES/LicenseRef-SecPal-Attribution.txt',
+        'bootstrap.legal.license_base_url' => 'https://www.gnu.org/licenses/agpl-3.0.html',
         'bootstrap.legal.copyright_notice' => 'Copyright SecPal and contributors.',
         'bootstrap.legal.warranty_notice' => 'This program is distributed without any warranty; without even the implied warranty of merchantability or fitness for a particular purpose.',
         'bootstrap.legal.source_repositories' => [
@@ -58,8 +59,9 @@ test('public source endpoint returns license and corresponding source metadata',
                 'source_offer' => 'Corresponding source for the SecPal components made available through this service.',
                 'license' => [
                     'spdx_id' => 'AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution',
-                    'name' => 'GNU Affero General Public License v3.0 or later',
-                    'url' => 'https://www.gnu.org/licenses/agpl-3.0.html',
+                    'name' => 'GNU Affero General Public License v3.0 or later with SecPal attribution additional terms',
+                    'url' => 'https://github.com/SecPal/api/blob/main/LICENSES/LicenseRef-SecPal-Attribution.txt',
+                    'base_license_url' => 'https://www.gnu.org/licenses/agpl-3.0.html',
                 ],
                 'repositories' => [
                     [
@@ -88,7 +90,8 @@ test('public source endpoint is reachable without authentication and contains th
     getJson('/v1/source')
         ->assertOk()
         ->assertJsonPath('data.license.spdx_id', 'AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution')
-        ->assertJsonPath('data.license.url', 'https://www.gnu.org/licenses/agpl-3.0.html')
+        ->assertJsonPath('data.license.url', 'https://github.com/SecPal/api/blob/main/LICENSES/LicenseRef-SecPal-Attribution.txt')
+        ->assertJsonPath('data.license.base_license_url', 'https://www.gnu.org/licenses/agpl-3.0.html')
         ->assertJsonPath('data.repositories.0.url', 'https://github.com/SecPal/frontend')
         ->assertJsonPath('data.repositories.1.url', 'https://github.com/SecPal/api')
         ->assertJsonPath('data.repositories.2.url', 'https://github.com/SecPal/contracts')

--- a/tests/Feature/Api/V1/SourceApiTest.php
+++ b/tests/Feature/Api/V1/SourceApiTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 
@@ -23,7 +23,7 @@ beforeEach(function (): void {
         'bootstrap.public_enabled' => true,
         'bootstrap.minimum_supported_app_version' => '1.4.0',
         'bootstrap.minimum_supported_app_build' => 10400,
-        'bootstrap.legal.license_spdx_id' => 'AGPL-3.0-or-later',
+        'bootstrap.legal.license_spdx_id' => 'AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution',
         'bootstrap.legal.license_name' => 'GNU Affero General Public License v3.0 or later',
         'bootstrap.legal.license_url' => 'https://www.gnu.org/licenses/agpl-3.0.html',
         'bootstrap.legal.copyright_notice' => 'Copyright SecPal and contributors.',
@@ -57,7 +57,7 @@ test('public source endpoint returns license and corresponding source metadata',
                 'notice' => 'Source offer for users interacting with SecPal over a network.',
                 'source_offer' => 'Corresponding source for the SecPal components made available through this service.',
                 'license' => [
-                    'spdx_id' => 'AGPL-3.0-or-later',
+                    'spdx_id' => 'AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution',
                     'name' => 'GNU Affero General Public License v3.0 or later',
                     'url' => 'https://www.gnu.org/licenses/agpl-3.0.html',
                 ],
@@ -87,7 +87,7 @@ test('public source endpoint returns license and corresponding source metadata',
 test('public source endpoint is reachable without authentication and contains the expected source offer references', function (): void {
     getJson('/v1/source')
         ->assertOk()
-        ->assertJsonPath('data.license.spdx_id', 'AGPL-3.0-or-later')
+        ->assertJsonPath('data.license.spdx_id', 'AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution')
         ->assertJsonPath('data.license.url', 'https://www.gnu.org/licenses/agpl-3.0.html')
         ->assertJsonPath('data.repositories.0.url', 'https://github.com/SecPal/frontend')
         ->assertJsonPath('data.repositories.1.url', 'https://github.com/SecPal/api')

--- a/tests/Feature/ApiErrorHandlingTest.php
+++ b/tests/Feature/ApiErrorHandlingTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\Request;

--- a/tests/Feature/Auth/CsrfProtectionTest.php
+++ b/tests/Feature/Auth/CsrfProtectionTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;

--- a/tests/Feature/Auth/MfaAdminResetApiTest.php
+++ b/tests/Feature/Auth/MfaAdminResetApiTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\Activity;
 use App\Models\Permission;

--- a/tests/Feature/Auth/MfaApiEndpointsTest.php
+++ b/tests/Feature/Auth/MfaApiEndpointsTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\Activity;
 use App\Models\User;

--- a/tests/Feature/Auth/MfaFoundationTest.php
+++ b/tests/Feature/Auth/MfaFoundationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;

--- a/tests/Feature/Auth/PasskeyAuthTest.php
+++ b/tests/Feature/Auth/PasskeyAuthTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\PasskeyCredential;
 use App\Models\User;

--- a/tests/Feature/Auth/PasskeyChallengeEnumerationTest.php
+++ b/tests/Feature/Auth/PasskeyChallengeEnumerationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\PasskeyCredential;
 use App\Models\User;

--- a/tests/Feature/Auth/PasswordResetRequestTest.php
+++ b/tests/Feature/Auth/PasswordResetRequestTest.php
@@ -1,7 +1,7 @@
 <?php
 
-// SPDX-FileCopyrightText: 2025-2026 SecPal
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/tests/Feature/Auth/PasswordResetTest.php
+++ b/tests/Feature/Auth/PasswordResetTest.php
@@ -1,7 +1,7 @@
 <?php
 
-// SPDX-FileCopyrightText: 2025-2026 SecPal
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/tests/Feature/Auth/SanctumCookieAuthTest.php
+++ b/tests/Feature/Auth/SanctumCookieAuthTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;

--- a/tests/Feature/Auth/SanctumIntegrationTest.php
+++ b/tests/Feature/Auth/SanctumIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;

--- a/tests/Feature/Auth/SanctumSpaConfigTest.php
+++ b/tests/Feature/Auth/SanctumSpaConfigTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 

--- a/tests/Feature/AuthTest.php
+++ b/tests/Feature/AuthTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Http\Controllers\AuthController;
 use App\Models\Customer;

--- a/tests/Feature/BewachvEmployeeFieldsValidationTest.php
+++ b/tests/Feature/BewachvEmployeeFieldsValidationTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Http\Requests\StoreEmployeeRequest;
 use App\Http\Requests\UpdateEmployeeRequest;

--- a/tests/Feature/Commands/ApplyRetentionPoliciesArchiveTest.php
+++ b/tests/Feature/Commands/ApplyRetentionPoliciesArchiveTest.php
@@ -2,7 +2,7 @@
 
 /**
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/tests/Feature/Commands/ApplyRetentionPoliciesTenantIsolationTest.php
+++ b/tests/Feature/Commands/ApplyRetentionPoliciesTenantIsolationTest.php
@@ -2,7 +2,7 @@
 
 /**
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/tests/Feature/Commands/DeleteExpiredEmployeesCommandTest.php
+++ b/tests/Feature/Commands/DeleteExpiredEmployeesCommandTest.php
@@ -2,7 +2,7 @@
 
 /**
  * SPDX-FileCopyrightText: 2026 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/tests/Feature/Console/Commands/CheckOpenTimestampStatusTest.php
+++ b/tests/Feature/Console/Commands/CheckOpenTimestampStatusTest.php
@@ -2,7 +2,7 @@
 
 /**
  * SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/tests/Feature/Console/Commands/MonitorOpenTimestampTest.php
+++ b/tests/Feature/Console/Commands/MonitorOpenTimestampTest.php
@@ -2,7 +2,7 @@
 
 /**
  * SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/tests/Feature/Console/Commands/SendContractEndingNotificationsTest.php
+++ b/tests/Feature/Console/Commands/SendContractEndingNotificationsTest.php
@@ -2,7 +2,7 @@
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
 //
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/tests/Feature/Console/Commands/SendEmployeeComplianceAlertNotificationsTest.php
+++ b/tests/Feature/Console/Commands/SendEmployeeComplianceAlertNotificationsTest.php
@@ -2,7 +2,7 @@
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
 //
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/tests/Feature/Console/Commands/UpdateEmployeeStatusTest.php
+++ b/tests/Feature/Console/Commands/UpdateEmployeeStatusTest.php
@@ -2,7 +2,7 @@
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 //
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/tests/Feature/Console/Commands/UpdateOpenTimestampTest.php
+++ b/tests/Feature/Console/Commands/UpdateOpenTimestampTest.php
@@ -2,7 +2,7 @@
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 //
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/tests/Feature/Console/Commands/UpdateQualificationStatusTest.php
+++ b/tests/Feature/Console/Commands/UpdateQualificationStatusTest.php
@@ -2,7 +2,7 @@
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
 //
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/tests/Feature/Console/ExpireRolesCommandTest.php
+++ b/tests/Feature/Console/ExpireRolesCommandTest.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 use App\Models\RoleAssignmentLog;

--- a/tests/Feature/Console/ValidateSetupCommandTest.php
+++ b/tests/Feature/Console/ValidateSetupCommandTest.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 use App\Models\TenantKey;

--- a/tests/Feature/Controllers/Api/V1/ActivityLogControllerTest.php
+++ b/tests/Feature/Controllers/Api/V1/ActivityLogControllerTest.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2026 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 use App\Http\Controllers\Api\V1\ActivityLogController;

--- a/tests/Feature/Controllers/Api/V1/CostCenterControllerTest.php
+++ b/tests/Feature/Controllers/Api/V1/CostCenterControllerTest.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 use App\Models\CostCenter;

--- a/tests/Feature/Controllers/Api/V1/CustomerAssignmentControllerTest.php
+++ b/tests/Feature/Controllers/Api/V1/CustomerAssignmentControllerTest.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 use App\Models\Customer;

--- a/tests/Feature/Controllers/Api/V1/CustomerControllerTest.php
+++ b/tests/Feature/Controllers/Api/V1/CustomerControllerTest.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 use App\Models\Customer;

--- a/tests/Feature/Controllers/Api/V1/OrganizationalUnitControllerTest.php
+++ b/tests/Feature/Controllers/Api/V1/OrganizationalUnitControllerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\OrganizationalUnit;
 use App\Models\OrganizationalUnitClosure;

--- a/tests/Feature/Controllers/Api/V1/SiteAssignmentControllerTest.php
+++ b/tests/Feature/Controllers/Api/V1/SiteAssignmentControllerTest.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 use App\Models\Customer;

--- a/tests/Feature/Controllers/Api/V1/SiteControllerTest.php
+++ b/tests/Feature/Controllers/Api/V1/SiteControllerTest.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 use App\Models\Customer;

--- a/tests/Feature/Controllers/Api/V1/UserAssignmentControllerTest.php
+++ b/tests/Feature/Controllers/Api/V1/UserAssignmentControllerTest.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 use App\Models\Customer;

--- a/tests/Feature/Controllers/Api/V1/UserLanguagePreferenceTest.php
+++ b/tests/Feature/Controllers/Api/V1/UserLanguagePreferenceTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;

--- a/tests/Feature/Controllers/CustomerSiteNumberConcurrencyTest.php
+++ b/tests/Feature/Controllers/CustomerSiteNumberConcurrencyTest.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 use App\Models\Customer;

--- a/tests/Feature/Controllers/EmployeeControllerTest.php
+++ b/tests/Feature/Controllers/EmployeeControllerTest.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 use App\Mail\BwrIdDocumentAutoDeletedMail;

--- a/tests/Feature/Controllers/EmployeeDocumentControllerTest.php
+++ b/tests/Feature/Controllers/EmployeeDocumentControllerTest.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 use App\Models\Employee;

--- a/tests/Feature/Controllers/EmployeeNumberConcurrencyTest.php
+++ b/tests/Feature/Controllers/EmployeeNumberConcurrencyTest.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 use App\Models\Employee;

--- a/tests/Feature/Controllers/EmployeeQualificationControllerTest.php
+++ b/tests/Feature/Controllers/EmployeeQualificationControllerTest.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 use App\Models\Employee;

--- a/tests/Feature/Controllers/OnboardingControllerTest.php
+++ b/tests/Feature/Controllers/OnboardingControllerTest.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 use App\Models\Employee;

--- a/tests/Feature/Controllers/OrganizationalScopeControllerTest.php
+++ b/tests/Feature/Controllers/OrganizationalScopeControllerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\Employee;
 use App\Models\OrganizationalUnit;

--- a/tests/Feature/Controllers/QualificationControllerTest.php
+++ b/tests/Feature/Controllers/QualificationControllerTest.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 use App\Models\Permission;

--- a/tests/Feature/CustomNotFoundPageTest.php
+++ b/tests/Feature/CustomNotFoundPageTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Illuminate\Support\Facades\Route;
 

--- a/tests/Feature/EnvConfigSmokeTest.php
+++ b/tests/Feature/EnvConfigSmokeTest.php
@@ -3,8 +3,8 @@
 declare(strict_types=1);
 
 /**
- * SPDX-FileCopyrightText: 2025 SecPal
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2025 SecPal Contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 use Illuminate\Database\QueryException;

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 test('health endpoint returns ok', function (): void {
     $this->get('/health')

--- a/tests/Feature/GenerateKekCommandTest.php
+++ b/tests/Feature/GenerateKekCommandTest.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2026 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 use App\Models\TenantKey;

--- a/tests/Feature/GenerateTenantCommandTest.php
+++ b/tests/Feature/GenerateTenantCommandTest.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2026 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 use App\Models\TenantKey;

--- a/tests/Feature/GermanCatalogCompletenessTest.php
+++ b/tests/Feature/GermanCatalogCompletenessTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/tests/Feature/HealthCheckTest.php
+++ b/tests/Feature/HealthCheckTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\TenantKey;
 use App\Services\RuntimeHeartbeatService;

--- a/tests/Feature/Integration/RbacIntegrationTest.php
+++ b/tests/Feature/Integration/RbacIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\TemporalRoleUser;
 use App\Models\TenantKey;

--- a/tests/Feature/Jobs/BuildMerkleTreeBatchTest.php
+++ b/tests/Feature/Jobs/BuildMerkleTreeBatchTest.php
@@ -2,7 +2,7 @@
 
 /**
  * SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/tests/Feature/Jobs/DeliverAndroidPushMessageTest.php
+++ b/tests/Feature/Jobs/DeliverAndroidPushMessageTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/tests/Feature/Jobs/DeliverWebPushMessageTest.php
+++ b/tests/Feature/Jobs/DeliverWebPushMessageTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/tests/Feature/Jobs/ProcessActivityHashChainTest.php
+++ b/tests/Feature/Jobs/ProcessActivityHashChainTest.php
@@ -2,7 +2,7 @@
 
 /**
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/tests/Feature/Jobs/SubmitMerkleRootToOpenTimestampTest.php
+++ b/tests/Feature/Jobs/SubmitMerkleRootToOpenTimestampTest.php
@@ -2,7 +2,7 @@
 
 /**
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/tests/Feature/Jobs/UpgradeOpenTimestampProofsTest.php
+++ b/tests/Feature/Jobs/UpgradeOpenTimestampProofsTest.php
@@ -2,7 +2,7 @@
 
 /**
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/tests/Feature/KeyRotationTest.php
+++ b/tests/Feature/KeyRotationTest.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 use App\Models\Person;

--- a/tests/Feature/LocaleMiddlewareTest.php
+++ b/tests/Feature/LocaleMiddlewareTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Http\Middleware\SetLocaleFromHeader;
 use Illuminate\Foundation\Testing\RefreshDatabase;

--- a/tests/Feature/Mail/EmployeeLifecycleMailTest.php
+++ b/tests/Feature/Mail/EmployeeLifecycleMailTest.php
@@ -2,7 +2,7 @@
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 //
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/tests/Feature/Middleware/CheckOrganizationalScopeTest.php
+++ b/tests/Feature/Middleware/CheckOrganizationalScopeTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Http\Middleware\CheckOrganizationalScope;
 use App\Models\OrganizationalUnit;

--- a/tests/Feature/Middleware/EnsureNotPreContractTest.php
+++ b/tests/Feature/Middleware/EnsureNotPreContractTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Http\Middleware\EnsureNotPreContract;
 use App\Models\Employee;

--- a/tests/Feature/Middleware/EnsurePreContractTest.php
+++ b/tests/Feature/Middleware/EnsurePreContractTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Http\Middleware\EnsurePreContract;
 use App\Models\Employee;

--- a/tests/Feature/Middleware/InjectTenantIdMiddlewareTest.php
+++ b/tests/Feature/Middleware/InjectTenantIdMiddlewareTest.php
@@ -2,7 +2,7 @@
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
 //
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Http\Middleware\InjectTenantId;
 use App\Models\TenantKey;

--- a/tests/Feature/Middleware/MiddlewareAliasRegistrationTest.php
+++ b/tests/Feature/Middleware/MiddlewareAliasRegistrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 test('router only registers live custom middleware aliases', function (): void {
     $aliases = app('router')->getMiddleware();

--- a/tests/Feature/Middleware/RestoreSessionFromRememberTokenTest.php
+++ b/tests/Feature/Middleware/RestoreSessionFromRememberTokenTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Http\Middleware\RestoreSessionFromRememberToken;
 use App\Models\User;

--- a/tests/Feature/Middleware/SecurityHeadersTest.php
+++ b/tests/Feature/Middleware/SecurityHeadersTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 

--- a/tests/Feature/Migrations/AddResidentialAddressHistoryOnboardingStepMigrationTest.php
+++ b/tests/Feature/Migrations/AddResidentialAddressHistoryOnboardingStepMigrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\Employee;
 use App\Models\OnboardingFormSubmission;

--- a/tests/Feature/Migrations/CreateCostCentersTableTest.php
+++ b/tests/Feature/Migrations/CreateCostCentersTableTest.php
@@ -2,7 +2,7 @@
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
 //
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\TenantKey;
 use Illuminate\Foundation\Testing\RefreshDatabase;

--- a/tests/Feature/Migrations/CreateCustomerAssignmentsTableTest.php
+++ b/tests/Feature/Migrations/CreateCustomerAssignmentsTableTest.php
@@ -2,7 +2,7 @@
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 //
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\TenantKey;
 use Illuminate\Foundation\Testing\RefreshDatabase;

--- a/tests/Feature/Migrations/CreateCustomersTableTest.php
+++ b/tests/Feature/Migrations/CreateCustomersTableTest.php
@@ -2,7 +2,7 @@
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
 //
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\TenantKey;
 use Illuminate\Foundation\Testing\RefreshDatabase;

--- a/tests/Feature/Migrations/CreateOrganizationalUnitClosuresTableTest.php
+++ b/tests/Feature/Migrations/CreateOrganizationalUnitClosuresTableTest.php
@@ -2,7 +2,7 @@
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
 //
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\TenantKey;
 use Illuminate\Foundation\Testing\RefreshDatabase;

--- a/tests/Feature/Migrations/CreateOrganizationalUnitsTableTest.php
+++ b/tests/Feature/Migrations/CreateOrganizationalUnitsTableTest.php
@@ -2,7 +2,7 @@
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
 //
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\TenantKey;
 use Illuminate\Foundation\Testing\RefreshDatabase;

--- a/tests/Feature/Migrations/CreateSiteAssignmentsTableTest.php
+++ b/tests/Feature/Migrations/CreateSiteAssignmentsTableTest.php
@@ -2,7 +2,7 @@
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 //
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\TenantKey;
 use Illuminate\Foundation\Testing\RefreshDatabase;

--- a/tests/Feature/Migrations/CreateSitesTableTest.php
+++ b/tests/Feature/Migrations/CreateSitesTableTest.php
@@ -2,7 +2,7 @@
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
 //
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\TenantKey;
 use Illuminate\Foundation\Testing\RefreshDatabase;

--- a/tests/Feature/Migrations/CreateUserInternalOrganizationalScopesTableTest.php
+++ b/tests/Feature/Migrations/CreateUserInternalOrganizationalScopesTableTest.php
@@ -2,7 +2,7 @@
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
 //
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\TenantKey;
 use App\Models\User;

--- a/tests/Feature/Migrations/EmployeeAddressesTableMigrationTest.php
+++ b/tests/Feature/Migrations/EmployeeAddressesTableMigrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\Employee;
 use App\Models\TenantKey;

--- a/tests/Feature/Migrations/EmployeeNumberTenantUniquenessTest.php
+++ b/tests/Feature/Migrations/EmployeeNumberTenantUniquenessTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\Employee;
 use App\Models\OrganizationalUnit;

--- a/tests/Feature/Migrations/SplitNationalityResidenceOnboardingStepMigrationTest.php
+++ b/tests/Feature/Migrations/SplitNationalityResidenceOnboardingStepMigrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\Employee;
 use App\Models\OnboardingFormSubmission;

--- a/tests/Feature/Migrations/UpdateResidentialAddressHistoryResidedFromLabelMigrationTest.php
+++ b/tests/Feature/Migrations/UpdateResidentialAddressHistoryResidedFromLabelMigrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\OnboardingFormTemplate;
 use App\Models\TenantKey;

--- a/tests/Feature/Models/CostCenterTest.php
+++ b/tests/Feature/Models/CostCenterTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/tests/Feature/Models/CustomerAssignmentTest.php
+++ b/tests/Feature/Models/CustomerAssignmentTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/tests/Feature/Models/OnboardingFormSubmissionEncryptionTest.php
+++ b/tests/Feature/Models/OnboardingFormSubmissionEncryptionTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\Employee;
 use App\Models\OnboardingFormSubmission;

--- a/tests/Feature/Models/OrganizationalUnitClosureTest.php
+++ b/tests/Feature/Models/OrganizationalUnitClosureTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\OrganizationalUnit;
 use App\Models\OrganizationalUnitClosure;

--- a/tests/Feature/Models/OrganizationalUnitTest.php
+++ b/tests/Feature/Models/OrganizationalUnitTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\OrganizationalUnit;
 use App\Models\OrganizationalUnitClosure;

--- a/tests/Feature/Models/SiteAssignmentTest.php
+++ b/tests/Feature/Models/SiteAssignmentTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/tests/Feature/Models/TemporalRoleUserTest.php
+++ b/tests/Feature/Models/TemporalRoleUserTest.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 use App\Models\TenantKey;

--- a/tests/Feature/Models/TenantScopedRouteBindingTest.php
+++ b/tests/Feature/Models/TenantScopedRouteBindingTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\Activity;
 use App\Models\Customer;

--- a/tests/Feature/Models/UserInternalOrganizationalScopeTest.php
+++ b/tests/Feature/Models/UserInternalOrganizationalScopeTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\OrganizationalUnit;
 use App\Models\TenantKey;

--- a/tests/Feature/Models/UserTenantRelationshipTest.php
+++ b/tests/Feature/Models/UserTenantRelationshipTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\TenantKey;
 use App\Models\User;

--- a/tests/Feature/MultiTenant/CrossTenantSecurityTest.php
+++ b/tests/Feature/MultiTenant/CrossTenantSecurityTest.php
@@ -2,7 +2,7 @@
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
 //
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\Customer;
 use App\Models\Employee;

--- a/tests/Feature/Observers/EmployeeObserverTest.php
+++ b/tests/Feature/Observers/EmployeeObserverTest.php
@@ -2,7 +2,7 @@
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 //
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/tests/Feature/OnboardingCompletionTest.php
+++ b/tests/Feature/OnboardingCompletionTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/tests/Feature/OnboardingTokenValidationTest.php
+++ b/tests/Feature/OnboardingTokenValidationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/tests/Feature/OpenTimestampServiceIntegrationTest.php
+++ b/tests/Feature/OpenTimestampServiceIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/tests/Feature/OpenTimestampServiceTest.php
+++ b/tests/Feature/OpenTimestampServiceTest.php
@@ -2,7 +2,7 @@
 
 /**
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/tests/Feature/PasswordResetEmailLocalizationTest.php
+++ b/tests/Feature/PasswordResetEmailLocalizationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Illuminate\Support\Facades\App;
 

--- a/tests/Feature/PersonApiTest.php
+++ b/tests/Feature/PersonApiTest.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 use App\Models\Permission;

--- a/tests/Feature/PersonSchemaTest.php
+++ b/tests/Feature/PersonSchemaTest.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 use Illuminate\Foundation\Testing\RefreshDatabase;

--- a/tests/Feature/PersonTest.php
+++ b/tests/Feature/PersonTest.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 use App\Models\Person;

--- a/tests/Feature/Policies/ActivityPolicyTest.php
+++ b/tests/Feature/Policies/ActivityPolicyTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\Activity;
 use App\Models\Employee;

--- a/tests/Feature/Policies/CostCenterPolicyTest.php
+++ b/tests/Feature/Policies/CostCenterPolicyTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\CostCenter;
 use App\Models\Customer;

--- a/tests/Feature/Policies/CustomerAssignmentPolicyTest.php
+++ b/tests/Feature/Policies/CustomerAssignmentPolicyTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\Customer;
 use App\Models\CustomerAssignment;

--- a/tests/Feature/Policies/CustomerPolicyTest.php
+++ b/tests/Feature/Policies/CustomerPolicyTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\Customer;
 use App\Models\CustomerAssignment;

--- a/tests/Feature/Policies/EmployeeDocumentPolicyTest.php
+++ b/tests/Feature/Policies/EmployeeDocumentPolicyTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\Employee;
 use App\Models\EmployeeDocument;

--- a/tests/Feature/Policies/EmployeePolicyManagementLevelTest.php
+++ b/tests/Feature/Policies/EmployeePolicyManagementLevelTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\Employee;
 use App\Models\OrganizationalUnit;

--- a/tests/Feature/Policies/EmployeePolicyTest.php
+++ b/tests/Feature/Policies/EmployeePolicyTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\Employee;
 use App\Models\OrganizationalUnit;

--- a/tests/Feature/Policies/EmployeeQualificationPolicyTest.php
+++ b/tests/Feature/Policies/EmployeeQualificationPolicyTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\Employee;
 use App\Models\EmployeeQualification;

--- a/tests/Feature/Policies/OnboardingFormSubmissionPolicyTest.php
+++ b/tests/Feature/Policies/OnboardingFormSubmissionPolicyTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\Employee;
 use App\Models\OnboardingFormSubmission;

--- a/tests/Feature/Policies/OnboardingFormTemplatePolicyTest.php
+++ b/tests/Feature/Policies/OnboardingFormTemplatePolicyTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\Employee;
 use App\Models\OnboardingFormTemplate;

--- a/tests/Feature/Policies/OrganizationalUnitPolicyTest.php
+++ b/tests/Feature/Policies/OrganizationalUnitPolicyTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\OrganizationalUnit;
 use App\Models\TenantKey;

--- a/tests/Feature/Policies/QualificationPolicyTest.php
+++ b/tests/Feature/Policies/QualificationPolicyTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\Qualification;
 use App\Models\TenantKey;

--- a/tests/Feature/Policies/SiteAssignmentPolicyTest.php
+++ b/tests/Feature/Policies/SiteAssignmentPolicyTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\Customer;
 use App\Models\OrganizationalUnit;

--- a/tests/Feature/Policies/SitePolicyTest.php
+++ b/tests/Feature/Policies/SitePolicyTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\CostCenter;
 use App\Models\Customer;

--- a/tests/Feature/PolyglotConfigTest.php
+++ b/tests/Feature/PolyglotConfigTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/tests/Feature/RoleApiTest.php
+++ b/tests/Feature/RoleApiTest.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2026 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 use App\Models\Permission;

--- a/tests/Feature/RoleAssignmentLogTest.php
+++ b/tests/Feature/RoleAssignmentLogTest.php
@@ -1,7 +1,7 @@
 <?php
 
-// SPDX-FileCopyrightText: 2025-2026 SecPal
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\RoleAssignmentLog;
 use App\Models\User;

--- a/tests/Feature/RoleManagementApiTest.php
+++ b/tests/Feature/RoleManagementApiTest.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 use App\Http\Requests\Api\V1\CreateRoleRequest;

--- a/tests/Feature/Security/AuthorizationBeforeValidationOrderTest.php
+++ b/tests/Feature/Security/AuthorizationBeforeValidationOrderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/tests/Feature/SecurityHardeningTest.php
+++ b/tests/Feature/SecurityHardeningTest.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 use App\Models\Person;

--- a/tests/Feature/Seeders/AddressDataSeederTest.php
+++ b/tests/Feature/Seeders/AddressDataSeederTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\AddressDataImport;
 use App\Models\AddressStreet;

--- a/tests/Feature/Seeders/OnboardingDemoUserSeederTest.php
+++ b/tests/Feature/Seeders/OnboardingDemoUserSeederTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\Employee;
 use App\Models\TenantKey;

--- a/tests/Feature/Seeders/OnboardingFormTemplatesSeederTest.php
+++ b/tests/Feature/Seeders/OnboardingFormTemplatesSeederTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\OnboardingFormTemplate;
 use Database\Seeders\OnboardingFormTemplatesSeeder;

--- a/tests/Feature/Services/EmployeeDocumentStorageServiceTest.php
+++ b/tests/Feature/Services/EmployeeDocumentStorageServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Exceptions\EmployeeDocumentFileNotFoundException;
 use App\Models\Employee;

--- a/tests/Feature/Services/EmployeeLifecycleServiceTest.php
+++ b/tests/Feature/Services/EmployeeLifecycleServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/tests/Feature/Services/OrganizationalUnitAccessServiceTest.php
+++ b/tests/Feature/Services/OrganizationalUnitAccessServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/tests/Feature/SetTenantMiddlewareTest.php
+++ b/tests/Feature/SetTenantMiddlewareTest.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 use App\Models\TenantKey;

--- a/tests/Feature/TenantKeyTest.php
+++ b/tests/Feature/TenantKeyTest.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 use App\Exceptions\TenantKeyDecryptionException;

--- a/tests/Feature/TenantKeysSchemaTest.php
+++ b/tests/Feature/TenantKeysSchemaTest.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 use Illuminate\Foundation\Testing\RefreshDatabase;

--- a/tests/Feature/TenantSetupCommandTest.php
+++ b/tests/Feature/TenantSetupCommandTest.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 use App\Models\TenantKey;

--- a/tests/Feature/UserPermissionAssignmentApiTest.php
+++ b/tests/Feature/UserPermissionAssignmentApiTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\Permission;
 use App\Models\TenantKey;

--- a/tests/Performance/ActivityHashChainConcurrencyTest.php
+++ b/tests/Performance/ActivityHashChainConcurrencyTest.php
@@ -2,7 +2,7 @@
 
 /**
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/tests/Performance/MerkleProofPerformanceTest.php
+++ b/tests/Performance/MerkleProofPerformanceTest.php
@@ -2,7 +2,7 @@
 
 /**
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use Tests\Support\TestKekCounter;
 

--- a/tests/Support/ResetsRefreshDatabaseStateForAddressData.php
+++ b/tests/Support/ResetsRefreshDatabaseStateForAddressData.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/tests/Support/TenantKeyReadabilityOverride.php
+++ b/tests/Support/TenantKeyReadabilityOverride.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace Tests\Support;
 

--- a/tests/Support/TestCaseBootstrapEnvironmentFileNameOverrideProbe.php
+++ b/tests/Support/TestCaseBootstrapEnvironmentFileNameOverrideProbe.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/tests/Support/TestCaseBootstrapEnvironmentProbe.php
+++ b/tests/Support/TestCaseBootstrapEnvironmentProbe.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/tests/Support/TestKekCounter.php
+++ b/tests/Support/TestKekCounter.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace Tests\Support;
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace Tests;
 

--- a/tests/TestConstants.php
+++ b/tests/TestConstants.php
@@ -3,7 +3,7 @@
 /*
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
  *
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 // SHA-256 produces 32 bytes output

--- a/tests/Unit/ActivityLog/ActivityLogRetentionTest.php.TODO_ISSUE_441
+++ b/tests/Unit/ActivityLog/ActivityLogRetentionTest.php.TODO_ISSUE_441
@@ -2,7 +2,7 @@
 
 /**
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/tests/Unit/ActivityLog/ActivityLogServiceTest.php
+++ b/tests/Unit/ActivityLog/ActivityLogServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\Activity;
 use App\Models\Employee;

--- a/tests/Unit/ActivityLog/ActivityLogTest.php
+++ b/tests/Unit/ActivityLog/ActivityLogTest.php
@@ -2,7 +2,7 @@
 
 /**
  * SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/tests/Unit/ActivityLog/ActivityRetentionYearsTest.php
+++ b/tests/Unit/ActivityLog/ActivityRetentionYearsTest.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-// SPDX-FileCopyrightText: 2025-2026 SecPal <https://github.com/SecPal>
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\Activity;
 

--- a/tests/Unit/ActivityLog/AutoLoggingTest.php
+++ b/tests/Unit/ActivityLog/AutoLoggingTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\Activity;
 use App\Models\Customer;

--- a/tests/Unit/ActivityLog/EmployeeGDPRLoggingEdgeCasesTest.php
+++ b/tests/Unit/ActivityLog/EmployeeGDPRLoggingEdgeCasesTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\Activity;
 use App\Models\Employee;

--- a/tests/Unit/ActivityLog/ForensicEdgeCasesTest.php
+++ b/tests/Unit/ActivityLog/ForensicEdgeCasesTest.php
@@ -2,7 +2,7 @@
 
 /**
  * SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/tests/Unit/ActivityLog/ForensicEdgeCasesWithOtsTest.php.TODO_ISSUE_441
+++ b/tests/Unit/ActivityLog/ForensicEdgeCasesWithOtsTest.php.TODO_ISSUE_441
@@ -2,7 +2,7 @@
 
 /**
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/tests/Unit/ActivityLog/MerkleProofTest.php
+++ b/tests/Unit/ActivityLog/MerkleProofTest.php
@@ -2,7 +2,7 @@
 
 /**
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/tests/Unit/ActivityLog/RetentionRefactoringBaselineTest.php
+++ b/tests/Unit/ActivityLog/RetentionRefactoringBaselineTest.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-// SPDX-FileCopyrightText: 2025 SecPal <https://github.com/SecPal>
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\Activity;
 

--- a/tests/Unit/AddressDataRefreshDatabaseLifecycleConfigTest.php
+++ b/tests/Unit/AddressDataRefreshDatabaseLifecycleConfigTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/tests/Unit/BootstrapConfigTest.php
+++ b/tests/Unit/BootstrapConfigTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/tests/Unit/Commands/ApplyRetentionPoliciesLogicTest.php
+++ b/tests/Unit/Commands/ApplyRetentionPoliciesLogicTest.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-// SPDX-FileCopyrightText: 2025 SecPal <https://github.com/SecPal>
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\Activity;
 use Carbon\Carbon;

--- a/tests/Unit/ExampleTest.php
+++ b/tests/Unit/ExampleTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 test('environment is testing', function (): void {
     expect(config('app.env'))->toBe('testing');

--- a/tests/Unit/Factories/EmployeeFactoryBewachvTest.php
+++ b/tests/Unit/Factories/EmployeeFactoryBewachvTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\Employee;
 use Illuminate\Foundation\Testing\RefreshDatabase;

--- a/tests/Unit/Factories/OnboardingFormTemplateFactoryTest.php
+++ b/tests/Unit/Factories/OnboardingFormTemplateFactoryTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\OnboardingFormTemplate;
 use App\Models\TenantKey;

--- a/tests/Unit/Http/Middleware/DisablePolyglotUiTest.php
+++ b/tests/Unit/Http/Middleware/DisablePolyglotUiTest.php
@@ -1,6 +1,6 @@
 <?php
 
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
 
 declare(strict_types=1);

--- a/tests/Unit/Http/Middleware/ForceJsonResponseTest.php
+++ b/tests/Unit/Http/Middleware/ForceJsonResponseTest.php
@@ -1,7 +1,7 @@
 <?php
 
-// SPDX-License-Identifier: AGPL-3.0-or-later
-// SPDX-FileCopyrightText: 2024-2025 SecPal <https://github.com/SecPal>
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+// SPDX-FileCopyrightText: 2024-2025 SecPal Contributors
 
 declare(strict_types=1);
 

--- a/tests/Unit/Jobs/BuildMerkleTreeBatchLogicTest.php
+++ b/tests/Unit/Jobs/BuildMerkleTreeBatchLogicTest.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-// SPDX-FileCopyrightText: 2025 SecPal <https://github.com/SecPal>
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\Activity;
 

--- a/tests/Unit/Jobs/BuildMerkleTreeBatchRefactoringTest.php
+++ b/tests/Unit/Jobs/BuildMerkleTreeBatchRefactoringTest.php
@@ -2,7 +2,7 @@
 
 /**
  * SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/tests/Unit/LicenseCompatibilityScriptTest.php
+++ b/tests/Unit/LicenseCompatibilityScriptTest.php
@@ -90,3 +90,42 @@ SPDX
     expect($result['exit_code'])->toBe(1)
         ->and($result['stderr'])->toContain('incompatible license expression');
 });
+
+test('license compatibility script rejects strict-path files that omit the secpal attribution pair', function (): void {
+    $result = runLicenseCompatibilityScript(<<<'SPDX'
+SPDXVersion: SPDX-2.3
+DataLicense: CC0-1.0
+SPDXID: SPDXRef-DOCUMENT
+DocumentName: sample
+DocumentNamespace: https://secpal.dev/spdxdocs/sample
+
+FileName: app/Foo.php
+SPDXID: SPDXRef-File
+LicenseInfoInFile: MIT
+LicenseConcluded: MIT
+SPDX
+    );
+
+    expect($result['exit_code'])->toBe(1)
+        ->and($result['stderr'])->toContain('strict-path files must use exactly AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution');
+});
+
+test('license compatibility script rejects strict-path or-licensing when license concluded is noassertion', function (): void {
+    $result = runLicenseCompatibilityScript(<<<'SPDX'
+SPDXVersion: SPDX-2.3
+DataLicense: CC0-1.0
+SPDXID: SPDXRef-DOCUMENT
+DocumentName: sample
+DocumentNamespace: https://secpal.dev/spdxdocs/sample
+
+FileName: app/Foo.php
+SPDXID: SPDXRef-File
+LicenseInfoInFile: AGPL-3.0-or-later
+LicenseInfoInFile: MIT
+LicenseConcluded: NOASSERTION
+SPDX
+    );
+
+    expect($result['exit_code'])->toBe(1)
+        ->and($result['stderr'])->toContain('strict-path files must use exactly AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution');
+});

--- a/tests/Unit/LicenseCompatibilityScriptTest.php
+++ b/tests/Unit/LicenseCompatibilityScriptTest.php
@@ -129,3 +129,46 @@ SPDX
     expect($result['exit_code'])->toBe(1)
         ->and($result['stderr'])->toContain('strict-path files must use exactly AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution');
 });
+
+test('license compatibility script allows documented public cc0 assets', function (): void {
+    $result = runLicenseCompatibilityScript(<<<'SPDX'
+SPDXVersion: SPDX-2.3
+DataLicense: CC0-1.0
+SPDXID: SPDXRef-DOCUMENT
+DocumentName: sample
+DocumentNamespace: https://secpal.dev/spdxdocs/sample
+
+FileName: public/robots.txt
+SPDXID: SPDXRef-File
+LicenseInfoInFile: CC0-1.0
+LicenseConcluded: CC0-1.0
+SPDX
+    );
+
+    expect($result['exit_code'])->toBe(0)
+        ->and($result['stderr'])->toBe('');
+});
+
+test('license compatibility script allows documented non agpl exceptions in strict directories', function (): void {
+    $result = runLicenseCompatibilityScript(<<<'SPDX'
+SPDXVersion: SPDX-2.3
+DataLicense: CC0-1.0
+SPDXID: SPDXRef-DOCUMENT
+DocumentName: sample
+DocumentNamespace: https://secpal.dev/spdxdocs/sample
+
+FileName: config/permission.php
+SPDXID: SPDXRef-Config
+LicenseInfoInFile: CC0-1.0
+LicenseConcluded: CC0-1.0
+
+FileName: tests/fixtures/address_data/sample_streets.csv
+SPDXID: SPDXRef-Fixture
+LicenseInfoInFile: ODbL-1.0
+LicenseConcluded: ODbL-1.0
+SPDX
+    );
+
+    expect($result['exit_code'])->toBe(0)
+        ->and($result['stderr'])->toBe('');
+});

--- a/tests/Unit/LicenseCompatibilityScriptTest.php
+++ b/tests/Unit/LicenseCompatibilityScriptTest.php
@@ -1,0 +1,92 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+
+declare(strict_types=1);
+
+use Illuminate\Support\Str;
+
+function runLicenseCompatibilityScript(string $spdxContents): array
+{
+    if (! function_exists('proc_open')) {
+        test()->markTestSkipped('proc_open is required for license compatibility script coverage.');
+    }
+
+    $spdxPath = storage_path('framework/testing/'.Str::uuid().'.spdx');
+    file_put_contents($spdxPath, $spdxContents);
+
+    $process = proc_open(
+        ['bash', 'scripts/check-license-compatibility.sh', $spdxPath],
+        [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ],
+        $pipes,
+        base_path(),
+        [
+            'LC_ALL' => 'C',
+        ],
+    );
+
+    expect($process)->toBeResource();
+
+    fclose($pipes[0]);
+
+    $stdout = stream_get_contents($pipes[1]);
+    $stderr = stream_get_contents($pipes[2]);
+
+    fclose($pipes[1]);
+    fclose($pipes[2]);
+
+    $exitCode = proc_close($process);
+
+    unlink($spdxPath);
+
+    return [
+        'exit_code' => $exitCode,
+        'stdout' => $stdout,
+        'stderr' => $stderr,
+    ];
+}
+
+test('license compatibility script accepts the secpal attribution expression', function (): void {
+    $result = runLicenseCompatibilityScript(<<<'SPDX'
+SPDXVersion: SPDX-2.3
+DataLicense: CC0-1.0
+SPDXID: SPDXRef-DOCUMENT
+DocumentName: sample
+DocumentNamespace: https://secpal.dev/spdxdocs/sample
+
+FileName: app/Foo.php
+SPDXID: SPDXRef-File
+LicenseInfoInFile: AGPL-3.0-or-later
+LicenseInfoInFile: LicenseRef-SecPal-Attribution
+LicenseConcluded: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+SPDX
+    );
+
+    expect($result['exit_code'])->toBe(0)
+        ->and($result['stderr'])->not->toContain('incompatible');
+});
+
+test('license compatibility script rejects permissive or-licensing on application code', function (): void {
+    $result = runLicenseCompatibilityScript(<<<'SPDX'
+SPDXVersion: SPDX-2.3
+DataLicense: CC0-1.0
+SPDXID: SPDXRef-DOCUMENT
+DocumentName: sample
+DocumentNamespace: https://secpal.dev/spdxdocs/sample
+
+FileName: app/Foo.php
+SPDXID: SPDXRef-File
+LicenseInfoInFile: AGPL-3.0-or-later
+LicenseInfoInFile: MIT
+LicenseConcluded: AGPL-3.0-or-later OR MIT
+SPDX
+    );
+
+    expect($result['exit_code'])->toBe(1)
+        ->and($result['stderr'])->toContain('incompatible license expression');
+});

--- a/tests/Unit/Models/ActivityArchiveTest.php
+++ b/tests/Unit/Models/ActivityArchiveTest.php
@@ -2,7 +2,7 @@
 
 /**
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/tests/Unit/Models/CustomerTest.php
+++ b/tests/Unit/Models/CustomerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\Customer;
 use App\Models\TenantKey;

--- a/tests/Unit/Models/EmployeeAddressTest.php
+++ b/tests/Unit/Models/EmployeeAddressTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\Employee;
 use App\Models\EmployeeAddress;

--- a/tests/Unit/Models/EmployeeDocumentTest.php
+++ b/tests/Unit/Models/EmployeeDocumentTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\Employee;
 use App\Models\EmployeeDocument;

--- a/tests/Unit/Models/EmployeeModelBewachvFieldsTest.php
+++ b/tests/Unit/Models/EmployeeModelBewachvFieldsTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\Employee;
 use App\Models\EmployeeAddress;

--- a/tests/Unit/Models/EmployeeOnboardingTokenTest.php
+++ b/tests/Unit/Models/EmployeeOnboardingTokenTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/tests/Unit/Models/EmployeeQualificationTest.php
+++ b/tests/Unit/Models/EmployeeQualificationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\Employee;
 use App\Models\EmployeeQualification;

--- a/tests/Unit/Models/EmployeeTest.php
+++ b/tests/Unit/Models/EmployeeTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\Employee;
 use App\Models\EmployeeAddress;

--- a/tests/Unit/Models/OnboardingFormSubmissionTest.php
+++ b/tests/Unit/Models/OnboardingFormSubmissionTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\Employee;
 use App\Models\OnboardingFormSubmission;

--- a/tests/Unit/Models/OnboardingFormTemplateTest.php
+++ b/tests/Unit/Models/OnboardingFormTemplateTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\OnboardingFormSubmission;
 use App\Models\OnboardingFormTemplate;

--- a/tests/Unit/Models/PasskeyCredentialWebauthnMappingTest.php
+++ b/tests/Unit/Models/PasskeyCredentialWebauthnMappingTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\PasskeyCredential;
 use Illuminate\Foundation\Testing\RefreshDatabase;

--- a/tests/Unit/Models/QualificationTest.php
+++ b/tests/Unit/Models/QualificationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\Employee;
 use App\Models\Qualification;

--- a/tests/Unit/Models/SiteTest.php
+++ b/tests/Unit/Models/SiteTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\Customer;
 use App\Models\OrganizationalUnit;

--- a/tests/Unit/Models/TenantKeyTest.php
+++ b/tests/Unit/Models/TenantKeyTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\TenantKey;
 use Illuminate\Foundation\Testing\RefreshDatabase;

--- a/tests/Unit/Models/UserAccessTest.php
+++ b/tests/Unit/Models/UserAccessTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\Customer;
 use App\Models\CustomerAssignment;

--- a/tests/Unit/Observers/EmployeeObserverBewachvTest.php
+++ b/tests/Unit/Observers/EmployeeObserverBewachvTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\Employee;
 use App\Models\TenantKey;

--- a/tests/Unit/PhpCiSerialGroupConfigTest.php
+++ b/tests/Unit/PhpCiSerialGroupConfigTest.php
@@ -22,3 +22,11 @@ test('php ci excludes serial tests from the parallel pest run and executes them 
         ->toContain('php artisan test --group=serial --coverage-clover coverage-serial.xml')
         ->toContain('files: ./coverage.xml,./coverage-serial.xml');
 });
+
+test('php ci uses the precreated worker database public schema for parallel pest', function (): void {
+    $contents = phpCiWorkflowContents();
+
+    expect($contents)
+        ->toContain('SECPAL_TEST_SCHEMA: public')
+        ->toContain('php artisan test --parallel --exclude-group=serial --coverage-clover coverage.xml');
+});

--- a/tests/Unit/PhpCiSerialGroupConfigTest.php
+++ b/tests/Unit/PhpCiSerialGroupConfigTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/tests/Unit/PhpUnitDatabaseEnvironmentConfigTest.php
+++ b/tests/Unit/PhpUnitDatabaseEnvironmentConfigTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/tests/Unit/Policies/OnboardingFormTemplatePolicyTest.php
+++ b/tests/Unit/Policies/OnboardingFormTemplatePolicyTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\OnboardingFormTemplate;
 use App\Models\TenantKey;

--- a/tests/Unit/PreCommitMarkdownlintHookTest.php
+++ b/tests/Unit/PreCommitMarkdownlintHookTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 it('runs markdownlint in a pre-commit managed node environment', function (): void {
     $config = file_get_contents(base_path('.pre-commit-config.yaml'));

--- a/tests/Unit/PreflightSerialGroupConfigTest.php
+++ b/tests/Unit/PreflightSerialGroupConfigTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/tests/Unit/QualityLicenseCompatibilityWorkflowTest.php
+++ b/tests/Unit/QualityLicenseCompatibilityWorkflowTest.php
@@ -19,5 +19,6 @@ test('quality workflow allows the secpal attribution license reference', functio
 
     expect($contents)
         ->toContain('scripts/check-license-compatibility.sh')
+        ->toContain('reuse spdx --add-license-concluded')
         ->not->toContain('grep "LicenseInfoInFile"');
 });

--- a/tests/Unit/QualityLicenseCompatibilityWorkflowTest.php
+++ b/tests/Unit/QualityLicenseCompatibilityWorkflowTest.php
@@ -1,0 +1,23 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+
+declare(strict_types=1);
+
+function qualityWorkflowContents(): string
+{
+    $contents = file_get_contents(base_path('.github/workflows/quality.yml'));
+
+    expect($contents)->not->toBeFalse();
+
+    return $contents;
+}
+
+test('quality workflow allows the secpal attribution license reference', function (): void {
+    $contents = qualityWorkflowContents();
+
+    expect($contents)
+        ->toContain('LicenseRef-SecPal-Attribution')
+        ->not->toContain('reusable-license-compatibility.yml');
+});

--- a/tests/Unit/QualityLicenseCompatibilityWorkflowTest.php
+++ b/tests/Unit/QualityLicenseCompatibilityWorkflowTest.php
@@ -18,6 +18,6 @@ test('quality workflow allows the secpal attribution license reference', functio
     $contents = qualityWorkflowContents();
 
     expect($contents)
-        ->toContain('LicenseRef-SecPal-Attribution')
-        ->not->toContain('reusable-license-compatibility.yml');
+        ->toContain('scripts/check-license-compatibility.sh')
+        ->not->toContain('grep "LicenseInfoInFile"');
 });

--- a/tests/Unit/Resources/EmployeeResourceBewachvTest.php
+++ b/tests/Unit/Resources/EmployeeResourceBewachvTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Http\Resources\EmployeeResource;
 use App\Models\Employee;

--- a/tests/Unit/Services/ActivityLogServiceLoginFailureTest.php
+++ b/tests/Unit/Services/ActivityLogServiceLoginFailureTest.php
@@ -2,7 +2,7 @@
 
 /**
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/tests/Unit/Services/AddressDataImportServiceTest.php
+++ b/tests/Unit/Services/AddressDataImportServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\AddressDataImport;
 use App\Models\AddressStreet;

--- a/tests/Unit/Services/AddressStreetCsvImporterTest.php
+++ b/tests/Unit/Services/AddressStreetCsvImporterTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\AddressDataImport;
 use App\Services\AddressData\AddressStreetCsvImporter;

--- a/tests/Unit/Services/AddressSuggestionServiceResilienceTest.php
+++ b/tests/Unit/Services/AddressSuggestionServiceResilienceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Services\AddressData\AddressSuggestionService;
 use Illuminate\Database\Eloquent\Builder;

--- a/tests/Unit/Services/AddressSuggestionServiceTest.php
+++ b/tests/Unit/Services/AddressSuggestionServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\AddressDataImport;
 use App\Models\AddressStreet;

--- a/tests/Unit/Services/AndroidPushDeliveryServiceTest.php
+++ b/tests/Unit/Services/AndroidPushDeliveryServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/tests/Unit/Services/BewacherregisterExportServiceTest.php
+++ b/tests/Unit/Services/BewacherregisterExportServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/tests/Unit/Services/OnboardingCompletionServiceTest.php
+++ b/tests/Unit/Services/OnboardingCompletionServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\Employee;
 use App\Models\OnboardingFormSubmission;

--- a/tests/Unit/Services/OnboardingFormDataSchemaValidationServiceDateTest.php
+++ b/tests/Unit/Services/OnboardingFormDataSchemaValidationServiceDateTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\OnboardingFormTemplate;
 use App\Services\OnboardingFormDataSchemaValidationService;

--- a/tests/Unit/Services/OnboardingResidentialAddressHistorySyncServiceTest.php
+++ b/tests/Unit/Services/OnboardingResidentialAddressHistorySyncServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\Employee;
 use App\Models\OnboardingFormSubmission;

--- a/tests/Unit/Services/OnboardingSchemaLocalizationServiceTest.php
+++ b/tests/Unit/Services/OnboardingSchemaLocalizationServiceTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\OnboardingFormTemplate;
 use App\Services\OnboardingSchemaLocalizationService;

--- a/tests/Unit/Services/OpenTimestampCliVerificationTest.php
+++ b/tests/Unit/Services/OpenTimestampCliVerificationTest.php
@@ -2,7 +2,7 @@
 
 /**
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/tests/Unit/Services/OpenTimestampProofMergingTest.php
+++ b/tests/Unit/Services/OpenTimestampProofMergingTest.php
@@ -2,7 +2,7 @@
 
 /**
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/tests/Unit/Services/OpenTimestampServiceTest.php
+++ b/tests/Unit/Services/OpenTimestampServiceTest.php
@@ -2,7 +2,7 @@
 
 /**
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
  */
 
 declare(strict_types=1);

--- a/tests/Unit/Services/PasskeyServiceTest.php
+++ b/tests/Unit/Services/PasskeyServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\User;
 use App\Services\PasskeyService;

--- a/tests/Unit/Services/WebPushDeliveryServiceTest.php
+++ b/tests/Unit/Services/WebPushDeliveryServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/tests/Unit/Services/WebPushTransportTest.php
+++ b/tests/Unit/Services/WebPushTransportTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/tests/Unit/Support/AddressSearchNormalizerTest.php
+++ b/tests/Unit/Support/AddressSearchNormalizerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Support\AddressSearchNormalizer;
 

--- a/tests/Unit/Support/AndroidPushDeliveryConfigurationTest.php
+++ b/tests/Unit/Support/AndroidPushDeliveryConfigurationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/tests/Unit/Support/ApiTimestampTest.php
+++ b/tests/Unit/Support/ApiTimestampTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/tests/Unit/Support/InteractsWithConfigValuesTest.php
+++ b/tests/Unit/Support/InteractsWithConfigValuesTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Support\Concerns\InteractsWithConfigValues;
 

--- a/tests/Unit/Support/LikePatternTest.php
+++ b/tests/Unit/Support/LikePatternTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 // SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Support\LikePattern;
 

--- a/tests/Unit/Support/NotificationChannelRuntimeConfigurationTest.php
+++ b/tests/Unit/Support/NotificationChannelRuntimeConfigurationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/tests/Unit/Support/PublicApiReleaseTest.php
+++ b/tests/Unit/Support/PublicApiReleaseTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/tests/Unit/Support/PublicSourceOfferTest.php
+++ b/tests/Unit/Support/PublicSourceOfferTest.php
@@ -10,8 +10,9 @@ use App\Support\PublicSourceOffer;
 beforeEach(function (): void {
     config([
         'bootstrap.legal.license_spdx_id' => 'AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution',
-        'bootstrap.legal.license_name' => 'GNU Affero General Public License v3.0 or later',
-        'bootstrap.legal.license_url' => 'https://www.gnu.org/licenses/agpl-3.0.html',
+        'bootstrap.legal.license_name' => 'GNU Affero General Public License v3.0 or later with SecPal attribution additional terms',
+        'bootstrap.legal.license_url' => 'https://github.com/SecPal/api/blob/main/LICENSES/LicenseRef-SecPal-Attribution.txt',
+        'bootstrap.legal.license_base_url' => 'https://www.gnu.org/licenses/agpl-3.0.html',
         'bootstrap.legal.copyright_notice' => 'Copyright SecPal and contributors.',
         'bootstrap.legal.warranty_notice' => 'This program is distributed without any warranty; without even the implied warranty of merchantability or fitness for a particular purpose.',
         'bootstrap.legal.source_repositories' => [
@@ -86,5 +87,24 @@ test('missing fields reject source offer urls with embedded whitespace', functio
     expect(app(PublicSourceOffer::class)->missingFields())->toBe([
         'legal.license.url',
         'legal.source_repositories.0.url',
+    ]);
+});
+
+test('source response data exposes the effective license document and the AGPL base license url', function (): void {
+    expect(app(PublicSourceOffer::class)->sourceResponseData('https://api.secpal.dev/v1/source')['license'])->toBe([
+        'spdx_id' => 'AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution',
+        'name' => 'GNU Affero General Public License v3.0 or later with SecPal attribution additional terms',
+        'url' => 'https://github.com/SecPal/api/blob/main/LICENSES/LicenseRef-SecPal-Attribution.txt',
+        'base_license_url' => 'https://www.gnu.org/licenses/agpl-3.0.html',
+    ]);
+});
+
+test('missing fields report an invalid AGPL base license url separately from the effective license url', function (): void {
+    config([
+        'bootstrap.legal.license_base_url' => 'not-a-url',
+    ]);
+
+    expect(app(PublicSourceOffer::class)->missingFields())->toBe([
+        'legal.license.base_license_url',
     ]);
 });

--- a/tests/Unit/Support/PublicSourceOfferTest.php
+++ b/tests/Unit/Support/PublicSourceOfferTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 
@@ -9,7 +9,7 @@ use App\Support\PublicSourceOffer;
 
 beforeEach(function (): void {
     config([
-        'bootstrap.legal.license_spdx_id' => 'AGPL-3.0-or-later',
+        'bootstrap.legal.license_spdx_id' => 'AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution',
         'bootstrap.legal.license_name' => 'GNU Affero General Public License v3.0 or later',
         'bootstrap.legal.license_url' => 'https://www.gnu.org/licenses/agpl-3.0.html',
         'bootstrap.legal.copyright_notice' => 'Copyright SecPal and contributors.',

--- a/tests/Unit/TestCaseBootstrapEnvironmentFileTest.php
+++ b/tests/Unit/TestCaseBootstrapEnvironmentFileTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/tests/Unit/TestCaseBootstrapEnvironmentProbeAutoloadTest.php
+++ b/tests/Unit/TestCaseBootstrapEnvironmentProbeAutoloadTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/tests/Unit/TestCasePhpUnitEnvironmentOverridesTest.php
+++ b/tests/Unit/TestCasePhpUnitEnvironmentOverridesTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/tests/Unit/TestCasePostgresParallelDatabaseAccessTest.php
+++ b/tests/Unit/TestCasePostgresParallelDatabaseAccessTest.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,7 +1,7 @@
 <?php
 
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 declare(strict_types=1);
 


### PR DESCRIPTION
Closes #1219

## Summary

Focused Pest coverage failed once the SPDX contract was updated to the central policy value: `tests/Feature/Api/V1/BootstrapApiTest.php` still received `AGPL-3.0-or-later` from bootstrap metadata while this repo now needs `AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution`.

This change adds the SecPal attribution additional terms and aligns the repo's SecPal-owned AGPL metadata with that policy:

- add `LICENSES/LicenseRef-SecPal-Attribution.txt`
- update SecPal-owned AGPL SPDX headers, `.license` sidecars, and `REUSE.toml` annotations to `AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution`
- normalize touched project-owned copyright notices to `SecPal Contributors`
- update public/bootstrap-facing SPDX metadata and focused tests
- document the AGPLv3 section 7(b)/(c) attribution terms in the licensing and contributor docs

## Validation

- `php artisan test tests/Feature/Api/V1/SourceApiTest.php tests/Feature/Api/V1/BootstrapApiTest.php tests/Unit/Support/PublicSourceOfferTest.php`
- `vendor/bin/pint --dirty`
- `reuse lint`

## Before Ready

- linked workspaces used: none
- still required by repo policy: final self-review in the PR view with zero findings before marking ready
- broader full-suite/preflight coverage was not run locally; this draft currently includes focused touched-area validation only
- the repo's large-PR override is active because this REUSE/SPDX sweep exceeds the usual 600-line PR guideline
