### PR TITLE
Fix audit logging for soft-deleted organizational units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- allowed activity logging for same-tenant records that retain a reference to a soft-deleted organizational unit, so permitted historical record updates remain audit-safe instead of failing with a server error (fixes `api#1268`)
 - scoped the employee auto-logging regression lookup to the employee and tenant created by the test, so activity-log assertions cannot read a matching row leaked by an earlier test (fixes `api#1269`)
 - rejected new organizational scopes, effective scope expansions, employee or site placements, and site-user assignments on organizational units marked `is_assignable: false`, including access-level escalation exposed by scope-mask removal, reassignment, reactivation, future-coverage extension, and role-change attempts plus soft-deleted targets, while allowing redundant scope cleanup and fully historical assignment corrections and preserving the required creator bootstrap `manage` scope when creating an unassignable unit (fixes `api#1266`)
 - required a non-empty `custom_type_name` whenever an organizational-unit update explicitly sends `type: custom` or attempts to clear the name of an existing custom unit, matching the create and OpenAPI contracts (fixes `api#1262`)

--- a/app/Models/Activity.php
+++ b/app/Models/Activity.php
@@ -480,7 +480,7 @@ class Activity extends SpatieActivity
             );
         }
 
-        $organizationalUnit = OrganizationalUnit::query()
+        $organizationalUnit = OrganizationalUnit::withTrashed()
             ->select(['id', 'tenant_id'])
             ->find($this->organizational_unit_id);
 

--- a/tests/Unit/ActivityLog/ActivityLogTest.php
+++ b/tests/Unit/ActivityLog/ActivityLogTest.php
@@ -670,6 +670,7 @@ test('accepts a soft-deleted organizational_unit_id from the same tenant', funct
         'tenant_id' => $this->tenant->id,
     ]);
     $orgUnit->delete();
+    $this->assertSoftDeleted('organizational_units', ['id' => $orgUnit->id]);
 
     $this->actingAs($this->user);
 
@@ -716,6 +717,7 @@ test('throws exception when a soft-deleted organizational_unit_id belongs to dif
         'tenant_id' => $otherTenant->id,
     ]);
     $otherOrgUnit->delete();
+    $this->assertSoftDeleted('organizational_units', ['id' => $otherOrgUnit->id]);
 
     $this->actingAs($this->user);
 

--- a/tests/Unit/ActivityLog/ActivityLogTest.php
+++ b/tests/Unit/ActivityLog/ActivityLogTest.php
@@ -665,6 +665,24 @@ test('accepts valid organizational_unit_id from same tenant', function () {
     expect($log->organizational_unit_id)->toBe($orgUnit->id);
 })->group('security', 'issue-402');
 
+test('accepts a soft-deleted organizational_unit_id from the same tenant', function () {
+    $orgUnit = OrganizationalUnit::factory()->create([
+        'tenant_id' => $this->tenant->id,
+    ]);
+    $orgUnit->delete();
+
+    $this->actingAs($this->user);
+
+    $log = Activity::create([
+        'tenant_id' => $this->tenant->id,
+        'organizational_unit_id' => $orgUnit->id,
+        'log_name' => 'default',
+        'description' => 'Test log with deleted OU',
+    ]);
+
+    expect($log->organizational_unit_id)->toBe($orgUnit->id);
+})->group('security', 'issue-1268');
+
 test('throws exception when organizational_unit_id belongs to different tenant', function () {
     $otherTenant = TenantKey::factory()->create();
     $otherOrgUnit = OrganizationalUnit::factory()->create([

--- a/tests/Unit/ActivityLog/ActivityLogTest.php
+++ b/tests/Unit/ActivityLog/ActivityLogTest.php
@@ -710,6 +710,26 @@ test('throws exception when organizational_unit_id belongs to different tenant',
     }
 })->group('security', 'issue-402');
 
+test('throws exception when a soft-deleted organizational_unit_id belongs to different tenant', function () {
+    $otherTenant = TenantKey::factory()->create();
+    $otherOrgUnit = OrganizationalUnit::factory()->create([
+        'tenant_id' => $otherTenant->id,
+    ]);
+    $otherOrgUnit->delete();
+
+    $this->actingAs($this->user);
+
+    expect(fn () => Activity::create([
+        'tenant_id' => $this->tenant->id,
+        'organizational_unit_id' => $otherOrgUnit->id,
+        'log_name' => 'default',
+        'description' => 'Test log with deleted cross-tenant OU',
+    ]))->toThrow(
+        InvalidArgumentException::class,
+        "Organizational unit '{$otherOrgUnit->id}' belongs to tenant '{$otherTenant->id}' but activity log belongs to tenant '{$this->tenant->id}'"
+    );
+})->group('security', 'issue-1268');
+
 test('throws exception when organizational_unit_id does not exist', function () {
     $this->actingAs($this->user);
 


### PR DESCRIPTION
## Reproduced defect

The new regression test in `tests/Unit/ActivityLog/ActivityLogTest.php` first failed because an activity log referencing a soft-deleted same-tenant organizational unit threw `InvalidArgumentException` during validation.

## Change

- validate historical activity references through `OrganizationalUnit::withTrashed()` in `app/Models/Activity.php`
- retain the existing same-tenant constraint while allowing permitted updates to remain audit-safe
- add regression coverage and document the fix in `CHANGELOG.md`

Closes #1268.

## Validation

- `php artisan test --compact tests/Unit/ActivityLog/ActivityLogTest.php`
- `php artisan test --compact tests/Feature/Controllers/EmployeeControllerTest.php --filter='allows an unchanged closed organizational unit in an employee update'`
- `vendor/bin/pint --dirty`
- `reuse lint`
- `git diff --check`
- PHP syntax checks for touched PHP files
- pre-push checks, including PHPStan

## Before marking ready

- Linked workspaces: none.
- Unresolved local checks: none.
- Await CI and complete the final PR self-review before marking this draft ready.
