### PR TITLE
Add organizational-unit status flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- added independent organizational-unit `is_active` and `is_assignable` API flags with true defaults, strict boolean create/update validation, independent list filtering, persistence, and resource serialization (refs `api#1264`)
 - added independent organizational-unit `is_legal_entity` and `is_establishment` API flags with false defaults, strict boolean create/update validation, persistence, resource serialization, and focused Pest coverage (refs `api#1259`)
 - added the SecPal AGPL attribution additional terms in `LICENSES/LicenseRef-SecPal-Attribution.txt`, updated project-owned AGPL SPDX metadata to `AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution`, standardized touched AGPL copyright headers to `SecPal Contributors`, and documented the section 7(b)/(c) attribution requirements in the licensing/contributor guides (refs `api#1219`)
 - added a public unauthenticated `GET /v1/release` endpoint that returns only the currently deployed API release version plus immutable corresponding-source URL, so the frontend can identify the active backend release without widening the existing AGPL/source-offer metadata surface

--- a/app/Http/Controllers/Api/V1/OrganizationalUnitController.php
+++ b/app/Http/Controllers/Api/V1/OrganizationalUnitController.php
@@ -60,7 +60,7 @@ class OrganizationalUnitController extends Controller
     {
         $this->authorize('viewAny', OrganizationalUnit::class);
 
-        /** @var array{parent_id?: string, type?: string, is_active?: string, is_assignable?: string} $validated */
+        /** @var array{parent_id?: string|null, type?: string|null, is_active?: string|null, is_assignable?: string|null} $validated */
         $validated = $request->validated();
 
         /** @var User $user */

--- a/app/Http/Controllers/Api/V1/OrganizationalUnitController.php
+++ b/app/Http/Controllers/Api/V1/OrganizationalUnitController.php
@@ -60,7 +60,7 @@ class OrganizationalUnitController extends Controller
     {
         $this->authorize('viewAny', OrganizationalUnit::class);
 
-        /** @var array{parent_id?: string, type?: string} $validated */
+        /** @var array{parent_id?: string, type?: string, is_active?: string, is_assignable?: string} $validated */
         $validated = $request->validated();
 
         /** @var User $user */
@@ -85,6 +85,14 @@ class OrganizationalUnitController extends Controller
         // Filter by type if provided
         if (array_key_exists('type', $validated) && $validated['type'] !== null) {
             $query->where('type', $validated['type']);
+        }
+
+        if (array_key_exists('is_active', $validated) && $validated['is_active'] !== null) {
+            $query->where('is_active', $request->boolean('is_active'));
+        }
+
+        if (array_key_exists('is_assignable', $validated) && $validated['is_assignable'] !== null) {
+            $query->where('is_assignable', $request->boolean('is_assignable'));
         }
 
         // Filter by parent_id if provided
@@ -189,7 +197,7 @@ class OrganizationalUnitController extends Controller
             $this->authorize('createRoot', OrganizationalUnit::class);
         }
 
-        /** @var array{name: string, type: string, custom_type_name?: string|null, description?: string|null, metadata?: array<mixed>|null, is_legal_entity?: bool, is_establishment?: bool, parent_id?: string|null} $validated */
+        /** @var array{name: string, type: string, custom_type_name?: string|null, description?: string|null, metadata?: array<mixed>|null, is_legal_entity?: bool, is_establishment?: bool, is_active?: bool, is_assignable?: bool, parent_id?: string|null} $validated */
         $validated = $request->validated();
 
         $unit = OrganizationalUnit::create([
@@ -201,6 +209,8 @@ class OrganizationalUnitController extends Controller
             'metadata' => $validated['metadata'] ?? null,
             'is_legal_entity' => $validated['is_legal_entity'] ?? false,
             'is_establishment' => $validated['is_establishment'] ?? false,
+            'is_active' => $validated['is_active'] ?? true,
+            'is_assignable' => $validated['is_assignable'] ?? true,
         ]);
 
         // Attach parent if specified
@@ -243,7 +253,7 @@ class OrganizationalUnitController extends Controller
     {
         $this->authorize('update', $organizational_unit);
 
-        /** @var array{name?: string, type?: string, custom_type_name?: string|null, description?: string|null, metadata?: array<mixed>|null, is_legal_entity?: bool, is_establishment?: bool} $validated */
+        /** @var array{name?: string, type?: string, custom_type_name?: string|null, description?: string|null, metadata?: array<mixed>|null, is_legal_entity?: bool, is_establishment?: bool, is_active?: bool, is_assignable?: bool} $validated */
         $validated = $request->validated();
 
         $organizational_unit->update($validated);

--- a/app/Http/Controllers/Api/V1/OrganizationalUnitController.php
+++ b/app/Http/Controllers/Api/V1/OrganizationalUnitController.php
@@ -60,7 +60,7 @@ class OrganizationalUnitController extends Controller
     {
         $this->authorize('viewAny', OrganizationalUnit::class);
 
-        /** @var array{parent_id?: string|null, type?: string|null, is_active?: string|null, is_assignable?: string|null} $validated */
+        /** @var array{parent_id?: string|null, type?: string|null, is_active?: bool|string|null, is_assignable?: bool|string|null} $validated */
         $validated = $request->validated();
 
         /** @var User $user */

--- a/app/Http/Requests/Api/IndexOrganizationalUnitRequest.php
+++ b/app/Http/Requests/Api/IndexOrganizationalUnitRequest.php
@@ -30,8 +30,8 @@ class IndexOrganizationalUnitRequest extends FormRequest
         return [
             'per_page' => ['nullable', 'integer', 'min:1', 'max:100'],
             'type' => ['nullable', 'string', Rule::in(['holding', 'company', 'region', 'branch', 'division', 'department', 'custom'])],
-            'is_active' => ['nullable', $this->queryBooleanRule()],
-            'is_assignable' => ['nullable', $this->queryBooleanRule()],
+            'is_active' => ['nullable', 'boolean'],
+            'is_assignable' => ['nullable', 'boolean'],
             'parent_id' => [
                 'nullable',
                 'string',
@@ -54,14 +54,5 @@ class IndexOrganizationalUnitRequest extends FormRequest
         return [
             'per_page.max' => 'Maximum 100 items per page.',
         ];
-    }
-
-    private function queryBooleanRule(): \Closure
-    {
-        return function (string $attribute, mixed $value, \Closure $fail): void {
-            if ($value !== 'true' && $value !== 'false') {
-                $fail("The {$attribute} field must be true or false.");
-            }
-        };
     }
 }

--- a/app/Http/Requests/Api/IndexOrganizationalUnitRequest.php
+++ b/app/Http/Requests/Api/IndexOrganizationalUnitRequest.php
@@ -30,6 +30,8 @@ class IndexOrganizationalUnitRequest extends FormRequest
         return [
             'per_page' => ['nullable', 'integer', 'min:1', 'max:100'],
             'type' => ['nullable', 'string', Rule::in(['holding', 'company', 'region', 'branch', 'division', 'department', 'custom'])],
+            'is_active' => ['nullable', $this->queryBooleanRule()],
+            'is_assignable' => ['nullable', $this->queryBooleanRule()],
             'parent_id' => [
                 'nullable',
                 'string',
@@ -52,5 +54,14 @@ class IndexOrganizationalUnitRequest extends FormRequest
         return [
             'per_page.max' => 'Maximum 100 items per page.',
         ];
+    }
+
+    private function queryBooleanRule(): \Closure
+    {
+        return function (string $attribute, mixed $value, \Closure $fail): void {
+            if ($value !== 'true' && $value !== 'false') {
+                $fail("The {$attribute} field must be true or false.");
+            }
+        };
     }
 }

--- a/app/Http/Requests/Api/StoreOrganizationalUnitRequest.php
+++ b/app/Http/Requests/Api/StoreOrganizationalUnitRequest.php
@@ -78,6 +78,8 @@ class StoreOrganizationalUnitRequest extends FormRequest
             'metadata' => ['nullable', 'array'],
             'is_legal_entity' => ['sometimes', $this->strictBooleanRule()],
             'is_establishment' => ['sometimes', $this->strictBooleanRule()],
+            'is_active' => ['sometimes', $this->strictBooleanRule()],
+            'is_assignable' => ['sometimes', $this->strictBooleanRule()],
             'parent_id' => ['nullable', 'uuid', Rule::exists(OrganizationalUnit::class, 'id')],
         ];
     }

--- a/app/Http/Requests/Api/UpdateOrganizationalUnitRequest.php
+++ b/app/Http/Requests/Api/UpdateOrganizationalUnitRequest.php
@@ -53,6 +53,8 @@ class UpdateOrganizationalUnitRequest extends FormRequest
             'metadata' => ['nullable', 'array'],
             'is_legal_entity' => ['sometimes', $this->strictBooleanRule()],
             'is_establishment' => ['sometimes', $this->strictBooleanRule()],
+            'is_active' => ['sometimes', $this->strictBooleanRule()],
+            'is_assignable' => ['sometimes', $this->strictBooleanRule()],
         ];
     }
 

--- a/app/Http/Resources/OrganizationalUnitResource.php
+++ b/app/Http/Resources/OrganizationalUnitResource.php
@@ -38,6 +38,8 @@ class OrganizationalUnitResource extends JsonResource
             'metadata' => $this->metadata,
             'is_legal_entity' => $this->is_legal_entity,
             'is_establishment' => $this->is_establishment,
+            'is_active' => $this->is_active,
+            'is_assignable' => $this->is_assignable,
             'parent' => $this->transformParent($request),
             'permissions' => $this->resolvePermissions($request),
             'children' => OrganizationalUnitResource::collection($this->whenLoaded('children')),

--- a/app/Models/OrganizationalUnit.php
+++ b/app/Models/OrganizationalUnit.php
@@ -40,6 +40,8 @@ use Illuminate\Support\Facades\DB;
  * @property array<string, mixed>|null $metadata JSON metadata (address, phone, etc.)
  * @property bool $is_legal_entity Independent legal-person status; not derived from hierarchy type
  * @property bool $is_establishment Independent establishment status; not derived from hierarchy type
+ * @property bool $is_active Independent administrative status
+ * @property bool $is_assignable Independent eligibility for new operational assignments and scopes
  * @property \Illuminate\Support\Carbon $created_at
  * @property \Illuminate\Support\Carbon $updated_at
  * @property \Illuminate\Support\Carbon|null $deleted_at
@@ -78,6 +80,8 @@ class OrganizationalUnit extends Model
         'metadata',
         'is_legal_entity',
         'is_establishment',
+        'is_active',
+        'is_assignable',
     ];
 
     /**
@@ -92,6 +96,8 @@ class OrganizationalUnit extends Model
             'metadata' => 'array',
             'is_legal_entity' => 'boolean',
             'is_establishment' => 'boolean',
+            'is_active' => 'boolean',
+            'is_assignable' => 'boolean',
             'created_at' => 'datetime',
             'updated_at' => 'datetime',
             'deleted_at' => 'datetime',

--- a/database/factories/OrganizationalUnitFactory.php
+++ b/database/factories/OrganizationalUnitFactory.php
@@ -48,6 +48,8 @@ class OrganizationalUnitFactory extends Factory
             'metadata' => null,
             'is_legal_entity' => false,
             'is_establishment' => false,
+            'is_active' => true,
+            'is_assignable' => true,
         ];
     }
 

--- a/database/migrations/2026_07_11_000000_add_operational_status_flags_to_organizational_units_table.php
+++ b/database/migrations/2026_07_11_000000_add_operational_status_flags_to_organizational_units_table.php
@@ -1,0 +1,32 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('organizational_units', function (Blueprint $table): void {
+            $table->boolean('is_active')->default(true);
+            $table->boolean('is_assignable')->default(true);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('organizational_units', function (Blueprint $table): void {
+            $table->dropColumn(['is_active', 'is_assignable']);
+        });
+    }
+};

--- a/tests/Feature/Controllers/Api/V1/OrganizationalUnitControllerTest.php
+++ b/tests/Feature/Controllers/Api/V1/OrganizationalUnitControllerTest.php
@@ -145,6 +145,19 @@ describe('OrganizationalUnitController - List', function () {
             ->assertOk()
             ->assertJsonCount(1, 'data')
             ->assertJsonPath('data.0.id', $activeUnassignable->id);
+
+        getJson('/v1/organizational-units?is_active=false&is_assignable=true')
+            ->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.id', $inactiveAssignable->id);
+    });
+
+    test('list organizational units rejects non-boolean status filters', function () {
+        getJson('/v1/organizational-units?is_active=1&is_assignable=0')
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors(['is_active', 'is_assignable'])
+            ->assertJsonPath('errors.is_active.0', 'The is_active field must be true or false.')
+            ->assertJsonPath('errors.is_assignable.0', 'The is_assignable field must be true or false.');
     });
 
     test('list organizational units respects pagination', function () {

--- a/tests/Feature/Controllers/Api/V1/OrganizationalUnitControllerTest.php
+++ b/tests/Feature/Controllers/Api/V1/OrganizationalUnitControllerTest.php
@@ -98,7 +98,7 @@ describe('OrganizationalUnitController - List', function () {
         $response->assertOk()
             ->assertJsonStructure([
                 'data' => [
-                    '*' => ['id', 'name', 'type', 'is_legal_entity', 'is_establishment', 'created_at', 'updated_at'],
+                    '*' => ['id', 'name', 'type', 'is_legal_entity', 'is_establishment', 'is_active', 'is_assignable', 'created_at', 'updated_at'],
                 ],
                 'meta' => ['current_page', 'last_page', 'per_page', 'total', 'root_unit_ids'],
             ])
@@ -119,6 +119,32 @@ describe('OrganizationalUnitController - List', function () {
                 'is_legal_entity' => true,
                 'is_establishment' => false,
             ]);
+    });
+
+    test('list organizational units filters independent status flags', function () {
+        $inactiveAssignable = OrganizationalUnit::factory()->create([
+            'tenant_id' => $this->tenant->id,
+            'is_active' => false,
+            'is_assignable' => true,
+        ]);
+        $inactiveAssignable->setParent($this->rootUnit);
+
+        $activeUnassignable = OrganizationalUnit::factory()->create([
+            'tenant_id' => $this->tenant->id,
+            'is_active' => true,
+            'is_assignable' => false,
+        ]);
+        $activeUnassignable->setParent($this->rootUnit);
+
+        getJson('/v1/organizational-units?is_active=false')
+            ->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.id', $inactiveAssignable->id);
+
+        getJson('/v1/organizational-units?is_assignable=false')
+            ->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.id', $activeUnassignable->id);
     });
 
     test('list organizational units respects pagination', function () {
@@ -275,7 +301,9 @@ describe('OrganizationalUnitController - Create', function () {
             ->assertJsonPath('data.type', 'department')
             ->assertJsonPath('data.description', 'A new department')
             ->assertJsonPath('data.is_legal_entity', false)
-            ->assertJsonPath('data.is_establishment', false);
+            ->assertJsonPath('data.is_establishment', false)
+            ->assertJsonPath('data.is_active', true)
+            ->assertJsonPath('data.is_assignable', true);
 
         $this->assertDatabaseHas('organizational_units', [
             'name' => 'New Department',
@@ -283,6 +311,8 @@ describe('OrganizationalUnitController - Create', function () {
             'tenant_id' => $this->tenant->id,
             'is_legal_entity' => false,
             'is_establishment' => false,
+            'is_active' => true,
+            'is_assignable' => true,
         ]);
     });
 
@@ -320,6 +350,40 @@ describe('OrganizationalUnitController - Create', function () {
             ->assertJsonValidationErrors(['is_legal_entity', 'is_establishment'])
             ->assertJsonPath('errors.is_legal_entity.0', 'The is_legal_entity field must be a JSON boolean (true or false).')
             ->assertJsonPath('errors.is_establishment.0', 'The is_establishment field must be a JSON boolean (true or false).');
+    });
+
+    test('create accepts all independent operational status flag combinations', function (bool $isActive, bool $isAssignable) {
+        $response = postJson('/v1/organizational-units', [
+            'name' => sprintf('Operational Status Unit %s %s', $isActive ? 'active' : 'inactive', $isAssignable ? 'assignable' : 'unassignable'),
+            'type' => 'department',
+            'is_active' => $isActive,
+            'is_assignable' => $isAssignable,
+        ]);
+
+        $response->assertCreated()
+            ->assertJsonPath('data.is_active', $isActive)
+            ->assertJsonPath('data.is_assignable', $isAssignable);
+
+        $this->assertDatabaseHas('organizational_units', [
+            'id' => $response->json('data.id'),
+            'is_active' => $isActive,
+            'is_assignable' => $isAssignable,
+        ]);
+    })->with([
+        'inactive and unassignable' => [false, false],
+        'active only' => [true, false],
+        'assignable only' => [false, true],
+        'active and assignable' => [true, true],
+    ]);
+
+    test('create strictly validates operational status flags as booleans', function () {
+        postJson('/v1/organizational-units', [
+            'name' => 'Invalid Operational Status Unit',
+            'type' => 'department',
+            'is_active' => 'true',
+            'is_assignable' => 1,
+        ])->assertUnprocessable()
+            ->assertJsonValidationErrors(['is_active', 'is_assignable']);
     });
 
     test('user can create organizational unit with parent', function () {
@@ -738,7 +802,9 @@ describe('OrganizationalUnitController - Show', function () {
             ->assertJsonPath('data.id', $this->rootUnit->id)
             ->assertJsonPath('data.name', 'Root Company')
             ->assertJsonPath('data.is_legal_entity', false)
-            ->assertJsonPath('data.is_establishment', false);
+            ->assertJsonPath('data.is_establishment', false)
+            ->assertJsonPath('data.is_active', true)
+            ->assertJsonPath('data.is_assignable', true);
     });
 
     test('show response exposes action permissions and accessible parent data', function () {
@@ -911,6 +977,33 @@ describe('OrganizationalUnitController - Update', function () {
             ->assertJsonValidationErrors(['is_legal_entity', 'is_establishment'])
             ->assertJsonPath('errors.is_legal_entity.0', 'The is_legal_entity field must be a JSON boolean (true or false).')
             ->assertJsonPath('errors.is_establishment.0', 'The is_establishment field must be a JSON boolean (true or false).');
+    });
+
+    test('patch accepts all independent operational status flag combinations', function (bool $isActive, bool $isAssignable) {
+        patchJson("/v1/organizational-units/{$this->rootUnit->id}", [
+            'is_active' => $isActive,
+            'is_assignable' => $isAssignable,
+        ])->assertOk()
+            ->assertJsonPath('data.is_active', $isActive)
+            ->assertJsonPath('data.is_assignable', $isAssignable);
+
+        $this->rootUnit->refresh();
+
+        expect($this->rootUnit->is_active)->toBe($isActive)
+            ->and($this->rootUnit->is_assignable)->toBe($isAssignable);
+    })->with([
+        'inactive and unassignable' => [false, false],
+        'active only' => [true, false],
+        'assignable only' => [false, true],
+        'active and assignable' => [true, true],
+    ]);
+
+    test('patch strictly validates operational status flags as booleans', function () {
+        patchJson("/v1/organizational-units/{$this->rootUnit->id}", [
+            'is_active' => 'false',
+            'is_assignable' => 0,
+        ])->assertUnprocessable()
+            ->assertJsonValidationErrors(['is_active', 'is_assignable']);
     });
 });
 
@@ -1301,6 +1394,8 @@ describe('OrganizationalUnitController - Hierarchy', function () {
             'tenant_id' => $this->tenant->id,
             'name' => 'Child Unit',
             'type' => 'department',
+            'is_active' => false,
+            'is_assignable' => true,
         ]);
         $child->setParent($this->rootUnit);
 
@@ -1316,11 +1411,21 @@ describe('OrganizationalUnitController - Hierarchy', function () {
 
         // Assert
         $response->assertOk()
-            ->assertJsonCount(2, 'data');
+            ->assertJsonCount(2, 'data')
+            ->assertJsonFragment([
+                'id' => $child->id,
+                'is_active' => false,
+                'is_assignable' => true,
+            ]);
     });
 
     test('user can get ancestors of unit', function () {
         // Arrange: Create hierarchy
+        $this->rootUnit->update([
+            'is_active' => true,
+            'is_assignable' => false,
+        ]);
+
         $child = OrganizationalUnit::factory()->create([
             'tenant_id' => $this->tenant->id,
             'name' => 'Child Unit',
@@ -1334,7 +1439,9 @@ describe('OrganizationalUnitController - Hierarchy', function () {
         // Assert
         $response->assertOk()
             ->assertJsonCount(1, 'data')
-            ->assertJsonPath('data.0.id', $this->rootUnit->id);
+            ->assertJsonPath('data.0.id', $this->rootUnit->id)
+            ->assertJsonPath('data.0.is_active', true)
+            ->assertJsonPath('data.0.is_assignable', false);
     });
 
     test('user can attach parent to unit', function () {

--- a/tests/Feature/Controllers/Api/V1/OrganizationalUnitControllerTest.php
+++ b/tests/Feature/Controllers/Api/V1/OrganizationalUnitControllerTest.php
@@ -136,28 +136,26 @@ describe('OrganizationalUnitController - List', function () {
         ]);
         $activeUnassignable->setParent($this->rootUnit);
 
-        getJson('/v1/organizational-units?is_active=false')
+        getJson('/v1/organizational-units?is_active=0')
             ->assertOk()
             ->assertJsonCount(1, 'data')
             ->assertJsonPath('data.0.id', $inactiveAssignable->id);
 
-        getJson('/v1/organizational-units?is_assignable=false')
+        getJson('/v1/organizational-units?is_assignable=0')
             ->assertOk()
             ->assertJsonCount(1, 'data')
             ->assertJsonPath('data.0.id', $activeUnassignable->id);
 
-        getJson('/v1/organizational-units?is_active=false&is_assignable=true')
+        getJson('/v1/organizational-units?is_active=0&is_assignable=1')
             ->assertOk()
             ->assertJsonCount(1, 'data')
             ->assertJsonPath('data.0.id', $inactiveAssignable->id);
     });
 
     test('list organizational units rejects non-boolean status filters', function () {
-        getJson('/v1/organizational-units?is_active=1&is_assignable=0')
+        getJson('/v1/organizational-units?is_active=not-a-boolean&is_assignable=not-a-boolean')
             ->assertUnprocessable()
-            ->assertJsonValidationErrors(['is_active', 'is_assignable'])
-            ->assertJsonPath('errors.is_active.0', 'The is_active field must be true or false.')
-            ->assertJsonPath('errors.is_assignable.0', 'The is_assignable field must be true or false.');
+            ->assertJsonValidationErrors(['is_active', 'is_assignable']);
     });
 
     test('list organizational units respects pagination', function () {

--- a/tests/Feature/Migrations/CreateOrganizationalUnitsTableTest.php
+++ b/tests/Feature/Migrations/CreateOrganizationalUnitsTableTest.php
@@ -36,6 +36,8 @@ describe('CreateOrganizationalUnitsTable Migration', function () {
         expect(Schema::hasColumn('organizational_units', 'metadata'))->toBeTrue();
         expect(Schema::hasColumn('organizational_units', 'is_legal_entity'))->toBeTrue();
         expect(Schema::hasColumn('organizational_units', 'is_establishment'))->toBeTrue();
+        expect(Schema::hasColumn('organizational_units', 'is_active'))->toBeTrue();
+        expect(Schema::hasColumn('organizational_units', 'is_assignable'))->toBeTrue();
         expect(Schema::hasColumn('organizational_units', 'created_at'))->toBeTrue();
         expect(Schema::hasColumn('organizational_units', 'updated_at'))->toBeTrue();
         expect(Schema::hasColumn('organizational_units', 'deleted_at'))->toBeTrue();
@@ -63,6 +65,17 @@ describe('CreateOrganizationalUnitsTable Migration', function () {
             ->and($columns->get('is_establishment')['default'])->toBeIn([false, 'false', 0, '0']);
     });
 
+    test('operational status flag columns are required booleans with true defaults', function (): void {
+        $columns = collect(Schema::getColumns('organizational_units'))->keyBy('name');
+
+        expect($columns->get('is_active'))->not->toBeNull()
+            ->and($columns->get('is_active')['nullable'])->toBeFalse()
+            ->and($columns->get('is_active')['default'])->toBeIn([true, 'true', 1, '1'])
+            ->and($columns->get('is_assignable'))->not->toBeNull()
+            ->and($columns->get('is_assignable')['nullable'])->toBeFalse()
+            ->and($columns->get('is_assignable')['default'])->toBeIn([true, 'true', 1, '1']);
+    });
+
     test('status flag migration assigns false to existing organizational units', function (): void {
         $keys = TenantKey::generateEnvelopeKeys();
         $tenant = TenantKey::create($keys);
@@ -88,6 +101,35 @@ describe('CreateOrganizationalUnitsTable Migration', function () {
 
         expect((bool) $unit->is_legal_entity)->toBeFalse()
             ->and((bool) $unit->is_establishment)->toBeFalse();
+    });
+
+    test('operational status flag migration assigns true to existing organizational units', function (): void {
+        $keys = TenantKey::generateEnvelopeKeys();
+        $tenant = TenantKey::create($keys);
+        $unitId = Str::uuid()->toString();
+
+        Schema::table('organizational_units', function ($table): void {
+            $table->dropColumn(['is_active', 'is_assignable']);
+        });
+
+        DB::table('organizational_units')->insert([
+            'id' => $unitId,
+            'tenant_id' => $tenant->id,
+            'name' => 'Existing Operational Unit',
+            'type' => 'company',
+            'is_legal_entity' => false,
+            'is_establishment' => false,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $migration = require database_path('migrations/2026_07_11_000000_add_operational_status_flags_to_organizational_units_table.php');
+        $migration->up();
+
+        $unit = DB::table('organizational_units')->where('id', $unitId)->first();
+
+        expect((bool) $unit->is_active)->toBeTrue()
+            ->and((bool) $unit->is_assignable)->toBeTrue();
     });
 
     test('type column accepts valid enum values', function (): void {

--- a/tests/Feature/Models/OrganizationalUnitTest.php
+++ b/tests/Feature/Models/OrganizationalUnitTest.php
@@ -110,6 +110,21 @@ describe('OrganizationalUnit Model', function () {
                 ->and($unit->is_establishment)->toBeFalse();
         });
 
+        it('mass assigns and casts independent operational status flags', function (): void {
+            $unit = OrganizationalUnit::create([
+                'tenant_id' => $this->tenant->id,
+                'name' => 'Operational Status Unit',
+                'type' => 'company',
+                'is_active' => 0,
+                'is_assignable' => 1,
+            ]);
+
+            $unit->refresh();
+
+            expect($unit->is_active)->toBeFalse()
+                ->and($unit->is_assignable)->toBeTrue();
+        });
+
         it('casts metadata to array', function (): void {
             $metadata = ['key' => 'value', 'nested' => ['a' => 1]];
 


### PR DESCRIPTION
## Evidence

The focused regression tests initially failed because `organizational_units` had no `is_active` or `is_assignable` columns, create and update ignored the submitted fields, resources omitted them, and list filtering was unavailable. The new tests now pass for all four independent flag combinations, strict JSON-boolean validation, defaults, filtering, and hierarchy responses.

## Summary

- add non-null organizational-unit status columns with `true` defaults for existing and new rows
- persist and cast `is_active` and `is_assignable` independently
- validate create and update payloads as strict JSON booleans and add independent list filters
- serialize both fields through the shared organizational-unit resource
- cover list, detail, ancestor, and descendant responses and update the changelog

## Validation

- `php artisan test tests/Feature/Controllers/Api/V1/OrganizationalUnitControllerTest.php --compact`
- `php artisan test tests/Feature/Models/OrganizationalUnitTest.php --compact`
- `vendor/bin/pint --dirty`
- `reuse lint`
- `git diff --check`

## Linked work and follow-up

- Implements `SecPal/api#1264` under epic `SecPal/api#1260` and aligns with `SecPal/contracts#338`.
- No unresolved local checks. Before marking this draft ready, CI must pass and the final self-review in the PR view must find zero issues.

Closes #1264
