### PR TITLE
chore: align SecPal licensing policy

### DIFF
--- a/.ddev/web-build/Dockerfile.opentimestamps
+++ b/.ddev/web-build/Dockerfile.opentimestamps
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: 2026 SecPal
-# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends python3-pip \

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 # SPDX-License-Identifier: CC0-1.0
 
 # EditorConfig is awesome: https://EditorConfig.org

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 SecPal
+# SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 # SPDX-License-Identifier: CC0-1.0
 
 APP_NAME=SecPal

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 # SPDX-License-Identifier: CC0-1.0
 
 # Auto detect text files and perform LF normalization

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,6 @@
 <!--
-SPDX-FileCopyrightText: 2026 SecPal
-SPDX-License-Identifier: AGPL-3.0-or-later
+SPDX-FileCopyrightText: 2026 SecPal Contributors
+SPDX-License-Identifier: CC0-1.0
 -->
 
 # SecPal/api Copilot Instructions

--- a/.github/instructions/github-workflows.instructions.md
+++ b/.github/instructions/github-workflows.instructions.md
@@ -1,6 +1,6 @@
 ---
-# SPDX-FileCopyrightText: 2026 SecPal
-# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: CC0-1.0
 name: GitHub Workflow Rules
 description: Applies workflow and Dependabot rules to GitHub automation files in this repo.
 applyTo: ".github/workflows/**/*.yml,.github/workflows/**/*.yaml,.github/dependabot.yml,.github/dependabot.yaml"

--- a/.github/instructions/org-shared.instructions.md
+++ b/.github/instructions/org-shared.instructions.md
@@ -1,6 +1,6 @@
 ---
-# SPDX-FileCopyrightText: 2026 SecPal
-# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: CC0-1.0
 name: API Runtime Overlay
 description: Reinforces strict SecPal governance for all files in this repo.
 applyTo: "**"

--- a/.github/instructions/php-laravel.instructions.md
+++ b/.github/instructions/php-laravel.instructions.md
@@ -1,6 +1,6 @@
 ---
-# SPDX-FileCopyrightText: 2026 SecPal
-# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
+# SPDX-License-Identifier: CC0-1.0
 name: Laravel PHP Rules
 description: Applies Laravel, Pest, and native PHP runtime rules to PHP work in the API repository.
 applyTo: "**/*.php,artisan"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 # SPDX-License-Identifier: CC0-1.0
 
 # Dependabot Auto-Merge Workflow (API Repository)

--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 # SPDX-License-Identifier: CC0-1.0
 
 name: PR Size Check

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 SecPal
+# SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 # SPDX-License-Identifier: CC0-1.0
 
 name: Project Board Automation

--- a/.github/workflows/reusable-prettier.yml
+++ b/.github/workflows/reusable-prettier.yml
@@ -1,5 +1,5 @@
 ---
-# SPDX-FileCopyrightText: 2026 SecPal
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
 # SPDX-License-Identifier: CC0-1.0
 
 name: Reusable - Prettier (local)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: 2025 SecPal
-# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
+# SPDX-License-Identifier: CC0-1.0
 
 # Pre-commit hooks for quality checks
 # Install: pre-commit install

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: 2025 SecPal
-# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
+# SPDX-License-Identifier: CC0-1.0
 
 # Ignore files that should not be formatted
 node_modules/

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: 2025 SecPal
-# SPDX-License-Identifier: AGPL-3.0-or-later
+# SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
+# SPDX-License-Identifier: CC0-1.0
 
 extends: default
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 <!--
 SPDX-FileCopyrightText: 2026 SecPal Contributors
-SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+SPDX-License-Identifier: CC0-1.0
 -->
 
 # SecPal/api Agent Instructions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- aligned repository-owned runtime code and asset SPDX metadata with the SecPal Contributors AGPL attribution policy, returned documentation and configuration to their CC0 policy, preserved third-party notices separately, and added a license-check regression guard for attribution addendum scope (refs `api#1226`)
+- aligned repository-owned runtime code and asset SPDX metadata with the SecPal Contributors AGPL attribution policy, returned documentation and configuration to their CC0 policy, preserved third-party notices separately, and added license-check regression guards for attribution addendum scope in concluded and in-file SPDX metadata (refs `api#1226`)
 - seed the SecPal Holding organizational unit as both a legal entity and establishment, including repairing the flags when the unit already exists
 - grouped Dependabot updates for `SecPal/.github/.github/workflows/*` under stable `shared-github-workflows` identifiers in `.github/dependabot.yml`, so GitHub derives readable branch names and PR titles from the group name instead of transliterating the full reusable-workflow path into long `SecPal-dot-github-dot-...` strings
 - restored Dependabot pull request branch names to the standard hyphen-separated format in `.github/dependabot.yml`, so GitHub Actions, Composer, and npm update branches no longer expand into deep slash-separated paths like `dependabot/github_actions/main/...`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- aligned repository-owned runtime code and asset SPDX metadata with the SecPal Contributors AGPL attribution policy, returned documentation and configuration to their CC0 policy, preserved third-party notices separately, and added a license-check regression guard for attribution addendum scope (refs `api#1226`)
 - seed the SecPal Holding organizational unit as both a legal entity and establishment, including repairing the flags when the unit already exists
 - grouped Dependabot updates for `SecPal/.github/.github/workflows/*` under stable `shared-github-workflows` identifiers in `.github/dependabot.yml`, so GitHub derives readable branch names and PR titles from the group name instead of transliterating the full reusable-workflow path into long `SecPal-dot-github-dot-...` strings
 - restored Dependabot pull request branch names to the standard hyphen-separated format in `.github/dependabot.yml`, so GitHub Actions, Composer, and npm update branches no longer expand into deep slash-separated paths like `dependabot/github_actions/main/...`

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,6 +1,7 @@
 <!--
-SPDX-FileCopyrightText: 2025 SecPal Contributors
-SPDX-License-Identifier: CC0-1.0
+SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
+SPDX-FileCopyrightText: Contributor Covenant
+SPDX-License-Identifier: CC0-1.0 AND CC-BY-4.0
 -->
 
 # Contributor Covenant Code of Conduct

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,6 +1,6 @@
 <!--
 SPDX-FileCopyrightText: 2025 SecPal Contributors
-SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+SPDX-License-Identifier: CC0-1.0
 -->
 
 # Contributor Covenant Code of Conduct

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 <!--
 SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+SPDX-License-Identifier: CC0-1.0
 -->
 
 # Contributing to SecPal
@@ -414,12 +414,22 @@ All files must include SPDX license headers. **SecPal uses different licenses de
 
 ### License Selection Guide
 
-| File Type            | License                                               | Use For                                         |
-| -------------------- | ----------------------------------------------------- | ----------------------------------------------- |
-| **Application Code** | `AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution` | PHP, TypeScript, JavaScript, React components   |
-| **Configuration**    | `CC0-1.0`                                             | YAML, JSON, TOML, `.gitignore`, `.editorconfig` |
-| **Helper Scripts**   | `MIT`                                                 | Standalone bash/shell scripts, build utilities  |
-| **Documentation**    | `CC0-1.0`                                             | Markdown files (except LICENSE itself)          |
+| File Type                   | License                                               | Use For                                                                                             |
+| --------------------------- | ----------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| **Runtime code and assets** | `AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution` | Application PHP, templates, translations, routes, migrations, tests, and SecPal-owned public assets |
+| **Configuration**           | `CC0-1.0`                                             | YAML, JSON, TOML, `.gitignore`, `.editorconfig`                                                     |
+| **Helper Scripts**          | `MIT`                                                 | Standalone bash/shell scripts, build utilities                                                      |
+| **Documentation**           | `CC0-1.0`                                             | Markdown files (except LICENSE itself)                                                              |
+
+`LicenseRef-SecPal-Attribution` is an AGPL section 7(b)/(c) addendum, not a
+standalone license. Use it only for SecPal-owned AGPL code and assets, and
+always pair it exactly with `AGPL-3.0-or-later`. Do not add it to documentation,
+configuration, generated files, data, or third-party material unless that
+material has been deliberately reviewed for the addendum.
+
+Keep third-party copyright and license notices intact and separate; never
+replace them with `SecPal Contributors`. Do not add Tailwind-specific license
+terms unless this repository actually includes Tailwind-derived material.
 
 ### SPDX Header Examples
 
@@ -427,24 +437,24 @@ All files must include SPDX license headers. **SecPal uses different licenses de
 
 ```php
 <?php
-// SPDX-FileCopyrightText: 2025 SecPal Contributors
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 ```
 
 ```javascript
-// SPDX-FileCopyrightText: 2025 SecPal Contributors
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 ```
 
 ```typescript
-// SPDX-FileCopyrightText: 2025 SecPal Contributors
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 ```
 
 **For configuration files (CC0-1.0):**
 
 ```yaml
-# SPDX-FileCopyrightText: 2025 SecPal Contributors
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
 # SPDX-License-Identifier: CC0-1.0
 ```
 
@@ -452,7 +462,7 @@ All files must include SPDX license headers. **SecPal uses different licenses de
 
 ```json
 {
-  "_comment": "SPDX-FileCopyrightText: 2025 SecPal Contributors",
+  "_comment": "SPDX-FileCopyrightText: 2026 SecPal Contributors",
   "_license": "SPDX-License-Identifier: CC0-1.0"
 }
 ```
@@ -463,7 +473,7 @@ All files must include SPDX license headers. **SecPal uses different licenses de
 
 ```bash
 #!/bin/bash
-# SPDX-FileCopyrightText: 2025 SecPal Contributors
+# SPDX-FileCopyrightText: 2026 SecPal Contributors
 # SPDX-License-Identifier: MIT
 ```
 
@@ -471,7 +481,7 @@ All files must include SPDX license headers. **SecPal uses different licenses de
 
 ```markdown
 <!--
-SPDX-FileCopyrightText: 2025 SecPal Contributors
+SPDX-FileCopyrightText: 2026 SecPal Contributors
 SPDX-License-Identifier: CC0-1.0
 -->
 ```
@@ -503,7 +513,7 @@ version = 1
 [[annotations]]
 path = "assets/images/**"
 precedence = "aggregate"
-SPDX-FileCopyrightText = "2025 SecPal Contributors"
+SPDX-FileCopyrightText = "2026 SecPal Contributors"
 SPDX-License-Identifier = "CC0-1.0"
 
 # Example: Override licensing for vendor/third-party code
@@ -527,10 +537,9 @@ SPDX-License-Identifier = "SEE-LICENSE-IN-PACKAGE"
 **How to choose the correct copyright attribution:**
 
 - Use **"SecPal Contributors"** for all code files, including source code, test files, scripts, and any file where individual contributors make changes (e.g., `.js`, `.ts`, `.php`, `.py`, `.sh`, test files in any language).
-- Use **"SecPal"** for organizational documentation (e.g., `README.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`), workflow files (e.g., `.github/workflows/*.yml`), and configuration files in the root directory (e.g., `.eslintrc.yml`, `.prettierrc`, `package.json`, `composer.json`, etc.).
-- If a configuration file is specific to a code module or contains logic contributed by individuals, use **"SecPal Contributors"**.
-- For ambiguous cases, prefer **"SecPal Contributors"** if the file is likely to be edited by multiple people over time.
-- Use the **current year** in the copyright date (e.g., 2025 for files created in 2025).
+- Use **"SecPal Contributors"** for repository-owned files. Do not use **"SecPal"** alone as a copyright holder unless a documented legal rights holder requires it.
+- Preserve the original copyright and license information for third-party, generated, data-specific, or otherwise separately licensed material.
+- Use the current year for a new file (for example, `2026`). Use an inclusive range ending in the current year only after the file has been changed across multiple years (for example, `2025-2026`).
 
 Run `reuse lint` to check compliance.
 
@@ -544,6 +553,15 @@ If you have questions or need help:
 
 ## License
 
-By contributing to SecPal, you agree that your contributions will be licensed under `AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution`; see [AGPL-3.0-or-later](https://spdx.org/licenses/AGPL-3.0-or-later.html) and [LICENSES/LicenseRef-SecPal-Attribution.txt](LICENSES/LicenseRef-SecPal-Attribution.txt).
+Before a contribution can be merged, sign the canonical [SecPal Contributor
+License Agreement](https://github.com/SecPal/.github/blob/main/CLA.md).
+Contributors retain copyright in their work and grant SecPal the rights needed
+to distribute it under the AGPL and offer commercial licenses. The agreement
+defines SecPal, the Project Maintainer, and the CLA rights recipient.
+
+Repository-owned AGPL code and assets use
+`AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution`; see
+[AGPL-3.0-or-later](https://spdx.org/licenses/AGPL-3.0-or-later.html) and
+[LICENSES/LicenseRef-SecPal-Attribution.txt](LICENSES/LicenseRef-SecPal-Attribution.txt).
 
 Thank you for contributing to SecPal! 🎉

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -433,6 +433,8 @@ terms unless this repository actually includes Tailwind-derived material.
 
 ### SPDX Header Examples
 
+<!-- REUSE-IgnoreStart -->
+
 **For application code (`AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution`):**
 
 ```php
@@ -458,16 +460,12 @@ terms unless this repository actually includes Tailwind-derived material.
 # SPDX-License-Identifier: CC0-1.0
 ```
 
-<!-- REUSE-IgnoreStart -->
-
 ```json
 {
   "_comment": "SPDX-FileCopyrightText: 2026 SecPal Contributors",
   "_license": "SPDX-License-Identifier: CC0-1.0"
 }
 ```
-
-<!-- REUSE-IgnoreEnd -->
 
 **For helper scripts (MIT):**
 
@@ -485,6 +483,8 @@ SPDX-FileCopyrightText: 2026 SecPal Contributors
 SPDX-License-Identifier: CC0-1.0
 -->
 ```
+
+<!-- REUSE-IgnoreEnd -->
 
 ### Verification
 

--- a/LICENSES/CC-BY-4.0.txt
+++ b/LICENSES/CC-BY-4.0.txt
@@ -1,0 +1,156 @@
+Creative Commons Attribution 4.0 International
+
+ Creative Commons Corporation (“Creative Commons”) is not a law firm and does not provide legal services or legal advice. Distribution of Creative Commons public licenses does not create a lawyer-client or other relationship. Creative Commons makes its licenses and related information available on an “as-is” basis. Creative Commons gives no warranties regarding its licenses, any material licensed under their terms and conditions, or any related information. Creative Commons disclaims all liability for damages resulting from their use to the fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and conditions that creators and other rights holders may use to share original works of authorship and other material subject to copyright and certain other rights specified in the public license below. The following considerations are for informational purposes only, are not exhaustive, and do not form part of our licenses.
+
+Considerations for licensors: Our public licenses are intended for use by those authorized to give the public permission to use material in ways otherwise restricted by copyright and certain other rights. Our licenses are irrevocable. Licensors should read and understand the terms and conditions of the license they choose before applying it. Licensors should also secure all rights necessary before applying our licenses so that the public can reuse the material as expected. Licensors should clearly mark any material not subject to the license. This includes other CC-licensed material, or material used under an exception or limitation to copyright. More considerations for licensors.
+
+Considerations for the public: By using one of our public licenses, a licensor grants the public permission to use the licensed material under specified terms and conditions. If the licensor’s permission is not necessary for any reason–for example, because of any applicable exception or limitation to copyright–then that use is not regulated by the license. Our licenses grant only permissions under copyright and certain other rights that a licensor has authority to grant. Use of the licensed material may still be restricted for other reasons, including because others have copyright or other rights in the material. A licensor may make special requests, such as asking that all changes be marked or described. Although not required by our licenses, you are encouraged to respect those requests where reasonable. More considerations for the public.
+
+Creative Commons Attribution 4.0 International Public License
+
+By exercising the Licensed Rights (defined below), You accept and agree to be bound by the terms and conditions of this Creative Commons Attribution 4.0 International Public License ("Public License"). To the extent this Public License may be interpreted as a contract, You are granted the Licensed Rights in consideration of Your acceptance of these terms and conditions, and the Licensor grants You such rights in consideration of benefits the Licensor receives from making the Licensed Material available under these terms and conditions.
+
+Section 1 – Definitions.
+
+     a.	Adapted Material means material subject to Copyright and Similar Rights that is derived from or based upon the Licensed Material and in which the Licensed Material is translated, altered, arranged, transformed, or otherwise modified in a manner requiring permission under the Copyright and Similar Rights held by the Licensor. For purposes of this Public License, where the Licensed Material is a musical work, performance, or sound recording, Adapted Material is always produced where the Licensed Material is synched in timed relation with a moving image.
+
+     b.	Adapter's License means the license You apply to Your Copyright and Similar Rights in Your contributions to Adapted Material in accordance with the terms and conditions of this Public License.
+
+     c.	Copyright and Similar Rights means copyright and/or similar rights closely related to copyright including, without limitation, performance, broadcast, sound recording, and Sui Generis Database Rights, without regard to how the rights are labeled or categorized. For purposes of this Public License, the rights specified in Section 2(b)(1)-(2) are not Copyright and Similar Rights.
+
+     d.	Effective Technological Measures means those measures that, in the absence of proper authority, may not be circumvented under laws fulfilling obligations under Article 11 of the WIPO Copyright Treaty adopted on December 20, 1996, and/or similar international agreements.
+
+     e.	Exceptions and Limitations means fair use, fair dealing, and/or any other exception or limitation to Copyright and Similar Rights that applies to Your use of the Licensed Material.
+
+     f.	Licensed Material means the artistic or literary work, database, or other material to which the Licensor applied this Public License.
+
+     g.	Licensed Rights means the rights granted to You subject to the terms and conditions of this Public License, which are limited to all Copyright and Similar Rights that apply to Your use of the Licensed Material and that the Licensor has authority to license.
+
+     h.	Licensor means the individual(s) or entity(ies) granting rights under this Public License.
+
+     i.	Share means to provide material to the public by any means or process that requires permission under the Licensed Rights, such as reproduction, public display, public performance, distribution, dissemination, communication, or importation, and to make material available to the public including in ways that members of the public may access the material from a place and at a time individually chosen by them.
+
+     j.	Sui Generis Database Rights means rights other than copyright resulting from Directive 96/9/EC of the European Parliament and of the Council of 11 March 1996 on the legal protection of databases, as amended and/or succeeded, as well as other essentially equivalent rights anywhere in the world.
+
+     k.	You means the individual or entity exercising the Licensed Rights under this Public License. Your has a corresponding meaning.
+
+Section 2 – Scope.
+
+     a.	License grant.
+
+          1. Subject to the terms and conditions of this Public License, the Licensor hereby grants You a worldwide, royalty-free, non-sublicensable, non-exclusive, irrevocable license to exercise the Licensed Rights in the Licensed Material to:
+
+               A. reproduce and Share the Licensed Material, in whole or in part; and
+
+               B. produce, reproduce, and Share Adapted Material.
+
+          2. Exceptions and Limitations. For the avoidance of doubt, where Exceptions and Limitations apply to Your use, this Public License does not apply, and You do not need to comply with its terms and conditions.
+
+          3. Term. The term of this Public License is specified in Section 6(a).
+
+          4. Media and formats; technical modifications allowed. The Licensor authorizes You to exercise the Licensed Rights in all media and formats whether now known or hereafter created, and to make technical modifications necessary to do so. The Licensor waives and/or agrees not to assert any right or authority to forbid You from making technical modifications necessary to exercise the Licensed Rights, including technical modifications necessary to circumvent Effective Technological Measures. For purposes of this Public License, simply making modifications authorized by this Section 2(a)(4) never produces Adapted Material.
+
+          5. Downstream recipients.
+
+               A. Offer from the Licensor – Licensed Material. Every recipient of the Licensed Material automatically receives an offer from the Licensor to exercise the Licensed Rights under the terms and conditions of this Public License.
+
+               B. No downstream restrictions. You may not offer or impose any additional or different terms or conditions on, or apply any Effective Technological Measures to, the Licensed Material if doing so restricts exercise of the Licensed Rights by any recipient of the Licensed Material.
+
+          6.  No endorsement. Nothing in this Public License constitutes or may be construed as permission to assert or imply that You are, or that Your use of the Licensed Material is, connected with, or sponsored, endorsed, or granted official status by, the Licensor or others designated to receive attribution as provided in Section 3(a)(1)(A)(i).
+
+b. Other rights.
+
+          1. Moral rights, such as the right of integrity, are not licensed under this Public License, nor are publicity, privacy, and/or other similar personality rights; however, to the extent possible, the Licensor waives and/or agrees not to assert any such rights held by the Licensor to the limited extent necessary to allow You to exercise the Licensed Rights, but not otherwise.
+
+          2. Patent and trademark rights are not licensed under this Public License.
+
+          3. To the extent possible, the Licensor waives any right to collect royalties from You for the exercise of the Licensed Rights, whether directly or through a collecting society under any voluntary or waivable statutory or compulsory licensing scheme. In all other cases the Licensor expressly reserves any right to collect such royalties.
+
+Section 3 – License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the following conditions.
+
+     a.	Attribution.
+
+          1. If You Share the Licensed Material (including in modified form), You must:
+
+               A. retain the following if it is supplied by the Licensor with the Licensed Material:
+
+                    i. identification of the creator(s) of the Licensed Material and any others designated to receive attribution, in any reasonable manner requested by the Licensor (including by pseudonym if designated);
+
+                    ii. a copyright notice;
+
+                    iii. a notice that refers to this Public License;
+
+                    iv.	a notice that refers to the disclaimer of warranties;
+
+                    v. a URI or hyperlink to the Licensed Material to the extent reasonably practicable;
+
+               B. indicate if You modified the Licensed Material and retain an indication of any previous modifications; and
+
+               C. indicate the Licensed Material is licensed under this Public License, and include the text of, or the URI or hyperlink to, this Public License.
+
+          2. You may satisfy the conditions in Section 3(a)(1) in any reasonable manner based on the medium, means, and context in which You Share the Licensed Material. For example, it may be reasonable to satisfy the conditions by providing a URI or hyperlink to a resource that includes the required information.
+
+          3. If requested by the Licensor, You must remove any of the information required by Section 3(a)(1)(A) to the extent reasonably practicable.
+
+          4. If You Share Adapted Material You produce, the Adapter's License You apply must not prevent recipients of the Adapted Material from complying with this Public License.
+
+Section 4 – Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that apply to Your use of the Licensed Material:
+
+     a.	for the avoidance of doubt, Section 2(a)(1) grants You the right to extract, reuse, reproduce, and Share all or a substantial portion of the contents of the database;
+
+     b.	if You include all or a substantial portion of the database contents in a database in which You have Sui Generis Database Rights, then the database in which You have Sui Generis Database Rights (but not its individual contents) is Adapted Material; and
+
+     c.	You must comply with the conditions in Section 3(a) if You Share all or a substantial portion of the contents of the database.
+For the avoidance of doubt, this Section 4 supplements and does not replace Your obligations under this Public License where the Licensed Rights include other Copyright and Similar Rights.
+
+Section 5 – Disclaimer of Warranties and Limitation of Liability.
+
+     a.	Unless otherwise separately undertaken by the Licensor, to the extent possible, the Licensor offers the Licensed Material as-is and as-available, and makes no representations or warranties of any kind concerning the Licensed Material, whether express, implied, statutory, or other. This includes, without limitation, warranties of title, merchantability, fitness for a particular purpose, non-infringement, absence of latent or other defects, accuracy, or the presence or absence of errors, whether or not known or discoverable. Where disclaimers of warranties are not allowed in full or in part, this disclaimer may not apply to You.
+
+     b.	To the extent possible, in no event will the Licensor be liable to You on any legal theory (including, without limitation, negligence) or otherwise for any direct, special, indirect, incidental, consequential, punitive, exemplary, or other losses, costs, expenses, or damages arising out of this Public License or use of the Licensed Material, even if the Licensor has been advised of the possibility of such losses, costs, expenses, or damages. Where a limitation of liability is not allowed in full or in part, this limitation may not apply to You.
+
+     c.	The disclaimer of warranties and limitation of liability provided above shall be interpreted in a manner that, to the extent possible, most closely approximates an absolute disclaimer and waiver of all liability.
+
+Section 6 – Term and Termination.
+
+     a.	This Public License applies for the term of the Copyright and Similar Rights licensed here. However, if You fail to comply with this Public License, then Your rights under this Public License terminate automatically.
+
+     b.	Where Your right to use the Licensed Material has terminated under Section 6(a), it reinstates:
+
+          1. automatically as of the date the violation is cured, provided it is cured within 30 days of Your discovery of the violation; or
+
+          2. upon express reinstatement by the Licensor.
+
+     c.	For the avoidance of doubt, this Section 6(b) does not affect any right the Licensor may have to seek remedies for Your violations of this Public License.
+
+     d.	For the avoidance of doubt, the Licensor may also offer the Licensed Material under separate terms or conditions or stop distributing the Licensed Material at any time; however, doing so will not terminate this Public License.
+
+     e.	Sections 1, 5, 6, 7, and 8 survive termination of this Public License.
+
+Section 7 – Other Terms and Conditions.
+
+     a.	The Licensor shall not be bound by any additional or different terms or conditions communicated by You unless expressly agreed.
+
+     b.	Any arrangements, understandings, or agreements regarding the Licensed Material not stated herein are separate from and independent of the terms and conditions of this Public License.
+
+Section 8 – Interpretation.
+
+     a.	For the avoidance of doubt, this Public License does not, and shall not be interpreted to, reduce, limit, restrict, or impose conditions on any use of the Licensed Material that could lawfully be made without permission under this Public License.
+
+     b.	To the extent possible, if any provision of this Public License is deemed unenforceable, it shall be automatically reformed to the minimum extent necessary to make it enforceable. If the provision cannot be reformed, it shall be severed from this Public License without affecting the enforceability of the remaining terms and conditions.
+
+     c.	No term or condition of this Public License will be waived and no failure to comply consented to unless expressly agreed to by the Licensor.
+
+     d.	Nothing in this Public License constitutes or may be interpreted as a limitation upon, or waiver of, any privileges and immunities that apply to the Licensor or You, including from the legal processes of any jurisdiction or authority.
+
+Creative Commons is not a party to its public licenses. Notwithstanding, Creative Commons may elect to apply one of its public licenses to material it publishes and in those instances will be considered the “Licensor.” Except for the limited purpose of indicating that material is shared under a Creative Commons public license or as otherwise permitted by the Creative Commons policies published at creativecommons.org/policies, Creative Commons does not authorize the use of the trademark “Creative Commons” or any other trademark or logo of Creative Commons without its prior written consent including, without limitation, in connection with any unauthorized modifications to any of its public licenses or any other arrangements, understandings, or agreements concerning use of licensed material. For the avoidance of doubt, this paragraph does not form part of the public licenses.
+
+Creative Commons may be contacted at creativecommons.org.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -86,7 +86,7 @@ SPDX-License-Identifier = "CC0-1.0"
 
 [[annotations]]
 path = "README.md"
-SPDX-FileCopyrightText = "2025 SecPal"
+SPDX-FileCopyrightText = "2025-2026 SecPal Contributors"
 SPDX-License-Identifier = "CC0-1.0"
 
 [[annotations]]
@@ -99,7 +99,7 @@ SPDX-License-Identifier = "ODbL-1.0"
 
 [[annotations]]
 path = ".github/**"
-SPDX-FileCopyrightText = "2025 SecPal"
+SPDX-FileCopyrightText = "2025-2026 SecPal Contributors"
 SPDX-License-Identifier = "CC0-1.0"
 
 [[annotations]]

--- a/docs/ACTIVITY_LOGGING_ADMIN_GUIDE.md
+++ b/docs/ACTIVITY_LOGGING_ADMIN_GUIDE.md
@@ -1,6 +1,6 @@
 <!--
 SPDX-FileCopyrightText: 2026 SecPal Contributors
-SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+SPDX-License-Identifier: CC0-1.0
 -->
 
 # Activity Logging Admin Guide

--- a/docs/ACTIVITY_LOGGING_LEGAL_GUIDE.md
+++ b/docs/ACTIVITY_LOGGING_LEGAL_GUIDE.md
@@ -1,6 +1,6 @@
 <!--
 SPDX-FileCopyrightText: 2026 SecPal Contributors
-SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+SPDX-License-Identifier: CC0-1.0
 -->
 
 # Activity Logging Legal Guide

--- a/docs/ACTIVITY_LOGGING_USER_GUIDE.md
+++ b/docs/ACTIVITY_LOGGING_USER_GUIDE.md
@@ -1,6 +1,6 @@
 <!--
 SPDX-FileCopyrightText: 2026 SecPal Contributors
-SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+SPDX-License-Identifier: CC0-1.0
 -->
 
 # Activity Logging User Guide

--- a/docs/BEWACHV_COMPLIANCE.md
+++ b/docs/BEWACHV_COMPLIANCE.md
@@ -1,7 +1,7 @@
 <!--
 SPDX-FileCopyrightText: 2024-2026 SecPal Contributors
 
-SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+SPDX-License-Identifier: CC0-1.0
 -->
 
 # BewachV Compliance Documentation

--- a/docs/BEWACHV_COMPLIANCE.md
+++ b/docs/BEWACHV_COMPLIANCE.md
@@ -813,4 +813,4 @@ For production deployment, verify:
 **Document Version:** 1.0
 **Last Updated:** 2026-01-04
 **Author:** SecPal Contributors
-**License:** AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+**License:** CC0-1.0

--- a/docs/MAIL_SYSTEM.md
+++ b/docs/MAIL_SYSTEM.md
@@ -1,6 +1,6 @@
 <!--
 SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
-SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+SPDX-License-Identifier: CC0-1.0
 -->
 
 # Mail System Documentation

--- a/docs/api/rbac-endpoints.md
+++ b/docs/api/rbac-endpoints.md
@@ -1,5 +1,5 @@
 <!-- SPDX-FileCopyrightText: 2025-2026 SecPal Contributors -->
-<!-- SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution -->
+<!-- SPDX-License-Identifier: CC0-1.0 -->
 
 # RBAC API Endpoints Reference
 

--- a/docs/guides/direct-permissions.md
+++ b/docs/guides/direct-permissions.md
@@ -1,5 +1,5 @@
 <!-- SPDX-FileCopyrightText: 2025 SecPal Contributors -->
-<!-- SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution -->
+<!-- SPDX-License-Identifier: CC0-1.0 -->
 
 # Developer Guide: Direct Permissions
 

--- a/docs/guides/direct-permissions.md
+++ b/docs/guides/direct-permissions.md
@@ -1,4 +1,4 @@
-<!-- SPDX-FileCopyrightText: 2025 SecPal Contributors -->
+<!-- SPDX-FileCopyrightText: 2025-2026 SecPal Contributors -->
 <!-- SPDX-License-Identifier: CC0-1.0 -->
 
 # Developer Guide: Direct Permissions

--- a/docs/guides/firebase-push-bootstrap-audit.md
+++ b/docs/guides/firebase-push-bootstrap-audit.md
@@ -1,5 +1,5 @@
 <!-- SPDX-FileCopyrightText: 2026 SecPal Contributors -->
-<!-- SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution -->
+<!-- SPDX-License-Identifier: CC0-1.0 -->
 
 # Firebase Push Bootstrap Audit
 

--- a/docs/guides/permission-system.md
+++ b/docs/guides/permission-system.md
@@ -1,5 +1,5 @@
 <!-- SPDX-FileCopyrightText: 2025-2026 SecPal Contributors -->
-<!-- SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution -->
+<!-- SPDX-License-Identifier: CC0-1.0 -->
 
 # Permission System Guide
 

--- a/docs/guides/production-deployment.md
+++ b/docs/guides/production-deployment.md
@@ -1,4 +1,4 @@
-<!-- SPDX-FileCopyrightText: 2025 SecPal Contributors -->
+<!-- SPDX-FileCopyrightText: 2025-2026 SecPal Contributors -->
 <!-- SPDX-License-Identifier: CC0-1.0 -->
 
 # Production Deployment Guide

--- a/docs/guides/production-deployment.md
+++ b/docs/guides/production-deployment.md
@@ -1,5 +1,5 @@
 <!-- SPDX-FileCopyrightText: 2025 SecPal Contributors -->
-<!-- SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution -->
+<!-- SPDX-License-Identifier: CC0-1.0 -->
 
 # Production Deployment Guide
 

--- a/docs/guides/role-management.md
+++ b/docs/guides/role-management.md
@@ -1,5 +1,5 @@
 <!-- SPDX-FileCopyrightText: 2025-2026 SecPal Contributors -->
-<!-- SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution -->
+<!-- SPDX-License-Identifier: CC0-1.0 -->
 
 # Role Management Guide
 

--- a/docs/guides/sanctum-spa-auth.md
+++ b/docs/guides/sanctum-spa-auth.md
@@ -1,5 +1,5 @@
 <!-- SPDX-FileCopyrightText: 2025-2026 SecPal Contributors -->
-<!-- SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution -->
+<!-- SPDX-License-Identifier: CC0-1.0 -->
 
 # Sanctum SPA Authentication with httpOnly Cookies
 

--- a/docs/guides/temporal-roles.md
+++ b/docs/guides/temporal-roles.md
@@ -1,4 +1,4 @@
-<!-- SPDX-FileCopyrightText: 2025 SecPal Contributors -->
+<!-- SPDX-FileCopyrightText: 2025-2026 SecPal Contributors -->
 <!-- SPDX-License-Identifier: CC0-1.0 -->
 
 # Developer Guide: Temporal Roles

--- a/docs/guides/temporal-roles.md
+++ b/docs/guides/temporal-roles.md
@@ -1,5 +1,5 @@
 <!-- SPDX-FileCopyrightText: 2025 SecPal Contributors -->
-<!-- SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution -->
+<!-- SPDX-License-Identifier: CC0-1.0 -->
 
 # Developer Guide: Temporal Roles
 

--- a/docs/planning/ou-status-flags-issues.md
+++ b/docs/planning/ou-status-flags-issues.md
@@ -1,6 +1,6 @@
 <!--
 SPDX-FileCopyrightText: 2026 SecPal Contributors
-SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+SPDX-License-Identifier: CC0-1.0
 -->
 
 # Organizational Unit Status Flags Issue Split

--- a/docs/rbac-architecture.md
+++ b/docs/rbac-architecture.md
@@ -1,5 +1,5 @@
 <!-- SPDX-FileCopyrightText: 2025-2026 SecPal Contributors -->
-<!-- SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution -->
+<!-- SPDX-License-Identifier: CC0-1.0 -->
 
 # RBAC Architecture
 

--- a/scripts/add-pest-property-annotations.php
+++ b/scripts/add-pest-property-annotations.php
@@ -2,7 +2,7 @@
 <?php
 
 /**
- * SPDX-FileCopyrightText: 2025 SecPal Contributors
+ * SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
  * SPDX-License-Identifier: MIT
  */
 

--- a/scripts/add-pest-property-annotations.php
+++ b/scripts/add-pest-property-annotations.php
@@ -3,7 +3,7 @@
 
 /**
  * SPDX-FileCopyrightText: 2025 SecPal Contributors
- * SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+ * SPDX-License-Identifier: MIT
  */
 
 declare(strict_types=1);

--- a/scripts/check-license-compatibility.sh
+++ b/scripts/check-license-compatibility.sh
@@ -40,6 +40,20 @@ is_allowed_atom() {
   return 1
 }
 
+has_license() {
+  local expected="$1"
+  shift
+  local license
+
+  for license in "$@"; do
+    if [[ "$license" == "$expected" ]]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
 is_strict_path() {
   local path="$1"
 
@@ -93,7 +107,9 @@ validate_current_file() {
     fi
   done
 
-  if [[ "$concluded" == *'LicenseRef-SecPal-Attribution'* ]] && ! is_strict_path "$path"; then
+  if ! is_strict_path "$path" \
+    && ([[ "$concluded" == *'LicenseRef-SecPal-Attribution'* ]] \
+      || has_license 'LicenseRef-SecPal-Attribution' "${licenses[@]}"); then
     echo "ERROR: attribution addendum is only permitted for SecPal-owned AGPL code and assets in $path" >&2
     return 1
   fi

--- a/scripts/check-license-compatibility.sh
+++ b/scripts/check-license-compatibility.sh
@@ -39,6 +39,20 @@ is_allowed_atom() {
   return 1
 }
 
+has_license() {
+  local expected="$1"
+  shift
+  local license
+
+  for license in "$@"; do
+    if [[ "$license" == "$expected" ]]; then
+      return 0
+    fi
+  done
+
+  return 1
+}
+
 is_strict_path() {
   local path="$1"
 
@@ -93,7 +107,8 @@ validate_current_file() {
   done
 
   if [[ "$concluded" == *'LicenseRef-SecPal-Attribution'* ]] \
-    && ! is_strict_path "$path"; then
+    && ! is_strict_path "$path" \
+    && ! has_license 'CC0-1.0' "${licenses[@]}"; then
     echo "ERROR: attribution addendum is only permitted for SecPal-owned AGPL code and assets in $path" >&2
     return 1
   fi

--- a/scripts/check-license-compatibility.sh
+++ b/scripts/check-license-compatibility.sh
@@ -52,10 +52,13 @@ is_strict_path() {
     || [[ "$path" == bootstrap/* ]] \
     || [[ "$path" == config/* ]] \
     || [[ "$path" == database/* ]] \
+    || [[ "$path" == lang/* ]] \
     || [[ "$path" == public/* ]] \
+    || [[ "$path" == resources/* ]] \
     || [[ "$path" == routes/* ]] \
     || [[ "$path" == tests/* ]] \
-    || [[ "$path" == artisan ]]
+    || [[ "$path" == artisan ]] \
+    || [[ "$path" == .ddev/web-build/Dockerfile.opentimestamps ]]
 }
 
 is_strict_exception() {
@@ -88,6 +91,12 @@ validate_current_file() {
       return 1
     fi
   done
+
+  if [[ "$concluded" == *'LicenseRef-SecPal-Attribution'* ]] \
+    && ! is_strict_path "$path"; then
+    echo "ERROR: attribution addendum is only permitted for SecPal-owned AGPL code and assets in $path" >&2
+    return 1
+  fi
 
   if ! is_strict_path "$path"; then
     return 0

--- a/scripts/check-license-compatibility.sh
+++ b/scripts/check-license-compatibility.sh
@@ -19,6 +19,7 @@ compatible_licenses=(
   "BSD-2-Clause"
   "BSD-3-Clause"
   "Apache-2.0"
+  "CC-BY-4.0"
   "CC0-1.0"
   "ISC"
   "OFL-1.1"
@@ -32,20 +33,6 @@ is_allowed_atom() {
 
   for compatible in "${compatible_licenses[@]}"; do
     if [[ "$atom" == "$compatible" ]]; then
-      return 0
-    fi
-  done
-
-  return 1
-}
-
-has_license() {
-  local expected="$1"
-  shift
-  local license
-
-  for license in "$@"; do
-    if [[ "$license" == "$expected" ]]; then
       return 0
     fi
   done
@@ -106,9 +93,7 @@ validate_current_file() {
     fi
   done
 
-  if [[ "$concluded" == *'LicenseRef-SecPal-Attribution'* ]] \
-    && ! is_strict_path "$path" \
-    && ! has_license 'CC0-1.0' "${licenses[@]}"; then
+  if [[ "$concluded" == *'LicenseRef-SecPal-Attribution'* ]] && ! is_strict_path "$path"; then
     echo "ERROR: attribution addendum is only permitted for SecPal-owned AGPL code and assets in $path" >&2
     return 1
   fi

--- a/tests/Unit/LicenseCompatibilityScriptTest.php
+++ b/tests/Unit/LicenseCompatibilityScriptTest.php
@@ -59,7 +59,7 @@ SPDXID: SPDXRef-DOCUMENT
 DocumentName: sample
 DocumentNamespace: https://secpal.dev/spdxdocs/sample
 
-FileName: app/Foo.php
+FileName: app/Models/User.php
 SPDXID: SPDXRef-File
 LicenseInfoInFile: AGPL-3.0-or-later
 LicenseInfoInFile: LicenseRef-SecPal-Attribution
@@ -79,7 +79,7 @@ SPDXID: SPDXRef-DOCUMENT
 DocumentName: sample
 DocumentNamespace: https://secpal.dev/spdxdocs/sample
 
-FileName: app/Foo.php
+FileName: app/Models/User.php
 SPDXID: SPDXRef-File
 LicenseInfoInFile: AGPL-3.0-or-later
 LicenseInfoInFile: MIT
@@ -99,7 +99,7 @@ SPDXID: SPDXRef-DOCUMENT
 DocumentName: sample
 DocumentNamespace: https://secpal.dev/spdxdocs/sample
 
-FileName: app/Foo.php
+FileName: app/Models/User.php
 SPDXID: SPDXRef-File
 LicenseInfoInFile: MIT
 LicenseConcluded: MIT
@@ -118,7 +118,7 @@ SPDXID: SPDXRef-DOCUMENT
 DocumentName: sample
 DocumentNamespace: https://secpal.dev/spdxdocs/sample
 
-FileName: app/Foo.php
+FileName: app/Models/User.php
 SPDXID: SPDXRef-File
 LicenseInfoInFile: AGPL-3.0-or-later
 LicenseInfoInFile: MIT
@@ -253,7 +253,7 @@ SPDX
         ->and($result['stderr'])->toContain('attribution addendum is only permitted for SecPal-owned AGPL code and assets');
 });
 
-test('license compatibility script allows documentation that only contains attribution examples', function (): void {
+test('license compatibility script rejects documentation attribution when concluded is noassertion', function (): void {
     $result = runLicenseCompatibilityScript(<<<'SPDX'
 SPDXVersion: SPDX-2.3
 DataLicense: CC0-1.0
@@ -270,8 +270,8 @@ LicenseConcluded: NOASSERTION
 SPDX
     );
 
-    expect($result['exit_code'])->toBe(0)
-        ->and($result['stderr'])->toBe('');
+    expect($result['exit_code'])->toBe(1)
+        ->and($result['stderr'])->toContain('attribution addendum is only permitted for SecPal-owned AGPL code and assets');
 });
 
 test('license compatibility script allows ci concluded documentation after ignoring attribution examples', function (): void {

--- a/tests/Unit/LicenseCompatibilityScriptTest.php
+++ b/tests/Unit/LicenseCompatibilityScriptTest.php
@@ -172,3 +172,64 @@ SPDX
     expect($result['exit_code'])->toBe(0)
         ->and($result['stderr'])->toBe('');
 });
+
+test('license compatibility script rejects the attribution addendum in documentation', function (): void {
+    $result = runLicenseCompatibilityScript(<<<'SPDX'
+SPDXVersion: SPDX-2.3
+DataLicense: CC0-1.0
+SPDXID: SPDXRef-DOCUMENT
+DocumentName: sample
+DocumentNamespace: https://secpal.dev/spdxdocs/sample
+
+FileName: docs/licensing.md
+SPDXID: SPDXRef-File
+LicenseInfoInFile: AGPL-3.0-or-later
+LicenseInfoInFile: LicenseRef-SecPal-Attribution
+LicenseConcluded: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+SPDX
+    );
+
+    expect($result['exit_code'])->toBe(1)
+        ->and($result['stderr'])->toContain('attribution addendum is only permitted for SecPal-owned AGPL code and assets');
+});
+
+test('license compatibility script allows documentation that only contains attribution examples', function (): void {
+    $result = runLicenseCompatibilityScript(<<<'SPDX'
+SPDXVersion: SPDX-2.3
+DataLicense: CC0-1.0
+SPDXID: SPDXRef-DOCUMENT
+DocumentName: sample
+DocumentNamespace: https://secpal.dev/spdxdocs/sample
+
+FileName: docs/licensing.md
+SPDXID: SPDXRef-File
+LicenseInfoInFile: CC0-1.0
+LicenseInfoInFile: AGPL-3.0-or-later
+LicenseInfoInFile: LicenseRef-SecPal-Attribution
+LicenseConcluded: NOASSERTION
+SPDX
+    );
+
+    expect($result['exit_code'])->toBe(0)
+        ->and($result['stderr'])->toBe('');
+});
+
+test('license compatibility script accepts the OpenTimestamps runtime build asset', function (): void {
+    $result = runLicenseCompatibilityScript(<<<'SPDX'
+SPDXVersion: SPDX-2.3
+DataLicense: CC0-1.0
+SPDXID: SPDXRef-DOCUMENT
+DocumentName: sample
+DocumentNamespace: https://secpal.dev/spdxdocs/sample
+
+FileName: .ddev/web-build/Dockerfile.opentimestamps
+SPDXID: SPDXRef-File
+LicenseInfoInFile: AGPL-3.0-or-later
+LicenseInfoInFile: LicenseRef-SecPal-Attribution
+LicenseConcluded: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+SPDX
+    );
+
+    expect($result['exit_code'])->toBe(0)
+        ->and($result['stderr'])->toBe('');
+});

--- a/tests/Unit/LicenseCompatibilityScriptTest.php
+++ b/tests/Unit/LicenseCompatibilityScriptTest.php
@@ -214,6 +214,28 @@ SPDX
         ->and($result['stderr'])->toBe('');
 });
 
+test('license compatibility script allows ci concluded documentation with attribution examples', function (): void {
+    $result = runLicenseCompatibilityScript(<<<'SPDX'
+SPDXVersion: SPDX-2.3
+DataLicense: CC0-1.0
+SPDXID: SPDXRef-DOCUMENT
+DocumentName: sample
+DocumentNamespace: https://secpal.dev/spdxdocs/sample
+
+FileName: CONTRIBUTING.md
+SPDXID: SPDXRef-File
+LicenseInfoInFile: AGPL-3.0-or-later
+LicenseInfoInFile: CC0-1.0
+LicenseInfoInFile: LicenseRef-SecPal-Attribution
+LicenseInfoInFile: MIT
+LicenseConcluded: AGPL-3.0-or-later AND CC0-1.0 AND LicenseRef-SecPal-Attribution AND MIT
+SPDX
+    );
+
+    expect($result['exit_code'])->toBe(0)
+        ->and($result['stderr'])->toBe('');
+});
+
 test('license compatibility script accepts the OpenTimestamps runtime build asset', function (): void {
     $result = runLicenseCompatibilityScript(<<<'SPDX'
 SPDXVersion: SPDX-2.3

--- a/tests/Unit/LicenseCompatibilityScriptTest.php
+++ b/tests/Unit/LicenseCompatibilityScriptTest.php
@@ -173,6 +173,25 @@ SPDX
         ->and($result['stderr'])->toBe('');
 });
 
+test('license compatibility script allows the Contributor Covenant third-party notice', function (): void {
+    $result = runLicenseCompatibilityScript(<<<'SPDX'
+SPDXVersion: SPDX-2.3
+DataLicense: CC0-1.0
+SPDXID: SPDXRef-DOCUMENT
+DocumentName: sample
+DocumentNamespace: https://secpal.dev/spdxdocs/sample
+
+FileName: CODE_OF_CONDUCT.md
+SPDXID: SPDXRef-File
+LicenseInfoInFile: CC-BY-4.0
+LicenseConcluded: CC-BY-4.0
+SPDX
+    );
+
+    expect($result['exit_code'])->toBe(0)
+        ->and($result['stderr'])->toBe('');
+});
+
 test('license compatibility script rejects the attribution addendum in documentation', function (): void {
     $result = runLicenseCompatibilityScript(<<<'SPDX'
 SPDXVersion: SPDX-2.3
@@ -181,11 +200,52 @@ SPDXID: SPDXRef-DOCUMENT
 DocumentName: sample
 DocumentNamespace: https://secpal.dev/spdxdocs/sample
 
-FileName: docs/licensing.md
+FileName: docs/rbac-architecture.md
 SPDXID: SPDXRef-File
 LicenseInfoInFile: AGPL-3.0-or-later
 LicenseInfoInFile: LicenseRef-SecPal-Attribution
 LicenseConcluded: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+SPDX
+    );
+
+    expect($result['exit_code'])->toBe(1)
+        ->and($result['stderr'])->toContain('attribution addendum is only permitted for SecPal-owned AGPL code and assets');
+});
+
+test('license compatibility script rejects concluded documentation attribution despite a cc0 example', function (): void {
+    $result = runLicenseCompatibilityScript(<<<'SPDX'
+SPDXVersion: SPDX-2.3
+DataLicense: CC0-1.0
+SPDXID: SPDXRef-DOCUMENT
+DocumentName: sample
+DocumentNamespace: https://secpal.dev/spdxdocs/sample
+
+FileName: docs/rbac-architecture.md
+SPDXID: SPDXRef-File
+LicenseInfoInFile: AGPL-3.0-or-later
+LicenseInfoInFile: LicenseRef-SecPal-Attribution
+LicenseInfoInFile: CC0-1.0
+LicenseConcluded: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+SPDX
+    );
+
+    expect($result['exit_code'])->toBe(1)
+        ->and($result['stderr'])->toContain('attribution addendum is only permitted for SecPal-owned AGPL code and assets');
+});
+
+test('license compatibility script rejects concluded documentation attribution paired with cc0', function (): void {
+    $result = runLicenseCompatibilityScript(<<<'SPDX'
+SPDXVersion: SPDX-2.3
+DataLicense: CC0-1.0
+SPDXID: SPDXRef-DOCUMENT
+DocumentName: sample
+DocumentNamespace: https://secpal.dev/spdxdocs/sample
+
+FileName: docs/rbac-architecture.md
+SPDXID: SPDXRef-File
+LicenseInfoInFile: CC0-1.0
+LicenseInfoInFile: LicenseRef-SecPal-Attribution
+LicenseConcluded: CC0-1.0 AND LicenseRef-SecPal-Attribution
 SPDX
     );
 
@@ -201,7 +261,7 @@ SPDXID: SPDXRef-DOCUMENT
 DocumentName: sample
 DocumentNamespace: https://secpal.dev/spdxdocs/sample
 
-FileName: docs/licensing.md
+FileName: docs/rbac-architecture.md
 SPDXID: SPDXRef-File
 LicenseInfoInFile: CC0-1.0
 LicenseInfoInFile: AGPL-3.0-or-later
@@ -214,7 +274,7 @@ SPDX
         ->and($result['stderr'])->toBe('');
 });
 
-test('license compatibility script allows ci concluded documentation with attribution examples', function (): void {
+test('license compatibility script allows ci concluded documentation after ignoring attribution examples', function (): void {
     $result = runLicenseCompatibilityScript(<<<'SPDX'
 SPDXVersion: SPDX-2.3
 DataLicense: CC0-1.0
@@ -224,11 +284,8 @@ DocumentNamespace: https://secpal.dev/spdxdocs/sample
 
 FileName: CONTRIBUTING.md
 SPDXID: SPDXRef-File
-LicenseInfoInFile: AGPL-3.0-or-later
 LicenseInfoInFile: CC0-1.0
-LicenseInfoInFile: LicenseRef-SecPal-Attribution
-LicenseInfoInFile: MIT
-LicenseConcluded: AGPL-3.0-or-later AND CC0-1.0 AND LicenseRef-SecPal-Attribution AND MIT
+LicenseConcluded: CC0-1.0
 SPDX
     );
 


### PR DESCRIPTION
## Evidence

The new attribution-scope regression test initially failed because the license compatibility script accepted `AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution` for `docs/licensing.md`. It now rejects that concluded expression while permitting documentation that merely includes SPDX examples.

## Summary

- Align repository-owned SPDX copyright holders with `SecPal Contributors` and keep AGPL attribution limited to approved SecPal-owned AGPL code and assets.
- Return documentation and configuration metadata to their existing CC0 policy, preserve third-party notices, and keep helper tooling under MIT.
- Document attribution pairing, CLA ownership terms, third-party notice handling, and the Tailwind-derived-material rule in `CONTRIBUTING.md`.
- Extend the license compatibility guard for translations, templates, and the OpenTimestamps runtime build asset.

## Validation

- `php artisan test tests/Unit/QualityLicenseCompatibilityWorkflowTest.php tests/Unit/LicenseCompatibilityScriptTest.php`
- `vendor/bin/pint --dirty`
- `reuse lint`
- `reuse spdx` followed by `bash scripts/check-license-compatibility.sh`
- `markdownlint-cli2` for the changed Markdown files
- Push preflight: Prettier, Markdownlint, REUSE, domain policy, Pint, and PHPStan

## Follow-up before ready

- No linked workspace changes are required.
- #1272 tracks the pre-existing CC0/CC-BY metadata conflict in `docs/OPENTIMESTAMP_INTEGRATION.md`; it is intentionally outside this PR's scope.
