### PR TITLE
feat: add independent organizational-unit status flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- added independent organizational-unit `is_legal_entity` and `is_establishment` API flags with false defaults, strict boolean create/update validation, persistence, resource serialization, and focused Pest coverage (refs `api#1259`)
 - added the SecPal AGPL attribution additional terms in `LICENSES/LicenseRef-SecPal-Attribution.txt`, updated project-owned AGPL SPDX metadata to `AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution`, standardized touched AGPL copyright headers to `SecPal Contributors`, and documented the section 7(b)/(c) attribution requirements in the licensing/contributor guides (refs `api#1219`)
 - added a public unauthenticated `GET /v1/release` endpoint that returns only the currently deployed API release version plus immutable corresponding-source URL, so the frontend can identify the active backend release without widening the existing AGPL/source-offer metadata surface
 - added a public unauthenticated `GET /v1/source` AGPL source-offer endpoint that keeps the canonical license, repository, copyright, and warranty payload while also returning explicit network-use source-offer notices for SecPal users

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- seed the SecPal Holding organizational unit as both a legal entity and establishment by default
 - grouped Dependabot updates for `SecPal/.github/.github/workflows/*` under stable `shared-github-workflows` identifiers in `.github/dependabot.yml`, so GitHub derives readable branch names and PR titles from the group name instead of transliterating the full reusable-workflow path into long `SecPal-dot-github-dot-...` strings
 - restored Dependabot pull request branch names to the standard hyphen-separated format in `.github/dependabot.yml`, so GitHub Actions, Composer, and npm update branches no longer expand into deep slash-separated paths like `dependabot/github_actions/main/...`
 - fixed SQLite-backed setup/test migrations that still issued PostgreSQL-only `ALTER TABLE ... CONSTRAINT` rewrites, including the admin-to-manage scope cleanup, employee address constraints, and user-deletion audit-history foreign-key updates, so `migrate:fresh` can progress on SQLite worktrees without aborting on unsupported DDL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- seed the SecPal Holding organizational unit as both a legal entity and establishment by default
+- seed the SecPal Holding organizational unit as both a legal entity and establishment, including repairing the flags when the unit already exists
 - grouped Dependabot updates for `SecPal/.github/.github/workflows/*` under stable `shared-github-workflows` identifiers in `.github/dependabot.yml`, so GitHub derives readable branch names and PR titles from the group name instead of transliterating the full reusable-workflow path into long `SecPal-dot-github-dot-...` strings
 - restored Dependabot pull request branch names to the standard hyphen-separated format in `.github/dependabot.yml`, so GitHub Actions, Composer, and npm update branches no longer expand into deep slash-separated paths like `dependabot/github_actions/main/...`
 - fixed SQLite-backed setup/test migrations that still issued PostgreSQL-only `ALTER TABLE ... CONSTRAINT` rewrites, including the admin-to-manage scope cleanup, employee address constraints, and user-deletion audit-history foreign-key updates, so `migrate:fresh` can progress on SQLite worktrees without aborting on unsupported DDL

--- a/app/Http/Controllers/Api/V1/OrganizationalUnitController.php
+++ b/app/Http/Controllers/Api/V1/OrganizationalUnitController.php
@@ -189,7 +189,7 @@ class OrganizationalUnitController extends Controller
             $this->authorize('createRoot', OrganizationalUnit::class);
         }
 
-        /** @var array{name: string, type: string, custom_type_name?: string|null, description?: string|null, metadata?: array<mixed>|null, parent_id?: string|null} $validated */
+        /** @var array{name: string, type: string, custom_type_name?: string|null, description?: string|null, metadata?: array<mixed>|null, is_legal_entity?: bool, is_establishment?: bool, parent_id?: string|null} $validated */
         $validated = $request->validated();
 
         $unit = OrganizationalUnit::create([
@@ -199,6 +199,8 @@ class OrganizationalUnitController extends Controller
             'custom_type_name' => $validated['custom_type_name'] ?? null,
             'description' => $validated['description'] ?? null,
             'metadata' => $validated['metadata'] ?? null,
+            'is_legal_entity' => $validated['is_legal_entity'] ?? false,
+            'is_establishment' => $validated['is_establishment'] ?? false,
         ]);
 
         // Attach parent if specified
@@ -241,7 +243,7 @@ class OrganizationalUnitController extends Controller
     {
         $this->authorize('update', $organizational_unit);
 
-        /** @var array{name?: string, type?: string, custom_type_name?: string|null, description?: string|null, metadata?: array<mixed>|null} $validated */
+        /** @var array{name?: string, type?: string, custom_type_name?: string|null, description?: string|null, metadata?: array<mixed>|null, is_legal_entity?: bool, is_establishment?: bool} $validated */
         $validated = $request->validated();
 
         $organizational_unit->update($validated);

--- a/app/Http/Requests/Api/StoreOrganizationalUnitRequest.php
+++ b/app/Http/Requests/Api/StoreOrganizationalUnitRequest.php
@@ -76,8 +76,19 @@ class StoreOrganizationalUnitRequest extends FormRequest
             'custom_type_name' => ['nullable', 'string', 'max:255', 'required_if:type,custom'],
             'description' => ['nullable', 'string', 'max:1000'],
             'metadata' => ['nullable', 'array'],
+            'is_legal_entity' => ['sometimes', $this->strictBooleanRule()],
+            'is_establishment' => ['sometimes', $this->strictBooleanRule()],
             'parent_id' => ['nullable', 'uuid', Rule::exists(OrganizationalUnit::class, 'id')],
         ];
+    }
+
+    private function strictBooleanRule(): \Closure
+    {
+        return function (string $attribute, mixed $value, \Closure $fail): void {
+            if (! is_bool($value)) {
+                $fail("The {$attribute} field must be true or false.");
+            }
+        };
     }
 
     /**

--- a/app/Http/Requests/Api/StoreOrganizationalUnitRequest.php
+++ b/app/Http/Requests/Api/StoreOrganizationalUnitRequest.php
@@ -86,7 +86,7 @@ class StoreOrganizationalUnitRequest extends FormRequest
     {
         return function (string $attribute, mixed $value, \Closure $fail): void {
             if (! is_bool($value)) {
-                $fail("The {$attribute} field must be true or false.");
+                $fail("The {$attribute} field must be a JSON boolean (true or false).");
             }
         };
     }

--- a/app/Http/Requests/Api/UpdateOrganizationalUnitRequest.php
+++ b/app/Http/Requests/Api/UpdateOrganizationalUnitRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-// SPDX-FileCopyrightText: 2025 SecPal Contributors
+// SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Requests\Api;
@@ -39,6 +39,17 @@ class UpdateOrganizationalUnitRequest extends FormRequest
             'custom_type_name' => ['nullable', 'string', 'max:255'],
             'description' => ['nullable', 'string', 'max:1000'],
             'metadata' => ['nullable', 'array'],
+            'is_legal_entity' => ['sometimes', $this->strictBooleanRule()],
+            'is_establishment' => ['sometimes', $this->strictBooleanRule()],
         ];
+    }
+
+    private function strictBooleanRule(): \Closure
+    {
+        return function (string $attribute, mixed $value, \Closure $fail): void {
+            if (! is_bool($value)) {
+                $fail("The {$attribute} field must be true or false.");
+            }
+        };
     }
 }

--- a/app/Http/Requests/Api/UpdateOrganizationalUnitRequest.php
+++ b/app/Http/Requests/Api/UpdateOrganizationalUnitRequest.php
@@ -48,7 +48,7 @@ class UpdateOrganizationalUnitRequest extends FormRequest
     {
         return function (string $attribute, mixed $value, \Closure $fail): void {
             if (! is_bool($value)) {
-                $fail("The {$attribute} field must be true or false.");
+                $fail("The {$attribute} field must be a JSON boolean (true or false).");
             }
         };
     }

--- a/app/Http/Resources/OrganizationalUnitResource.php
+++ b/app/Http/Resources/OrganizationalUnitResource.php
@@ -1,6 +1,6 @@
 <?php
 
-// SPDX-FileCopyrightText: 2025 SecPal Contributors
+// SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 namespace App\Http\Resources;
@@ -36,6 +36,8 @@ class OrganizationalUnitResource extends JsonResource
             'custom_type_name' => $this->custom_type_name,
             'description' => $this->description,
             'metadata' => $this->metadata,
+            'is_legal_entity' => $this->is_legal_entity,
+            'is_establishment' => $this->is_establishment,
             'parent' => $this->transformParent($request),
             'permissions' => $this->resolvePermissions($request),
             'children' => OrganizationalUnitResource::collection($this->whenLoaded('children')),

--- a/app/Models/OrganizationalUnit.php
+++ b/app/Models/OrganizationalUnit.php
@@ -38,6 +38,8 @@ use Illuminate\Support\Facades\DB;
  * @property string|null $custom_type_name Custom type name when type='custom'
  * @property string|null $description Optional description
  * @property array<string, mixed>|null $metadata JSON metadata (address, phone, etc.)
+ * @property bool $is_legal_entity Independent legal-person status; not derived from hierarchy type
+ * @property bool $is_establishment Independent establishment status; not derived from hierarchy type
  * @property \Illuminate\Support\Carbon $created_at
  * @property \Illuminate\Support\Carbon $updated_at
  * @property \Illuminate\Support\Carbon|null $deleted_at
@@ -74,6 +76,8 @@ class OrganizationalUnit extends Model
         'custom_type_name',
         'description',
         'metadata',
+        'is_legal_entity',
+        'is_establishment',
     ];
 
     /**
@@ -86,6 +90,8 @@ class OrganizationalUnit extends Model
         return [
             'tenant_id' => 'integer',
             'metadata' => 'array',
+            'is_legal_entity' => 'boolean',
+            'is_establishment' => 'boolean',
             'created_at' => 'datetime',
             'updated_at' => 'datetime',
             'deleted_at' => 'datetime',

--- a/database/factories/OrganizationalUnitFactory.php
+++ b/database/factories/OrganizationalUnitFactory.php
@@ -46,6 +46,8 @@ class OrganizationalUnitFactory extends Factory
             'custom_type_name' => null,
             'description' => fake()->optional()->sentence(),
             'metadata' => null,
+            'is_legal_entity' => false,
+            'is_establishment' => false,
         ];
     }
 

--- a/database/migrations/2026_07_10_000000_add_status_flags_to_organizational_units_table.php
+++ b/database/migrations/2026_07_10_000000_add_status_flags_to_organizational_units_table.php
@@ -1,0 +1,32 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('organizational_units', function (Blueprint $table): void {
+            $table->boolean('is_legal_entity')->default(false);
+            $table->boolean('is_establishment')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('organizational_units', function (Blueprint $table): void {
+            $table->dropColumn(['is_legal_entity', 'is_establishment']);
+        });
+    }
+};

--- a/database/seeders/OrganizationalUnitSeeder.php
+++ b/database/seeders/OrganizationalUnitSeeder.php
@@ -48,6 +48,8 @@ class OrganizationalUnitSeeder extends Seeder
             [
                 'type' => 'holding',
                 'description' => 'Main holding company for SecPal Group',
+                'is_legal_entity' => true,
+                'is_establishment' => true,
             ]
         );
 

--- a/database/seeders/OrganizationalUnitSeeder.php
+++ b/database/seeders/OrganizationalUnitSeeder.php
@@ -48,10 +48,12 @@ class OrganizationalUnitSeeder extends Seeder
             [
                 'type' => 'holding',
                 'description' => 'Main holding company for SecPal Group',
-                'is_legal_entity' => true,
-                'is_establishment' => true,
             ]
         );
+        $holding->update([
+            'is_legal_entity' => true,
+            'is_establishment' => true,
+        ]);
 
         // Ensure self-reference in closure table
         $this->ensureSelfReference($holding);

--- a/docs/planning/ou-status-flags-issues.md
+++ b/docs/planning/ou-status-flags-issues.md
@@ -13,15 +13,15 @@ US-001 prepared the repository-crossing organizational-unit status flag work as 
 
 The epic defines two independent booleans:
 
-- `is_active`: whether the organizational unit is administratively active.
-- `is_assignable`: whether the organizational unit can be selected for new operational assignments, scopes, or related workflows.
+- `is_legal_entity`: whether the organizational unit is a legal entity.
+- `is_establishment`: whether the organizational unit is an establishment.
 
 Neither flag is derived from the other, from hierarchy, from soft deletion, or from the organizational-unit type.
 
 ## Sub-Issues
 
 - SecPal/contracts#338: define the public request and response contract.
-- SecPal/api#1259: persist, validate, expose, filter, and test the flags in the API.
+- SecPal/api#1259: persist, validate, expose, and test the flags in the API.
 - SecPal/frontend#1361: consume, display, edit, cache, and test the flags in the frontend.
 
 ## Branch And PR Boundaries

--- a/docs/planning/ou-status-flags-issues.md
+++ b/docs/planning/ou-status-flags-issues.md
@@ -1,0 +1,33 @@
+<!--
+SPDX-FileCopyrightText: 2026 SecPal Contributors
+SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+-->
+
+# Organizational Unit Status Flags Issue Split
+
+US-001 prepared the repository-crossing organizational-unit status flag work as one epic with three implementation sub-issues.
+
+## Epic
+
+- SecPal/api#1260: Add independent organizational-unit status flags.
+
+The epic defines two independent booleans:
+
+- `is_active`: whether the organizational unit is administratively active.
+- `is_assignable`: whether the organizational unit can be selected for new operational assignments, scopes, or related workflows.
+
+Neither flag is derived from the other, from hierarchy, from soft deletion, or from the organizational-unit type.
+
+## Sub-Issues
+
+- SecPal/contracts#338: define the public request and response contract.
+- SecPal/api#1259: persist, validate, expose, filter, and test the flags in the API.
+- SecPal/frontend#1361: consume, display, edit, cache, and test the flags in the frontend.
+
+## Branch And PR Boundaries
+
+- Contracts branch: `add-ou-status-flags-contracts`, from current `main`.
+- API branch: `add-ou-status-flags-api`, from current `main`.
+- Frontend branch: `add-ou-status-flags-frontend`, from current `main`.
+
+Each repository owns one topic branch and one PR. Contract, API, and frontend changes must stay in their respective repositories and must not be mixed into a cross-repository PR.

--- a/tests/Feature/Controllers/Api/V1/OrganizationalUnitControllerTest.php
+++ b/tests/Feature/Controllers/Api/V1/OrganizationalUnitControllerTest.php
@@ -98,11 +98,24 @@ describe('OrganizationalUnitController - List', function () {
         $response->assertOk()
             ->assertJsonStructure([
                 'data' => [
-                    '*' => ['id', 'name', 'type', 'created_at', 'updated_at'],
+                    '*' => ['id', 'name', 'type', 'is_legal_entity', 'is_establishment', 'created_at', 'updated_at'],
                 ],
                 'meta' => ['current_page', 'last_page', 'per_page', 'total', 'root_unit_ids'],
             ])
             ->assertJsonCount(3, 'data'); // root + 2 created
+    });
+
+    test('list response includes independent status flags', function () {
+        $this->rootUnit->update([
+            'is_legal_entity' => true,
+            'is_establishment' => false,
+        ]);
+
+        $response = getJson('/v1/organizational-units');
+
+        $response->assertOk()
+            ->assertJsonPath('data.0.is_legal_entity', true)
+            ->assertJsonPath('data.0.is_establishment', false);
     });
 
     test('list organizational units respects pagination', function () {
@@ -257,13 +270,51 @@ describe('OrganizationalUnitController - Create', function () {
         $response->assertCreated()
             ->assertJsonPath('data.name', 'New Department')
             ->assertJsonPath('data.type', 'department')
-            ->assertJsonPath('data.description', 'A new department');
+            ->assertJsonPath('data.description', 'A new department')
+            ->assertJsonPath('data.is_legal_entity', false)
+            ->assertJsonPath('data.is_establishment', false);
 
         $this->assertDatabaseHas('organizational_units', [
             'name' => 'New Department',
             'type' => 'department',
             'tenant_id' => $this->tenant->id,
+            'is_legal_entity' => false,
+            'is_establishment' => false,
         ]);
+    });
+
+    test('create accepts all independent status flag combinations', function (bool $isLegalEntity, bool $isEstablishment) {
+        $response = postJson('/v1/organizational-units', [
+            'name' => sprintf('Status Unit %s %s', $isLegalEntity ? 'legal' : 'not-legal', $isEstablishment ? 'establishment' : 'not-establishment'),
+            'type' => 'department',
+            'is_legal_entity' => $isLegalEntity,
+            'is_establishment' => $isEstablishment,
+        ]);
+
+        $response->assertCreated()
+            ->assertJsonPath('data.is_legal_entity', $isLegalEntity)
+            ->assertJsonPath('data.is_establishment', $isEstablishment);
+
+        $this->assertDatabaseHas('organizational_units', [
+            'id' => $response->json('data.id'),
+            'is_legal_entity' => $isLegalEntity,
+            'is_establishment' => $isEstablishment,
+        ]);
+    })->with([
+        'neither' => [false, false],
+        'legal entity only' => [true, false],
+        'establishment only' => [false, true],
+        'both' => [true, true],
+    ]);
+
+    test('create strictly validates status flags as booleans', function () {
+        postJson('/v1/organizational-units', [
+            'name' => 'Invalid Status Unit',
+            'type' => 'department',
+            'is_legal_entity' => 'true',
+            'is_establishment' => 1,
+        ])->assertUnprocessable()
+            ->assertJsonValidationErrors(['is_legal_entity', 'is_establishment']);
     });
 
     test('user can create organizational unit with parent', function () {
@@ -680,7 +731,9 @@ describe('OrganizationalUnitController - Show', function () {
         // Assert
         $response->assertOk()
             ->assertJsonPath('data.id', $this->rootUnit->id)
-            ->assertJsonPath('data.name', 'Root Company');
+            ->assertJsonPath('data.name', 'Root Company')
+            ->assertJsonPath('data.is_legal_entity', false)
+            ->assertJsonPath('data.is_establishment', false);
     });
 
     test('show response exposes action permissions and accessible parent data', function () {
@@ -738,12 +791,62 @@ describe('OrganizationalUnitController - Update', function () {
         // Assert
         $response->assertOk()
             ->assertJsonPath('data.name', 'Updated Company Name')
-            ->assertJsonPath('data.description', 'Updated description');
+            ->assertJsonPath('data.description', 'Updated description')
+            ->assertJsonPath('data.is_legal_entity', false)
+            ->assertJsonPath('data.is_establishment', false);
 
         $this->assertDatabaseHas('organizational_units', [
             'id' => $this->rootUnit->id,
             'name' => 'Updated Company Name',
         ]);
+    });
+
+    test('patch accepts all independent status flag combinations', function (bool $isLegalEntity, bool $isEstablishment) {
+        $response = patchJson("/v1/organizational-units/{$this->rootUnit->id}", [
+            'is_legal_entity' => $isLegalEntity,
+            'is_establishment' => $isEstablishment,
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('data.is_legal_entity', $isLegalEntity)
+            ->assertJsonPath('data.is_establishment', $isEstablishment);
+
+        $this->rootUnit->refresh();
+
+        expect($this->rootUnit->is_legal_entity)->toBe($isLegalEntity)
+            ->and($this->rootUnit->is_establishment)->toBe($isEstablishment);
+    })->with([
+        'neither' => [false, false],
+        'legal entity only' => [true, false],
+        'establishment only' => [false, true],
+        'both' => [true, true],
+    ]);
+
+    test('patching one status flag leaves the other unchanged', function () {
+        $this->rootUnit->update([
+            'is_legal_entity' => true,
+            'is_establishment' => true,
+        ]);
+
+        patchJson("/v1/organizational-units/{$this->rootUnit->id}", [
+            'is_legal_entity' => false,
+        ])->assertOk()
+            ->assertJsonPath('data.is_legal_entity', false)
+            ->assertJsonPath('data.is_establishment', true);
+
+        patchJson("/v1/organizational-units/{$this->rootUnit->id}", [
+            'is_establishment' => false,
+        ])->assertOk()
+            ->assertJsonPath('data.is_legal_entity', false)
+            ->assertJsonPath('data.is_establishment', false);
+    });
+
+    test('patch strictly validates status flags as booleans', function () {
+        patchJson("/v1/organizational-units/{$this->rootUnit->id}", [
+            'is_legal_entity' => 'false',
+            'is_establishment' => 0,
+        ])->assertUnprocessable()
+            ->assertJsonValidationErrors(['is_legal_entity', 'is_establishment']);
     });
 });
 

--- a/tests/Feature/Controllers/Api/V1/OrganizationalUnitControllerTest.php
+++ b/tests/Feature/Controllers/Api/V1/OrganizationalUnitControllerTest.php
@@ -114,8 +114,11 @@ describe('OrganizationalUnitController - List', function () {
         $response = getJson('/v1/organizational-units');
 
         $response->assertOk()
-            ->assertJsonPath('data.0.is_legal_entity', true)
-            ->assertJsonPath('data.0.is_establishment', false);
+            ->assertJsonFragment([
+                'id' => $this->rootUnit->id,
+                'is_legal_entity' => true,
+                'is_establishment' => false,
+            ]);
     });
 
     test('list organizational units respects pagination', function () {
@@ -314,7 +317,9 @@ describe('OrganizationalUnitController - Create', function () {
             'is_legal_entity' => 'true',
             'is_establishment' => 1,
         ])->assertUnprocessable()
-            ->assertJsonValidationErrors(['is_legal_entity', 'is_establishment']);
+            ->assertJsonValidationErrors(['is_legal_entity', 'is_establishment'])
+            ->assertJsonPath('errors.is_legal_entity.0', 'The is_legal_entity field must be a JSON boolean (true or false).')
+            ->assertJsonPath('errors.is_establishment.0', 'The is_establishment field must be a JSON boolean (true or false).');
     });
 
     test('user can create organizational unit with parent', function () {
@@ -846,7 +851,9 @@ describe('OrganizationalUnitController - Update', function () {
             'is_legal_entity' => 'false',
             'is_establishment' => 0,
         ])->assertUnprocessable()
-            ->assertJsonValidationErrors(['is_legal_entity', 'is_establishment']);
+            ->assertJsonValidationErrors(['is_legal_entity', 'is_establishment'])
+            ->assertJsonPath('errors.is_legal_entity.0', 'The is_legal_entity field must be a JSON boolean (true or false).')
+            ->assertJsonPath('errors.is_establishment.0', 'The is_establishment field must be a JSON boolean (true or false).');
     });
 });
 

--- a/tests/Feature/Migrations/CreateOrganizationalUnitsTableTest.php
+++ b/tests/Feature/Migrations/CreateOrganizationalUnitsTableTest.php
@@ -34,6 +34,8 @@ describe('CreateOrganizationalUnitsTable Migration', function () {
         expect(Schema::hasColumn('organizational_units', 'custom_type_name'))->toBeTrue();
         expect(Schema::hasColumn('organizational_units', 'description'))->toBeTrue();
         expect(Schema::hasColumn('organizational_units', 'metadata'))->toBeTrue();
+        expect(Schema::hasColumn('organizational_units', 'is_legal_entity'))->toBeTrue();
+        expect(Schema::hasColumn('organizational_units', 'is_establishment'))->toBeTrue();
         expect(Schema::hasColumn('organizational_units', 'created_at'))->toBeTrue();
         expect(Schema::hasColumn('organizational_units', 'updated_at'))->toBeTrue();
         expect(Schema::hasColumn('organizational_units', 'deleted_at'))->toBeTrue();
@@ -46,6 +48,46 @@ describe('CreateOrganizationalUnitsTable Migration', function () {
         expect($indexColumns)->toContain('tenant_id');
         expect($indexColumns)->toContain('type');
         expect($indexColumns)->toContain('deleted_at');
+        expect($indexColumns)->not->toContain('is_legal_entity');
+        expect($indexColumns)->not->toContain('is_establishment');
+    });
+
+    test('organizational status flag columns are required booleans with false defaults', function (): void {
+        $columns = collect(Schema::getColumns('organizational_units'))->keyBy('name');
+
+        expect($columns->get('is_legal_entity'))->not->toBeNull()
+            ->and($columns->get('is_legal_entity')['nullable'])->toBeFalse()
+            ->and($columns->get('is_legal_entity')['default'])->toBeIn([false, 'false', 0, '0'])
+            ->and($columns->get('is_establishment'))->not->toBeNull()
+            ->and($columns->get('is_establishment')['nullable'])->toBeFalse()
+            ->and($columns->get('is_establishment')['default'])->toBeIn([false, 'false', 0, '0']);
+    });
+
+    test('status flag migration assigns false to existing organizational units', function (): void {
+        $keys = TenantKey::generateEnvelopeKeys();
+        $tenant = TenantKey::create($keys);
+        $unitId = Str::uuid()->toString();
+
+        Schema::table('organizational_units', function ($table): void {
+            $table->dropColumn(['is_legal_entity', 'is_establishment']);
+        });
+
+        DB::table('organizational_units')->insert([
+            'id' => $unitId,
+            'tenant_id' => $tenant->id,
+            'name' => 'Existing Unit',
+            'type' => 'company',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $migration = require database_path('migrations/2026_07_10_000000_add_status_flags_to_organizational_units_table.php');
+        $migration->up();
+
+        $unit = DB::table('organizational_units')->where('id', $unitId)->first();
+
+        expect((bool) $unit->is_legal_entity)->toBeFalse()
+            ->and((bool) $unit->is_establishment)->toBeFalse();
     });
 
     test('type column accepts valid enum values', function (): void {

--- a/tests/Feature/Migrations/CreateOrganizationalUnitsTableTest.php
+++ b/tests/Feature/Migrations/CreateOrganizationalUnitsTableTest.php
@@ -1,6 +1,6 @@
 <?php
 
-// SPDX-FileCopyrightText: 2025 SecPal Contributors
+// SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 

--- a/tests/Feature/Models/OrganizationalUnitTest.php
+++ b/tests/Feature/Models/OrganizationalUnitTest.php
@@ -36,10 +36,14 @@ describe('OrganizationalUnit Model', function () {
             ]);
 
             expect($unit)->toBeInstanceOf(OrganizationalUnit::class);
+            $unit->refresh();
+
             expect($unit->id)->toBeString();
             expect($unit->name)->toBe('ProSec Nord GmbH');
             expect($unit->type)->toBe('company');
             expect($unit->tenant_id)->toBe($this->tenant->id);
+            expect($unit->is_legal_entity)->toBeFalse();
+            expect($unit->is_establishment)->toBeFalse();
         });
 
         it('uses UUID for primary key', function (): void {
@@ -72,6 +76,38 @@ describe('OrganizationalUnit Model', function () {
             expect($unit->custom_type_name)->toBe('Einsatzgebiet');
             expect($unit->description)->toBe('A custom organizational unit type');
             expect($unit->metadata)->toBe($metadata);
+        });
+
+        it('mass assigns and casts independent legal status flags', function (): void {
+            $unit = OrganizationalUnit::create([
+                'tenant_id' => $this->tenant->id,
+                'name' => 'Status Unit',
+                'type' => 'company',
+                'is_legal_entity' => 1,
+                'is_establishment' => 0,
+            ]);
+
+            $unit->refresh();
+
+            expect($unit->is_legal_entity)->toBeTrue()
+                ->and($unit->is_establishment)->toBeFalse();
+
+            $unit->update([
+                'is_legal_entity' => false,
+                'is_establishment' => true,
+            ]);
+
+            $unit->refresh();
+
+            expect($unit->is_legal_entity)->toBeFalse()
+                ->and($unit->is_establishment)->toBeTrue();
+        });
+
+        it('factory uses stable false defaults for independent legal status flags', function (): void {
+            $unit = OrganizationalUnit::factory()->forTenant((string) $this->tenant->id)->create();
+
+            expect($unit->is_legal_entity)->toBeFalse()
+                ->and($unit->is_establishment)->toBeFalse();
         });
 
         it('casts metadata to array', function (): void {

--- a/tests/Feature/Seeders/OnboardingDemoUserSeederTest.php
+++ b/tests/Feature/Seeders/OnboardingDemoUserSeederTest.php
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\Employee;
+use App\Models\OrganizationalUnit;
 use App\Models\TenantKey;
 use App\Models\User;
 use Database\Seeders\DatabaseSeeder;
@@ -27,6 +28,17 @@ beforeEach(function (): void {
 afterEach(function (): void {
     cleanupTestKekFile();
     TenantKey::setKekPath(null);
+});
+
+test('OrganizationalUnitSeeder marks SecPal Holding as a legal entity and establishment', function (): void {
+    artisan('db:seed', ['--class' => OrganizationalUnitSeeder::class]);
+
+    $holding = OrganizationalUnit::query()
+        ->where('name', 'SecPal Holding')
+        ->firstOrFail();
+
+    expect($holding->is_legal_entity)->toBeTrue()
+        ->and($holding->is_establishment)->toBeTrue();
 });
 
 test('OnboardingDemoUserSeeder creates pre-contract employee at SecPal Holding', function (): void {

--- a/tests/Feature/Seeders/OnboardingDemoUserSeederTest.php
+++ b/tests/Feature/Seeders/OnboardingDemoUserSeederTest.php
@@ -41,6 +41,26 @@ test('OrganizationalUnitSeeder marks SecPal Holding as a legal entity and establ
         ->and($holding->is_establishment)->toBeTrue();
 });
 
+test('OrganizationalUnitSeeder repairs status flags on an existing SecPal Holding', function (): void {
+    artisan('db:seed', ['--class' => OrganizationalUnitSeeder::class]);
+
+    $holding = OrganizationalUnit::query()
+        ->where('name', 'SecPal Holding')
+        ->firstOrFail();
+
+    $holding->update([
+        'is_legal_entity' => false,
+        'is_establishment' => false,
+    ]);
+
+    artisan('db:seed', ['--class' => OrganizationalUnitSeeder::class]);
+
+    $holding->refresh();
+
+    expect($holding->is_legal_entity)->toBeTrue()
+        ->and($holding->is_establishment)->toBeTrue();
+});
+
 test('OnboardingDemoUserSeeder creates pre-contract employee at SecPal Holding', function (): void {
     artisan('db:seed', ['--class' => OrganizationalUnitSeeder::class]);
     artisan('db:seed', ['--class' => OnboardingDemoUserSeeder::class]);


### PR DESCRIPTION
## Reproduction

The focused organizational-unit seeder test initially failed because a newly created `SecPal Holding` inherited the database defaults of `false` for both legal-status flags.

## Summary

- Persist independent `is_legal_entity` and `is_establishment` flags for organizational units with additive database defaults of `false`.
- Validate both request fields as strict JSON booleans and return them from all organizational-unit resource responses.
- Seed a newly created `SecPal Holding` as both a legal entity and an establishment.
- Cover migration, model, controller, and seeder behavior with focused Pest tests.

Closes #1259.

## Validation

- `php artisan test tests/Feature/Migrations/CreateOrganizationalUnitsTableTest.php tests/Feature/Models/OrganizationalUnitTest.php tests/Feature/Controllers/Api/V1/OrganizationalUnitControllerTest.php tests/Feature/Seeders/OnboardingDemoUserSeederTest.php`
- `vendor/bin/pint --dirty`
- `reuse lint`
- `git diff --check`
- Push preflight: Prettier, markdownlint, REUSE, domain policy, Pint, and PHPStan

## Follow-up

No unresolved checks remain in this repository. The related contract and frontend work remains tracked in SecPal/contracts#338 and SecPal/frontend#1361; coordinate review and merge of those repository-specific changes before an end-to-end release.
