### PR TITLE
Fix OpenTimestamps documentation license

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- aligned the OpenTimestamps integration guide's declared license with its CC0-1.0 SPDX metadata and repository REUSE policy (fixes `api#1272`)
 - allowed activity logging for same-tenant records that retain a reference to a soft-deleted organizational unit, so permitted historical record updates remain audit-safe instead of failing with a server error (fixes `api#1268`)
 - scoped the employee auto-logging regression lookup to the employee and tenant created by the test, so activity-log assertions cannot read a matching row leaked by an earlier test (fixes `api#1269`)
 - rejected new organizational scopes, effective scope expansions, employee or site placements, and site-user assignments on organizational units marked `is_assignable: false`, including access-level escalation exposed by scope-mask removal, reassignment, reactivation, future-coverage extension, and role-change attempts plus soft-deleted targets, while allowing redundant scope cleanup and fully historical assignment corrections and preserving the required creator bootstrap `manage` scope when creating an unassignable unit (fixes `api#1266`)

--- a/docs/OPENTIMESTAMP_INTEGRATION.md
+++ b/docs/OPENTIMESTAMP_INTEGRATION.md
@@ -436,7 +436,7 @@ Search logs for `OpenTimestamp:` prefix.
 
 ## License
 
-This documentation is licensed under CC-BY-4.0.
+This documentation is licensed under CC0-1.0.
 
 The OpenTimestamp client is licensed under LGPL-3.0.
 


### PR DESCRIPTION
## Validation evidence

Reproduced the metadata conflict: `docs/OPENTIMESTAMP_INTEGRATION.md` declared `CC0-1.0` in its SPDX header while its License section stated `CC-BY-4.0`.

## Summary

- retain CC0-1.0, the repository's established documentation license
- align the guide's License section with its SPDX metadata and REUSE policy
- record the correction in the unreleased changelog

## Validation

- `reuse lint`
- `git diff --check`
- configured pre-commit checks: REUSE, Prettier, markdownlint, and whitespace checks
- configured pre-push checks: Prettier, markdownlint, REUSE, domain policy, Pint, and PHPStan

## Follow-up

No linked workspace changes or unresolved checks are required before review.

Fixes #1272
