### PR TITLE
feat: persist optional customer VAT ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- added `GET /v1/customers/legal-entities` as a tenant-injected minimal lookup for customer creation, returning only active same-tenant Legal Entities where the caller has global `customers.create` plus organizational write scope
 - added mandatory tenant-consistent `customers.legal_entity_id` persistence with a non-null organizational-unit FK, composite tenant/legal-entity database enforcement, create/update validation for active same-tenant legal entities, Customer model/resource/activity-log coverage, and a migration guard that fails fast when existing customers still need the US-001 approved deterministic backfill
 - added independent organizational-unit `is_active` and `is_assignable` API flags with true defaults, strict boolean create/update validation, independent list filtering, persistence, and resource serialization (refs `api#1264`)
 - added independent organizational-unit `is_legal_entity` and `is_establishment` API flags with false defaults, strict boolean create/update validation, persistence, resource serialization, and focused Pest coverage (refs `api#1259`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- added mandatory tenant-consistent `customers.legal_entity_id` persistence with a non-null organizational-unit FK, composite tenant/legal-entity database enforcement, create/update validation for active same-tenant legal entities, Customer model/resource/activity-log coverage, and a migration guard that fails fast when existing customers still need the US-001 approved deterministic backfill
 - added independent organizational-unit `is_active` and `is_assignable` API flags with true defaults, strict boolean create/update validation, independent list filtering, persistence, and resource serialization (refs `api#1264`)
 - added independent organizational-unit `is_legal_entity` and `is_establishment` API flags with false defaults, strict boolean create/update validation, persistence, resource serialization, and focused Pest coverage (refs `api#1259`)
 - added the SecPal AGPL attribution additional terms in `LICENSES/LicenseRef-SecPal-Attribution.txt`, updated project-owned AGPL SPDX metadata to `AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution`, standardized touched AGPL copyright headers to `SecPal Contributors`, and documented the section 7(b)/(c) attribution requirements in the licensing/contributor guides (refs `api#1219`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added optional customer VAT ID persistence, validation, and API response
+  support (refs #1280).
+
 - added `GET /v1/customers/legal-entities` as a tenant-injected minimal lookup for customer creation, returning only active same-tenant Legal Entities where the caller has global `customers.create` plus organizational write scope
 - added mandatory tenant-consistent `customers.legal_entity_id` persistence with a non-null organizational-unit FK, composite tenant/legal-entity database enforcement, create/update validation for active same-tenant legal entities, Customer model/resource/activity-log coverage, and a migration guard that fails fast when existing customers still need the US-001 approved deterministic backfill
 - added independent organizational-unit `is_active` and `is_assignable` API flags with true defaults, strict boolean create/update validation, independent list filtering, persistence, and resource serialization (refs `api#1264`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- required `POST /v1/customers` to combine `customers.create` with write access on the exact submitted active same-tenant Legal Entity, using inherited organizational scopes and rejecting customer creation when the entity scope is missing or read-only
 - applied the existing `passkey-verify` limiter to `DELETE /v1/me/passkeys/{credentialId}` so wrong `current_password` guesses on passkey deletion now lock out the same way as passkey enrollment verification attempts
 - required current-password step-up before passkey enrollment challenge creation, passkey enrollment verification, and passkey deletion, and defaulted passkey user verification to `required` so newly enrolled passkeys cannot convert a stolen token into an MFA-complete login without a fresh primary-auth proof.
 - single-shot identity-proof enforcement on `POST /v1/onboarding/complete`: a failed date-of-birth check or a name that deviates too far from the HR record now permanently burns the magic link (`invalidated_at`, `invalidated_from_ip`, `invalidated_user_agent`, `invalidation_reason` recorded on `employee_onboarding_tokens`). A single generic 422 is returned for all identity mismatches so an attacker cannot use the response as a per-field oracle. HR must issue a fresh invitation after any failed identity proof.

--- a/app/Http/Controllers/Api/V1/CustomerController.php
+++ b/app/Http/Controllers/Api/V1/CustomerController.php
@@ -13,6 +13,7 @@ use App\Http\Requests\Api\V1\UpdateCustomerRequest;
 use App\Http\Resources\CustomerResource;
 use App\Http\Resources\SiteResource;
 use App\Models\Customer;
+use App\Models\OrganizationalUnit;
 use App\Models\Site;
 use App\Models\TenantKey;
 use App\Models\User;
@@ -140,6 +141,18 @@ class CustomerController extends Controller
         /** @var int $tenantId */
         $tenantId = $request->get('tenant_id');
         $validated['tenant_id'] = $tenantId;
+        /** @var User $user */
+        $user = $request->user();
+        $legalEntity = OrganizationalUnit::query()
+            ->whereKey($validated['legal_entity_id'])
+            ->where('tenant_id', $tenantId)
+            ->where('is_legal_entity', true)
+            ->where('is_active', true)
+            ->firstOrFail();
+
+        if (! $user->hasAccessToUnit($legalEntity, 'write')) {
+            abort(Response::HTTP_FORBIDDEN, __('Insufficient access level. Required: :level', ['level' => 'write']));
+        }
 
         $customer = DB::transaction(function () use ($tenantId, $validated): Customer {
             TenantKey::query()->select('id')->whereKey($tenantId)->lockForUpdate()->firstOrFail();

--- a/app/Http/Controllers/Api/V1/CustomerController.php
+++ b/app/Http/Controllers/Api/V1/CustomerController.php
@@ -10,6 +10,7 @@ use App\Http\Requests\Api\V1\IndexCustomerRequest;
 use App\Http\Requests\Api\V1\IndexCustomerSitesRequest;
 use App\Http\Requests\Api\V1\StoreCustomerRequest;
 use App\Http\Requests\Api\V1\UpdateCustomerRequest;
+use App\Http\Resources\Api\V1\CustomerLegalEntityLookupResource;
 use App\Http\Resources\CustomerResource;
 use App\Http\Resources\SiteResource;
 use App\Models\Customer;
@@ -21,6 +22,8 @@ use App\Support\LikePattern;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\DB;
 
@@ -51,7 +54,7 @@ class CustomerController extends Controller
      * - search (name, customer_number)
      * - is_active (boolean)
      *
-     * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection Paginated customer list with metadata
+     * @return AnonymousResourceCollection Paginated customer list with metadata
      */
     public function index(IndexCustomerRequest $request)
     {
@@ -121,6 +124,41 @@ class CustomerController extends Controller
         $customers = $query->paginate($perPage);
 
         return CustomerResource::collection($customers);
+    }
+
+    /**
+     * Display Legal Entity options that can receive new customers.
+     *
+     * GET /api/v1/customers/legal-entities
+     *
+     * @return AnonymousResourceCollection<int, CustomerLegalEntityLookupResource>
+     */
+    public function legalEntities(Request $request): AnonymousResourceCollection
+    {
+        $this->authorize('create', Customer::class);
+
+        /** @var User $user */
+        $user = $request->user();
+        /** @var int $tenantId */
+        $tenantId = $request->get('tenant_id');
+        $organizationalScopes = $user->organizationalScopes()->get();
+
+        $legalEntities = OrganizationalUnit::query()
+            ->where('tenant_id', $tenantId)
+            ->where('is_legal_entity', true)
+            ->where('is_active', true)
+            ->orderBy('name')
+            ->get()
+            ->filter(
+                fn (OrganizationalUnit $legalEntity): bool => $user->hasAccessToUnit(
+                    $legalEntity,
+                    'write',
+                    $organizationalScopes
+                )
+            )
+            ->values();
+
+        return CustomerLegalEntityLookupResource::collection($legalEntities);
     }
 
     /**
@@ -266,7 +304,7 @@ class CustomerController extends Controller
      * Returns paginated list of sites belonging to the customer.
      * User must have view access to the customer.
      *
-     * @return \Illuminate\Http\Resources\Json\AnonymousResourceCollection<int, SiteResource> Paginated site list
+     * @return AnonymousResourceCollection<int, SiteResource> Paginated site list
      */
     public function sites(IndexCustomerSitesRequest $request, Customer $customer)
     {

--- a/app/Http/Requests/Api/V1/StoreCustomerRequest.php
+++ b/app/Http/Requests/Api/V1/StoreCustomerRequest.php
@@ -7,6 +7,7 @@ namespace App\Http\Requests\Api\V1;
 
 use App\Models\Customer;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 /**
  * Store Customer Request validation.
@@ -40,11 +41,20 @@ class StoreCustomerRequest extends FormRequest
 
         return [
             'name' => ['required', 'string', 'max:255'],
+            'legal_entity_id' => [
+                'required',
+                'uuid',
+                Rule::exists('organizational_units', 'id')
+                    ->where('tenant_id', $tenantId)
+                    ->where('is_legal_entity', true)
+                    ->where('is_active', true)
+                    ->whereNull('deleted_at'),
+            ],
             'customer_number' => [
                 'nullable',
                 'string',
                 'max:50',
-                \Illuminate\Validation\Rule::unique('customers', 'customer_number')
+                Rule::unique('customers', 'customer_number')
                     ->where('tenant_id', $tenantId),
             ],
             'billing_address' => ['required', 'array'],
@@ -74,6 +84,7 @@ class StoreCustomerRequest extends FormRequest
             'billing_address.city' => 'billing city',
             'billing_address.postal_code' => 'billing postal code',
             'billing_address.country' => 'billing country',
+            'legal_entity_id' => 'legal entity',
             'contact.name' => 'contact name',
             'contact.email' => 'contact email',
             'contact.phone' => 'contact phone',

--- a/app/Http/Requests/Api/V1/StoreCustomerRequest.php
+++ b/app/Http/Requests/Api/V1/StoreCustomerRequest.php
@@ -41,6 +41,7 @@ class StoreCustomerRequest extends FormRequest
 
         return [
             'name' => ['required', 'string', 'max:255'],
+            'vat_id' => ['nullable', 'string', 'max:32'],
             'legal_entity_id' => [
                 'required',
                 'uuid',

--- a/app/Http/Requests/Api/V1/UpdateCustomerRequest.php
+++ b/app/Http/Requests/Api/V1/UpdateCustomerRequest.php
@@ -42,6 +42,7 @@ class UpdateCustomerRequest extends FormRequest
 
         return [
             'name' => ['sometimes', 'string', 'max:255'],
+            'vat_id' => ['sometimes', 'nullable', 'string', 'max:32'],
             'legal_entity_id' => [
                 'sometimes',
                 'uuid',

--- a/app/Http/Requests/Api/V1/UpdateCustomerRequest.php
+++ b/app/Http/Requests/Api/V1/UpdateCustomerRequest.php
@@ -7,6 +7,7 @@ namespace App\Http\Requests\Api\V1;
 
 use App\Models\Customer;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 /**
  * Update Customer Request validation.
@@ -36,8 +37,20 @@ class UpdateCustomerRequest extends FormRequest
      */
     public function rules(): array
     {
+        /** @var int $tenantId */
+        $tenantId = $this->input('tenant_id');
+
         return [
             'name' => ['sometimes', 'string', 'max:255'],
+            'legal_entity_id' => [
+                'sometimes',
+                'uuid',
+                Rule::exists('organizational_units', 'id')
+                    ->where('tenant_id', $tenantId)
+                    ->where('is_legal_entity', true)
+                    ->where('is_active', true)
+                    ->whereNull('deleted_at'),
+            ],
             'billing_address' => ['sometimes', 'array'],
             'billing_address.street' => ['required_with:billing_address', 'string', 'max:255'],
             'billing_address.city' => ['required_with:billing_address', 'string', 'max:255'],
@@ -65,6 +78,7 @@ class UpdateCustomerRequest extends FormRequest
             'billing_address.city' => 'billing city',
             'billing_address.postal_code' => 'billing postal code',
             'billing_address.country' => 'billing country',
+            'legal_entity_id' => 'legal entity',
             'contact.name' => 'contact name',
             'contact.email' => 'contact email',
             'contact.phone' => 'contact phone',

--- a/app/Http/Resources/Api/V1/CustomerLegalEntityLookupResource.php
+++ b/app/Http/Resources/Api/V1/CustomerLegalEntityLookupResource.php
@@ -1,0 +1,31 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+
+namespace App\Http\Resources\Api\V1;
+
+use App\Models\OrganizationalUnit;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * Minimal Legal Entity lookup option for customer creation.
+ *
+ * @mixin OrganizationalUnit
+ */
+class CustomerLegalEntityLookupResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array{id: string, name: string}
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+        ];
+    }
+}

--- a/app/Http/Resources/Api/V1/CustomerResource.php
+++ b/app/Http/Resources/Api/V1/CustomerResource.php
@@ -34,6 +34,7 @@ class CustomerResource extends JsonResource
 
         return [
             'id' => $this->resource->id,
+            'legal_entity_id' => $this->resource->legal_entity_id,
             'customer_number' => $this->resource->customer_number,
             'name' => $this->resource->name,
             'billing_address' => $this->resource->billing_address,

--- a/app/Http/Resources/Api/V1/CustomerResource.php
+++ b/app/Http/Resources/Api/V1/CustomerResource.php
@@ -37,6 +37,7 @@ class CustomerResource extends JsonResource
             'legal_entity_id' => $this->resource->legal_entity_id,
             'customer_number' => $this->resource->customer_number,
             'name' => $this->resource->name,
+            'vat_id' => $this->resource->vat_id,
             'billing_address' => $this->resource->billing_address,
             'contact' => $this->resource->contact,
             'notes' => $canUpdate ? $this->resource->notes : null,

--- a/app/Http/Resources/CustomerResource.php
+++ b/app/Http/Resources/CustomerResource.php
@@ -36,6 +36,7 @@ class CustomerResource extends JsonResource
 
         return [
             'id' => $this->id,
+            'legal_entity_id' => $this->legal_entity_id,
             'customer_number' => $this->customer_number,
             'name' => $this->name,
             'billing_address' => $this->billing_address,

--- a/app/Http/Resources/CustomerResource.php
+++ b/app/Http/Resources/CustomerResource.php
@@ -39,6 +39,7 @@ class CustomerResource extends JsonResource
             'legal_entity_id' => $this->legal_entity_id,
             'customer_number' => $this->customer_number,
             'name' => $this->name,
+            'vat_id' => $this->vat_id,
             'billing_address' => $this->billing_address,
             'contact' => $this->contact,
             'notes' => $this->when((bool) $canUpdate, $this->notes),

--- a/app/Models/Customer.php
+++ b/app/Models/Customer.php
@@ -37,6 +37,7 @@ use Spatie\Activitylog\Support\LogOptions;
  * @property string $legal_entity_id Foreign key to organizational_units
  * @property string $customer_number Auto-generated unique identifier (e.g., KD-2025-0001)
  * @property string $name Company/Organization name
+ * @property string|null $vat_id VAT identification number
  * @property array<string, mixed> $billing_address Structured billing address
  * @property array<string, mixed>|null $contact Primary contact person information
  * @property string|null $notes Internal notes
@@ -79,6 +80,7 @@ class Customer extends Model
         'legal_entity_id',
         'customer_number',
         'name',
+        'vat_id',
         'billing_address',
         'contact',
         'notes',
@@ -118,6 +120,7 @@ class Customer extends Model
                 'customer_number',
                 'legal_entity_id',
                 'name',
+                'vat_id',
                 'billing_address',
                 'contact',
                 'is_active',

--- a/app/Models/Customer.php
+++ b/app/Models/Customer.php
@@ -34,6 +34,7 @@ use Spatie\Activitylog\Support\LogOptions;
  *
  * @property string $id UUID primary key
  * @property int $tenant_id Foreign key to tenant_keys
+ * @property string $legal_entity_id Foreign key to organizational_units
  * @property string $customer_number Auto-generated unique identifier (e.g., KD-2025-0001)
  * @property string $name Company/Organization name
  * @property array<string, mixed> $billing_address Structured billing address
@@ -45,6 +46,7 @@ use Spatie\Activitylog\Support\LogOptions;
  * @property \Illuminate\Support\Carbon $updated_at
  * @property \Illuminate\Support\Carbon|null $deleted_at
  * @property-read TenantKey $tenant The tenant this customer belongs to
+ * @property-read OrganizationalUnit $legalEntity The legal entity this customer is assigned to
  * @property-read \Illuminate\Database\Eloquent\Collection<int, Site> $sites Sites belonging to this customer
  * @property-read \Illuminate\Database\Eloquent\Collection<int, Model> $assignments User assignments to this customer
  * @property-read \Illuminate\Database\Eloquent\Collection<int, User> $assignedUsers Users assigned to this customer
@@ -74,6 +76,7 @@ class Customer extends Model
      */
     protected $fillable = [
         'tenant_id',
+        'legal_entity_id',
         'customer_number',
         'name',
         'billing_address',
@@ -113,6 +116,7 @@ class Customer extends Model
         return LogOptions::defaults()
             ->logOnly([
                 'customer_number',
+                'legal_entity_id',
                 'name',
                 'billing_address',
                 'contact',
@@ -141,6 +145,16 @@ class Customer extends Model
     public function tenant(): BelongsTo
     {
         return $this->belongsTo(TenantKey::class, 'tenant_id');
+    }
+
+    /**
+     * Get the legal entity this customer belongs to.
+     *
+     * @return BelongsTo<OrganizationalUnit, $this>
+     */
+    public function legalEntity(): BelongsTo
+    {
+        return $this->belongsTo(OrganizationalUnit::class, 'legal_entity_id');
     }
 
     /**

--- a/database/factories/CustomerFactory.php
+++ b/database/factories/CustomerFactory.php
@@ -78,6 +78,7 @@ class CustomerFactory extends Factory
             },
             'customer_number' => $customerNumber,
             'name' => fake()->company().' '.$companyType,
+            'vat_id' => null,
             'billing_address' => [
                 'street' => fake()->streetAddress(),
                 'city' => fake()->city(),

--- a/database/factories/CustomerFactory.php
+++ b/database/factories/CustomerFactory.php
@@ -6,6 +6,7 @@
 namespace Database\Factories;
 
 use App\Models\Customer;
+use App\Models\OrganizationalUnit;
 use App\Models\TenantKey;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
@@ -63,6 +64,18 @@ class CustomerFactory extends Factory
 
         return [
             'tenant_id' => $tenant->id,
+            'legal_entity_id' => function (array $attributes) use ($tenant): string {
+                $tenantId = $attributes['tenant_id'] ?? $tenant->id;
+
+                if (! is_int($tenantId) && ! is_string($tenantId)) {
+                    throw new \InvalidArgumentException('CustomerFactory tenant_id must be an integer or string.');
+                }
+
+                return OrganizationalUnit::factory()
+                    ->forTenant((string) $tenantId)
+                    ->create(['is_legal_entity' => true])
+                    ->id;
+            },
             'customer_number' => $customerNumber,
             'name' => fake()->company().' '.$companyType,
             'billing_address' => [

--- a/database/migrations/2026_07_14_120000_add_legal_entity_id_to_customers_table.php
+++ b/database/migrations/2026_07_14_120000_add_legal_entity_id_to_customers_table.php
@@ -1,0 +1,59 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (DB::table('customers')->exists()) {
+            throw new RuntimeException(
+                'Cannot add customers.legal_entity_id while customers exist. '
+                .'US-001 requires a product-approved deterministic tenant-consistent backfill before rollout.'
+            );
+        }
+
+        Schema::table('organizational_units', function (Blueprint $table): void {
+            $table->unique(['tenant_id', 'id'], 'unique_organizational_units_tenant_id_id');
+        });
+
+        Schema::table('customers', function (Blueprint $table): void {
+            $table->foreignUuid('legal_entity_id')
+                ->after('tenant_id');
+
+            $table->index(['tenant_id', 'legal_entity_id'], 'idx_customers_tenant_legal_entity');
+
+            $table->foreign(['tenant_id', 'legal_entity_id'], 'customers_tenant_legal_entity_fk')
+                ->references(['tenant_id', 'id'])
+                ->on('organizational_units')
+                ->restrictOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('customers', function (Blueprint $table): void {
+            $table->dropForeign('customers_tenant_legal_entity_fk');
+            $table->dropIndex('idx_customers_tenant_legal_entity');
+            $table->dropColumn('legal_entity_id');
+        });
+
+        Schema::table('organizational_units', function (Blueprint $table): void {
+            $table->dropUnique('unique_organizational_units_tenant_id_id');
+        });
+    }
+};

--- a/database/migrations/2026_07_14_130000_add_vat_id_to_customers_table.php
+++ b/database/migrations/2026_07_14_130000_add_vat_id_to_customers_table.php
@@ -1,0 +1,27 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('customers', function (Blueprint $table): void {
+            $table->string('vat_id', 32)->nullable()->after('name');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('customers', function (Blueprint $table): void {
+            $table->dropColumn('vat_id');
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -220,6 +220,7 @@ Route::prefix('v1')->group(function () {
             Route::middleware('tenant.inject')->group(function () {
                 Route::get('/customers', [CustomerController::class, 'index']);
                 Route::post('/customers', [CustomerController::class, 'store']);
+                Route::get('/customers/legal-entities', [CustomerController::class, 'legalEntities']);
                 Route::get('/customers/{customer}', [CustomerController::class, 'show']);
                 Route::patch('/customers/{customer}', [CustomerController::class, 'update']);
                 Route::delete('/customers/{customer}', [CustomerController::class, 'destroy']);

--- a/tests/Feature/Controllers/Api/V1/CustomerControllerTest.php
+++ b/tests/Feature/Controllers/Api/V1/CustomerControllerTest.php
@@ -561,6 +561,25 @@ describe('POST /v1/customers', function () {
         expect($response->json('data.is_active'))->toBeTrue();
     });
 
+    test('creates customer with an optional VAT ID', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'customers.create');
+        $legalEntity = OrganizationalUnit::factory()->forTenant((string) $this->tenant->id)->create([
+            'is_legal_entity' => true,
+        ]);
+        giveOrganizationalScope($this->user, $legalEntity, accessLevel: 'write');
+
+        $response = $this->withToken($this->token)
+            ->postJson('/v1/customers', customerLegalEntityPayload($legalEntity, [
+                'vat_id' => 'DE123456789',
+            ]));
+
+        $response->assertCreated()
+            ->assertJsonPath('data.vat_id', 'DE123456789');
+
+        expect(Customer::query()->findOrFail($response->json('data.id'))->vat_id)
+            ->toBe('DE123456789');
+    });
+
     test('creates customer with inherited write scope on the legal entity', function (): void {
         givePermissionWithTenant($this->user, $this->tenant->id, 'customers.create');
         $parentUnit = OrganizationalUnit::factory()->forTenant((string) $this->tenant->id)->create();
@@ -985,6 +1004,27 @@ describe('PATCH /v1/customers/{customer}', function () {
 
         $customer->refresh();
         expect($customer->name)->toBe('Updated Corporation');
+    });
+
+    test('updates and clears an optional VAT ID', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'customers.update');
+
+        $customer = Customer::factory()->create([
+            'tenant_id' => $this->tenant->id,
+            'vat_id' => 'DE123456789',
+        ]);
+
+        $this->withToken($this->token)
+            ->patchJson("/v1/customers/{$customer->id}", ['vat_id' => 'DE987654321'])
+            ->assertOk()
+            ->assertJsonPath('data.vat_id', 'DE987654321');
+
+        $this->withToken($this->token)
+            ->patchJson("/v1/customers/{$customer->id}", ['vat_id' => null])
+            ->assertOk()
+            ->assertJsonPath('data.vat_id', null);
+
+        expect($customer->refresh()->vat_id)->toBeNull();
     });
 
     test('updates customer when user is assigned', function (): void {

--- a/tests/Feature/Controllers/Api/V1/CustomerControllerTest.php
+++ b/tests/Feature/Controllers/Api/V1/CustomerControllerTest.php
@@ -366,6 +366,101 @@ describe('GET /v1/customers', function () {
     });
 });
 
+describe('GET /v1/customers/legal-entities', function () {
+    test('returns 401 when not authenticated', function (): void {
+        $response = $this->getJson('/v1/customers/legal-entities');
+
+        $response->assertStatus(401);
+    });
+
+    test('returns 403 when user lacks customers.create permission', function (): void {
+        $legalEntity = OrganizationalUnit::factory()->forTenant((string) $this->tenant->id)->create([
+            'is_legal_entity' => true,
+        ]);
+        giveOrganizationalScope($this->user, $legalEntity, accessLevel: 'write');
+
+        $response = $this->withToken($this->token)->getJson('/v1/customers/legal-entities');
+
+        $response->assertForbidden();
+    });
+
+    test('returns only writable active same-tenant legal entities with the minimal lookup shape', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'customers.create');
+
+        $includedLegalEntity = OrganizationalUnit::factory()->forTenant((string) $this->tenant->id)->create([
+            'name' => 'Allowed Legal Entity',
+            'is_legal_entity' => true,
+            'is_active' => true,
+        ]);
+        $foreignTenant = TenantKey::create(TenantKey::generateEnvelopeKeys());
+        $foreignLegalEntity = OrganizationalUnit::factory()->forTenant((string) $foreignTenant->id)->create([
+            'name' => 'Foreign Legal Entity',
+            'is_legal_entity' => true,
+            'is_active' => true,
+        ]);
+        $inactiveLegalEntity = OrganizationalUnit::factory()->forTenant((string) $this->tenant->id)->create([
+            'name' => 'Inactive Legal Entity',
+            'is_legal_entity' => true,
+            'is_active' => false,
+        ]);
+        $deletedLegalEntity = OrganizationalUnit::factory()->forTenant((string) $this->tenant->id)->create([
+            'name' => 'Deleted Legal Entity',
+            'is_legal_entity' => true,
+            'is_active' => true,
+        ]);
+        $nonLegalEntity = OrganizationalUnit::factory()->forTenant((string) $this->tenant->id)->create([
+            'name' => 'Operational Unit',
+            'is_legal_entity' => false,
+            'is_active' => true,
+        ]);
+        $readOnlyLegalEntity = OrganizationalUnit::factory()->forTenant((string) $this->tenant->id)->create([
+            'name' => 'Read Only Legal Entity',
+            'is_legal_entity' => true,
+            'is_active' => true,
+        ]);
+
+        giveOrganizationalScope($this->user, $includedLegalEntity, accessLevel: 'write');
+        giveOrganizationalScope($this->user, $foreignLegalEntity, accessLevel: 'write');
+        giveOrganizationalScope($this->user, $inactiveLegalEntity, accessLevel: 'write');
+        giveOrganizationalScope($this->user, $deletedLegalEntity, accessLevel: 'write');
+        giveOrganizationalScope($this->user, $nonLegalEntity, accessLevel: 'write');
+        giveOrganizationalScope($this->user, $readOnlyLegalEntity, accessLevel: 'read');
+        $deletedLegalEntity->delete();
+        $this->user->unsetRelation('organizationalScopes');
+
+        $response = $this->withToken($this->token)->getJson('/v1/customers/legal-entities');
+
+        $response->assertOk()
+            ->assertExactJson([
+                'data' => [
+                    [
+                        'id' => $includedLegalEntity->id,
+                        'name' => 'Allowed Legal Entity',
+                    ],
+                ],
+            ]);
+    });
+
+    test('returns legal entities reached through inherited write scope', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'customers.create');
+
+        $parentUnit = OrganizationalUnit::factory()->forTenant((string) $this->tenant->id)->create();
+        $legalEntity = OrganizationalUnit::factory()->forTenant((string) $this->tenant->id)->create([
+            'name' => 'Inherited Legal Entity',
+            'is_legal_entity' => true,
+        ]);
+        $legalEntity->setParent($parentUnit);
+        giveOrganizationalScope($this->user, $parentUnit, accessLevel: 'write');
+        $this->user->unsetRelation('organizationalScopes');
+
+        $response = $this->withToken($this->token)->getJson('/v1/customers/legal-entities');
+
+        $response->assertOk()
+            ->assertJsonPath('data.0.id', $legalEntity->id)
+            ->assertJsonPath('data.0.name', 'Inherited Legal Entity');
+    });
+});
+
 describe('POST /v1/customers', function () {
     test('returns 401 when not authenticated', function (): void {
         $response = $this->postJson('/v1/customers', [

--- a/tests/Feature/Controllers/Api/V1/CustomerControllerTest.php
+++ b/tests/Feature/Controllers/Api/V1/CustomerControllerTest.php
@@ -8,6 +8,7 @@
 
 use App\Models\Customer;
 use App\Models\CustomerAssignment;
+use App\Models\OrganizationalUnit;
 use App\Models\Site;
 use App\Models\SiteAssignment;
 use App\Models\TenantKey;
@@ -42,6 +43,20 @@ beforeEach(function (): void {
     $this->user = User::factory()->create();
     $this->token = $this->user->createToken('test-device')->plainTextToken;
 });
+
+function customerLegalEntityPayload(OrganizationalUnit $legalEntity, array $overrides = []): array
+{
+    return array_replace_recursive([
+        'name' => 'Acme Corporation',
+        'legal_entity_id' => $legalEntity->id,
+        'billing_address' => [
+            'street' => 'Main Street 123',
+            'city' => 'Berlin',
+            'postal_code' => '10115',
+            'country' => 'DE',
+        ],
+    ], $overrides);
+}
 
 afterEach(function (): void {
     // Reset tenant context
@@ -389,6 +404,7 @@ describe('POST /v1/customers', function () {
         $response->assertStatus(422)
             ->assertJsonValidationErrors([
                 'name',
+                'legal_entity_id',
                 'billing_address',
             ]);
     });
@@ -415,28 +431,25 @@ describe('POST /v1/customers', function () {
 
     test('creates customer with auto-generated customer_number', function (): void {
         givePermissionWithTenant($this->user, $this->tenant->id, 'customers.create');
+        $legalEntity = OrganizationalUnit::factory()->forTenant((string) $this->tenant->id)->create([
+            'is_legal_entity' => true,
+        ]);
 
         $response = $this->withToken($this->token)
-            ->postJson('/v1/customers', [
-                'name' => 'Acme Corporation',
-                'billing_address' => [
-                    'street' => 'Main Street 123',
-                    'city' => 'Berlin',
-                    'postal_code' => '10115',
-                    'country' => 'DE',
-                ],
+            ->postJson('/v1/customers', customerLegalEntityPayload($legalEntity, [
                 'contact' => [
                     'name' => 'John Doe',
                     'email' => 'john@acme.com',
                     'phone' => '+49 30 12345678',
                 ],
                 'notes' => 'Important customer',
-            ]);
+            ]));
 
         $response->assertCreated()
             ->assertJsonStructure([
                 'data' => [
                     'id',
+                    'legal_entity_id',
                     'customer_number',
                     'name',
                     'billing_address',
@@ -450,23 +463,21 @@ describe('POST /v1/customers', function () {
         $customerNumber = $response->json('data.customer_number');
         expect($customerNumber)->toMatch('/^KD-\d{4}-\d{4}$/');
         expect($response->json('data.name'))->toBe('Acme Corporation');
+        expect($response->json('data.legal_entity_id'))->toBe($legalEntity->id);
         expect($response->json('data.is_active'))->toBeTrue();
     });
 
     test('creates customer with custom customer_number', function (): void {
         givePermissionWithTenant($this->user, $this->tenant->id, 'customers.create');
+        $legalEntity = OrganizationalUnit::factory()->forTenant((string) $this->tenant->id)->create([
+            'is_legal_entity' => true,
+        ]);
 
         $response = $this->withToken($this->token)
-            ->postJson('/v1/customers', [
+            ->postJson('/v1/customers', customerLegalEntityPayload($legalEntity, [
                 'name' => 'Tech Industries',
                 'customer_number' => 'CUSTOM-001',
-                'billing_address' => [
-                    'street' => 'Tech Ave 42',
-                    'city' => 'Munich',
-                    'postal_code' => '80331',
-                    'country' => 'DE',
-                ],
-            ]);
+            ]));
 
         $response->assertCreated();
         expect($response->json('data.customer_number'))->toBe('CUSTOM-001');
@@ -474,28 +485,22 @@ describe('POST /v1/customers', function () {
 
     test('generates unique customer_number per tenant', function (): void {
         givePermissionWithTenant($this->user, $this->tenant->id, 'customers.create');
+        $legalEntity = OrganizationalUnit::factory()->forTenant((string) $this->tenant->id)->create([
+            'is_legal_entity' => true,
+        ]);
 
         $response1 = $this->withToken($this->token)
-            ->postJson('/v1/customers', [
+            ->postJson('/v1/customers', customerLegalEntityPayload($legalEntity, [
                 'name' => 'First Customer',
-                'billing_address' => [
-                    'street' => 'Street 1',
-                    'city' => 'Berlin',
-                    'postal_code' => '10115',
-                    'country' => 'DE',
-                ],
-            ]);
+            ]));
 
         $response2 = $this->withToken($this->token)
-            ->postJson('/v1/customers', [
+            ->postJson('/v1/customers', customerLegalEntityPayload($legalEntity, [
                 'name' => 'Second Customer',
                 'billing_address' => [
-                    'street' => 'Street 2',
                     'city' => 'Hamburg',
-                    'postal_code' => '20095',
-                    'country' => 'DE',
                 ],
-            ]);
+            ]));
 
         $response1->assertCreated();
         $response2->assertCreated();
@@ -510,20 +515,65 @@ describe('POST /v1/customers', function () {
 
     test('validates country code format (ISO 3166-1 alpha-2)', function (): void {
         givePermissionWithTenant($this->user, $this->tenant->id, 'customers.create');
+        $legalEntity = OrganizationalUnit::factory()->forTenant((string) $this->tenant->id)->create([
+            'is_legal_entity' => true,
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->postJson('/v1/customers', customerLegalEntityPayload($legalEntity, [
+                'name' => 'Invalid Customer',
+                'billing_address' => [
+                    'country' => 'DEU', // Invalid: should be 2 characters
+                ],
+            ]));
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['billing_address.country']);
+    });
+
+    test('rejects customer creation without a legal entity', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'customers.create');
 
         $response = $this->withToken($this->token)
             ->postJson('/v1/customers', [
-                'name' => 'Invalid Customer',
+                'name' => 'Missing Legal Entity',
                 'billing_address' => [
                     'street' => 'Street 1',
                     'city' => 'Berlin',
                     'postal_code' => '10115',
-                    'country' => 'DEU', // Invalid: should be 2 characters
+                    'country' => 'DE',
                 ],
             ]);
 
         $response->assertStatus(422)
-            ->assertJsonValidationErrors(['billing_address.country']);
+            ->assertJsonValidationErrors(['legal_entity_id']);
+    });
+
+    test('rejects customer creation with a legal entity from another tenant', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'customers.create');
+        $otherTenant = TenantKey::create(TenantKey::generateEnvelopeKeys());
+        $foreignLegalEntity = OrganizationalUnit::factory()->forTenant((string) $otherTenant->id)->create([
+            'is_legal_entity' => true,
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->postJson('/v1/customers', customerLegalEntityPayload($foreignLegalEntity));
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['legal_entity_id']);
+    });
+
+    test('rejects customer creation with an organizational unit that is not a legal entity', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'customers.create');
+        $nonLegalEntity = OrganizationalUnit::factory()->forTenant((string) $this->tenant->id)->create([
+            'is_legal_entity' => false,
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->postJson('/v1/customers', customerLegalEntityPayload($nonLegalEntity));
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['legal_entity_id']);
     });
 });
 
@@ -559,6 +609,7 @@ describe('GET /v1/customers/{customer}', function () {
             ->assertJsonStructure([
                 'data' => [
                     'id',
+                    'legal_entity_id',
                     'customer_number',
                     'name',
                     'billing_address',
@@ -572,6 +623,7 @@ describe('GET /v1/customers/{customer}', function () {
             ]);
 
         expect($response->json('data.id'))->toBe($customer->id);
+        expect($response->json('data.legal_entity_id'))->toBe($customer->legal_entity_id);
     });
 
     test('returns linked sites_count in customer detail responses', function (): void {

--- a/tests/Feature/Controllers/Api/V1/CustomerControllerTest.php
+++ b/tests/Feature/Controllers/Api/V1/CustomerControllerTest.php
@@ -382,15 +382,13 @@ describe('POST /v1/customers', function () {
     });
 
     test('returns 403 when user lacks customers.create permission', function (): void {
-        $response = $this->withToken($this->token)->postJson('/v1/customers', [
-            'name' => 'New Customer',
-            'billing_address' => [
-                'street' => 'Main St 1',
-                'city' => 'Berlin',
-                'postal_code' => '10115',
-                'country' => 'DE',
-            ],
+        $legalEntity = OrganizationalUnit::factory()->forTenant((string) $this->tenant->id)->create([
+            'is_legal_entity' => true,
         ]);
+        giveOrganizationalScope($this->user, $legalEntity, accessLevel: 'write');
+
+        $response = $this->withToken($this->token)
+            ->postJson('/v1/customers', customerLegalEntityPayload($legalEntity));
 
         $response->assertStatus(403);
     });
@@ -434,6 +432,7 @@ describe('POST /v1/customers', function () {
         $legalEntity = OrganizationalUnit::factory()->forTenant((string) $this->tenant->id)->create([
             'is_legal_entity' => true,
         ]);
+        giveOrganizationalScope($this->user, $legalEntity, accessLevel: 'write');
 
         $response = $this->withToken($this->token)
             ->postJson('/v1/customers', customerLegalEntityPayload($legalEntity, [
@@ -467,11 +466,28 @@ describe('POST /v1/customers', function () {
         expect($response->json('data.is_active'))->toBeTrue();
     });
 
+    test('creates customer with inherited write scope on the legal entity', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'customers.create');
+        $parentUnit = OrganizationalUnit::factory()->forTenant((string) $this->tenant->id)->create();
+        $legalEntity = OrganizationalUnit::factory()->forTenant((string) $this->tenant->id)->create([
+            'is_legal_entity' => true,
+        ]);
+        $legalEntity->setParent($parentUnit);
+        giveOrganizationalScope($this->user, $parentUnit, accessLevel: 'write');
+
+        $response = $this->withToken($this->token)
+            ->postJson('/v1/customers', customerLegalEntityPayload($legalEntity));
+
+        $response->assertCreated()
+            ->assertJsonPath('data.legal_entity_id', $legalEntity->id);
+    });
+
     test('creates customer with custom customer_number', function (): void {
         givePermissionWithTenant($this->user, $this->tenant->id, 'customers.create');
         $legalEntity = OrganizationalUnit::factory()->forTenant((string) $this->tenant->id)->create([
             'is_legal_entity' => true,
         ]);
+        giveOrganizationalScope($this->user, $legalEntity, accessLevel: 'write');
 
         $response = $this->withToken($this->token)
             ->postJson('/v1/customers', customerLegalEntityPayload($legalEntity, [
@@ -488,6 +504,7 @@ describe('POST /v1/customers', function () {
         $legalEntity = OrganizationalUnit::factory()->forTenant((string) $this->tenant->id)->create([
             'is_legal_entity' => true,
         ]);
+        giveOrganizationalScope($this->user, $legalEntity, accessLevel: 'write');
 
         $response1 = $this->withToken($this->token)
             ->postJson('/v1/customers', customerLegalEntityPayload($legalEntity, [
@@ -518,6 +535,7 @@ describe('POST /v1/customers', function () {
         $legalEntity = OrganizationalUnit::factory()->forTenant((string) $this->tenant->id)->create([
             'is_legal_entity' => true,
         ]);
+        giveOrganizationalScope($this->user, $legalEntity, accessLevel: 'write');
 
         $response = $this->withToken($this->token)
             ->postJson('/v1/customers', customerLegalEntityPayload($legalEntity, [
@@ -549,6 +567,25 @@ describe('POST /v1/customers', function () {
             ->assertJsonValidationErrors(['legal_entity_id']);
     });
 
+    test('rejects customer creation with an unknown legal entity id', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'customers.create');
+
+        $response = $this->withToken($this->token)
+            ->postJson('/v1/customers', [
+                'name' => 'Unknown Legal Entity Customer',
+                'legal_entity_id' => '00000000-0000-4000-8000-000000000000',
+                'billing_address' => [
+                    'street' => 'Street 1',
+                    'city' => 'Berlin',
+                    'postal_code' => '10115',
+                    'country' => 'DE',
+                ],
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['legal_entity_id']);
+    });
+
     test('rejects customer creation with a legal entity from another tenant', function (): void {
         givePermissionWithTenant($this->user, $this->tenant->id, 'customers.create');
         $otherTenant = TenantKey::create(TenantKey::generateEnvelopeKeys());
@@ -558,6 +595,21 @@ describe('POST /v1/customers', function () {
 
         $response = $this->withToken($this->token)
             ->postJson('/v1/customers', customerLegalEntityPayload($foreignLegalEntity));
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['legal_entity_id']);
+    });
+
+    test('rejects customer creation with a soft-deleted legal entity', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'customers.create');
+        $deletedLegalEntity = OrganizationalUnit::factory()->forTenant((string) $this->tenant->id)->create([
+            'is_legal_entity' => true,
+        ]);
+        giveOrganizationalScope($this->user, $deletedLegalEntity, accessLevel: 'write');
+        $deletedLegalEntity->delete();
+
+        $response = $this->withToken($this->token)
+            ->postJson('/v1/customers', customerLegalEntityPayload($deletedLegalEntity));
 
         $response->assertStatus(422)
             ->assertJsonValidationErrors(['legal_entity_id']);
@@ -574,6 +626,39 @@ describe('POST /v1/customers', function () {
 
         $response->assertStatus(422)
             ->assertJsonValidationErrors(['legal_entity_id']);
+    });
+
+    test('rejects customer creation without write scope on the legal entity', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'customers.create');
+        $legalEntity = OrganizationalUnit::factory()->forTenant((string) $this->tenant->id)->create([
+            'is_legal_entity' => true,
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->postJson('/v1/customers', customerLegalEntityPayload($legalEntity));
+
+        $response->assertForbidden();
+        $this->assertDatabaseMissing('customers', [
+            'tenant_id' => $this->tenant->id,
+            'legal_entity_id' => $legalEntity->id,
+        ]);
+    });
+
+    test('rejects customer creation with only read scope on the legal entity', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'customers.create');
+        $legalEntity = OrganizationalUnit::factory()->forTenant((string) $this->tenant->id)->create([
+            'is_legal_entity' => true,
+        ]);
+        giveOrganizationalScope($this->user, $legalEntity, accessLevel: 'read');
+
+        $response = $this->withToken($this->token)
+            ->postJson('/v1/customers', customerLegalEntityPayload($legalEntity));
+
+        $response->assertForbidden();
+        $this->assertDatabaseMissing('customers', [
+            'tenant_id' => $this->tenant->id,
+            'legal_entity_id' => $legalEntity->id,
+        ]);
     });
 });
 

--- a/tests/Feature/Controllers/CustomerSiteNumberConcurrencyTest.php
+++ b/tests/Feature/Controllers/CustomerSiteNumberConcurrencyTest.php
@@ -88,6 +88,7 @@ beforeEach(function (): void {
     $this->customer = Customer::factory()->create([
         'tenant_id' => $this->tenant->id,
     ]);
+    giveOrganizationalScope($this->user, $this->customer->legalEntity, accessLevel: 'write');
 
     $this->organizationalUnit = OrganizationalUnit::factory()->create([
         'tenant_id' => $this->tenant->id,

--- a/tests/Feature/Controllers/CustomerSiteNumberConcurrencyTest.php
+++ b/tests/Feature/Controllers/CustomerSiteNumberConcurrencyTest.php
@@ -113,7 +113,7 @@ test('concurrent customer creation requests produce distinct customer numbers', 
         $this,
         $requestCount,
         '/v1/customers',
-        fn (int $index): array => customerCreationPayload($index),
+        fn (int $index): array => customerCreationPayload($index, $this->customer->legal_entity_id),
         fn (array $body): array => [
             'status' => $body['status'],
             'customer_number' => $body['body']['data']['customer_number'] ?? null,
@@ -257,10 +257,11 @@ function runConcurrentJsonPosts(
 /**
  * @return array<string, mixed>
  */
-function customerCreationPayload(int $index): array
+function customerCreationPayload(int $index, string $legalEntityId): array
 {
     return [
         'name' => "Concurrent Customer {$index}",
+        'legal_entity_id' => $legalEntityId,
         'billing_address' => [
             'street' => "Concurrency Street {$index}",
             'city' => 'Berlin',

--- a/tests/Feature/Migrations/AddCustomerLegalEntityMigrationTest.php
+++ b/tests/Feature/Migrations/AddCustomerLegalEntityMigrationTest.php
@@ -1,0 +1,15 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+
+declare(strict_types=1);
+
+test('customer legal entity migration preserves the approved existing-data strategy', function (): void {
+    $migration = file_get_contents(base_path('database/migrations/2026_07_14_120000_add_legal_entity_id_to_customers_table.php'));
+
+    expect($migration)->toContain("DB::table('customers')->exists()")
+        ->and($migration)->toContain('Cannot add customers.legal_entity_id while customers exist.')
+        ->and($migration)->toContain('US-001 requires a product-approved deterministic tenant-consistent backfill')
+        ->and($migration)->not->toContain('default(');
+});

--- a/tests/Feature/Migrations/CreateCostCentersTableTest.php
+++ b/tests/Feature/Migrations/CreateCostCentersTableTest.php
@@ -50,6 +50,7 @@ function createCostCenterTestCustomer(string $tenantId, string $customerNumber):
     DB::table('customers')->insert([
         'id' => $customerId,
         'tenant_id' => $tenantId,
+        'legal_entity_id' => createCostCenterLegalEntity($tenantId),
         'customer_number' => $customerNumber,
         'name' => 'Test Customer',
         'billing_address' => json_encode(['street' => 'Test', 'city' => 'Berlin', 'postal_code' => '10115', 'country' => 'DE']),
@@ -59,6 +60,22 @@ function createCostCenterTestCustomer(string $tenantId, string $customerNumber):
     ]);
 
     return $customerId;
+}
+
+function createCostCenterLegalEntity(string $tenantId): string
+{
+    $legalEntityId = Str::uuid()->toString();
+    DB::table('organizational_units')->insert([
+        'id' => $legalEntityId,
+        'tenant_id' => $tenantId,
+        'type' => 'company',
+        'name' => 'Cost Center Legal Entity',
+        'is_legal_entity' => true,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    return $legalEntityId;
 }
 
 /**

--- a/tests/Feature/Migrations/CreateCustomerAssignmentsTableTest.php
+++ b/tests/Feature/Migrations/CreateCustomerAssignmentsTableTest.php
@@ -60,6 +60,7 @@ function createCustomerAssignmentTestCustomer(string $tenantId, string $customer
     DB::table('customers')->insert([
         'id' => $customerId,
         'tenant_id' => $tenantId,
+        'legal_entity_id' => createCustomerAssignmentLegalEntity($tenantId),
         'customer_number' => $customerNumber,
         'name' => 'Test Customer',
         'billing_address' => json_encode(['street' => 'Test', 'city' => 'Berlin', 'postal_code' => '10115', 'country' => 'DE']),
@@ -69,6 +70,22 @@ function createCustomerAssignmentTestCustomer(string $tenantId, string $customer
     ]);
 
     return $customerId;
+}
+
+function createCustomerAssignmentLegalEntity(string $tenantId): string
+{
+    $legalEntityId = Str::uuid()->toString();
+    DB::table('organizational_units')->insert([
+        'id' => $legalEntityId,
+        'tenant_id' => $tenantId,
+        'type' => 'company',
+        'name' => 'Assignment Legal Entity',
+        'is_legal_entity' => true,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    return $legalEntityId;
 }
 
 /**

--- a/tests/Feature/Migrations/CreateCustomersTableTest.php
+++ b/tests/Feature/Migrations/CreateCustomersTableTest.php
@@ -4,6 +4,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
+use App\Models\OrganizationalUnit;
 use App\Models\TenantKey;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
@@ -28,10 +29,15 @@ afterEach(function (): void {
  */
 function createMinimalCustomer(string $tenantId, string $customerNumber, string $name = 'Test Customer'): string
 {
+    $legalEntityId = OrganizationalUnit::factory()->forTenant($tenantId)->create([
+        'is_legal_entity' => true,
+    ])->id;
+
     $customerId = Str::uuid()->toString();
     DB::table('customers')->insert([
         'id' => $customerId,
         'tenant_id' => $tenantId,
+        'legal_entity_id' => $legalEntityId,
         'customer_number' => $customerNumber,
         'name' => $name,
         'billing_address' => json_encode(['street' => 'Test', 'city' => 'Berlin', 'postal_code' => '10115', 'country' => 'DE']),
@@ -43,12 +49,20 @@ function createMinimalCustomer(string $tenantId, string $customerNumber, string 
     return $customerId;
 }
 
+function createCustomerMigrationLegalEntity(string $tenantId): string
+{
+    return OrganizationalUnit::factory()->forTenant($tenantId)->create([
+        'is_legal_entity' => true,
+    ])->id;
+}
+
 describe('CreateCustomersTable Migration', function () {
     test('creates customers table with correct columns', function (): void {
         expect(Schema::hasTable('customers'))->toBeTrue();
 
         expect(Schema::hasColumn('customers', 'id'))->toBeTrue();
         expect(Schema::hasColumn('customers', 'tenant_id'))->toBeTrue();
+        expect(Schema::hasColumn('customers', 'legal_entity_id'))->toBeTrue();
         expect(Schema::hasColumn('customers', 'customer_number'))->toBeTrue();
         expect(Schema::hasColumn('customers', 'name'))->toBeTrue();
         expect(Schema::hasColumn('customers', 'billing_address'))->toBeTrue();
@@ -66,6 +80,7 @@ describe('CreateCustomersTable Migration', function () {
         $indexColumns = collect($indexes)->pluck('columns')->flatten()->toArray();
 
         expect($indexColumns)->toContain('tenant_id');
+        expect($indexColumns)->toContain('legal_entity_id');
         expect($indexColumns)->toContain('customer_number');
         expect($indexColumns)->toContain('is_active');
         expect($indexColumns)->toContain('name');
@@ -95,6 +110,58 @@ describe('CreateCustomersTable Migration', function () {
         expect($hasTenantForeignKey)->toBeTrue();
     });
 
+    test('foreign key constraint on legal_entity_id references organizational_units', function (): void {
+        $foreignKeys = Schema::getForeignKeys('customers');
+
+        $hasLegalEntityForeignKey = collect($foreignKeys)->contains(function ($fk) {
+            return in_array('legal_entity_id', $fk['columns'])
+                && $fk['foreign_table'] === 'organizational_units';
+        });
+
+        expect($hasLegalEntityForeignKey)->toBeTrue();
+    });
+
+    test('composite tenant legal entity foreign key enforces same tenant', function (): void {
+        $foreignKeys = Schema::getForeignKeys('customers');
+
+        $hasCompositeForeignKey = collect($foreignKeys)->contains(function ($fk) {
+            return in_array('tenant_id', $fk['columns'])
+                && in_array('legal_entity_id', $fk['columns'])
+                && $fk['foreign_table'] === 'organizational_units';
+        });
+
+        expect($hasCompositeForeignKey)->toBeTrue();
+    });
+
+    test('tenant and legal entity index is present', function (): void {
+        $indexes = Schema::getIndexes('customers');
+
+        $hasTenantLegalEntityIndex = collect($indexes)->contains(function ($index) {
+            return $index['name'] === 'idx_customers_tenant_legal_entity'
+                && $index['columns'] === ['tenant_id', 'legal_entity_id'];
+        });
+
+        expect($hasTenantLegalEntityIndex)->toBeTrue();
+    });
+
+    test('rejects a legal entity from another tenant at database level', function (): void {
+        $tenant = TenantKey::create(TenantKey::generateEnvelopeKeys());
+        $otherTenant = TenantKey::create(TenantKey::generateEnvelopeKeys());
+        $foreignLegalEntity = createCustomerMigrationLegalEntity((string) $otherTenant->id);
+
+        DB::table('customers')->insert([
+            'id' => Str::uuid()->toString(),
+            'tenant_id' => $tenant->id,
+            'legal_entity_id' => $foreignLegalEntity,
+            'customer_number' => 'KD-2025-CROSS',
+            'name' => 'Cross Tenant Customer',
+            'billing_address' => json_encode(['street' => 'Test', 'city' => 'Berlin', 'postal_code' => '10115', 'country' => 'DE']),
+            'is_active' => true,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    })->throws(PDOException::class);
+
     test('cascade delete removes customers when tenant is deleted', function (): void {
         $keys = TenantKey::generateEnvelopeKeys();
         $tenant = TenantKey::create($keys);
@@ -122,6 +189,7 @@ describe('CreateCustomersTable Migration', function () {
         DB::table('customers')->insert([
             'id' => $customerId,
             'tenant_id' => $tenant->id,
+            'legal_entity_id' => createCustomerMigrationLegalEntity((string) $tenant->id),
             'customer_number' => 'KD-2025-002',
             'name' => 'Acme Corporation',
             'billing_address' => json_encode($billingAddress),
@@ -154,6 +222,7 @@ describe('CreateCustomersTable Migration', function () {
         DB::table('customers')->insert([
             'id' => $customerId,
             'tenant_id' => $tenant->id,
+            'legal_entity_id' => createCustomerMigrationLegalEntity((string) $tenant->id),
             'customer_number' => 'KD-2025-003',
             'name' => 'Test Company',
             'billing_address' => json_encode(['street' => 'Test', 'city' => 'Berlin', 'postal_code' => '10115', 'country' => 'DE']),
@@ -184,6 +253,7 @@ describe('CreateCustomersTable Migration', function () {
         DB::table('customers')->insert([
             'id' => $customerId,
             'tenant_id' => $tenant->id,
+            'legal_entity_id' => createCustomerMigrationLegalEntity((string) $tenant->id),
             'customer_number' => 'KD-2025-004',
             'name' => 'Metadata Test Company',
             'billing_address' => json_encode(['street' => 'Test', 'city' => 'Berlin', 'postal_code' => '10115', 'country' => 'DE']),

--- a/tests/Feature/Migrations/CreateSiteAssignmentsTableTest.php
+++ b/tests/Feature/Migrations/CreateSiteAssignmentsTableTest.php
@@ -78,6 +78,7 @@ function createSiteTestCustomer(string $tenantId, string $customerNumber): strin
     DB::table('customers')->insert([
         'id' => $customerId,
         'tenant_id' => $tenantId,
+        'legal_entity_id' => createSiteAssignmentLegalEntity($tenantId),
         'customer_number' => $customerNumber,
         'name' => 'Test Customer',
         'billing_address' => json_encode(['street' => 'Test', 'city' => 'Berlin', 'postal_code' => '10115', 'country' => 'DE']),
@@ -87,6 +88,22 @@ function createSiteTestCustomer(string $tenantId, string $customerNumber): strin
     ]);
 
     return $customerId;
+}
+
+function createSiteAssignmentLegalEntity(string $tenantId): string
+{
+    $legalEntityId = Str::uuid()->toString();
+    DB::table('organizational_units')->insert([
+        'id' => $legalEntityId,
+        'tenant_id' => $tenantId,
+        'type' => 'company',
+        'name' => 'Site Assignment Legal Entity',
+        'is_legal_entity' => true,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    return $legalEntityId;
 }
 
 /**

--- a/tests/Feature/Migrations/CreateSitesTableTest.php
+++ b/tests/Feature/Migrations/CreateSitesTableTest.php
@@ -32,6 +32,7 @@ function createTestCustomer(string $tenantId, string $customerNumber = 'KD-TEST-
     DB::table('customers')->insert([
         'id' => $customerId,
         'tenant_id' => $tenantId,
+        'legal_entity_id' => createTestLegalEntity($tenantId),
         'customer_number' => $customerNumber,
         'name' => 'Test Customer',
         'billing_address' => json_encode(['street' => 'Test', 'city' => 'Berlin', 'postal_code' => '10115', 'country' => 'DE']),
@@ -59,6 +60,17 @@ function createTestOrgUnit(string $tenantId, string $type = 'branch'): string
     ]);
 
     return $orgUnitId;
+}
+
+function createTestLegalEntity(string $tenantId): string
+{
+    $legalEntityId = createTestOrgUnit($tenantId, 'company');
+
+    DB::table('organizational_units')
+        ->where('id', $legalEntityId)
+        ->update(['is_legal_entity' => true]);
+
+    return $legalEntityId;
 }
 
 describe('CreateSitesTable Migration', function () {
@@ -240,6 +252,7 @@ describe('CreateSitesTable Migration', function () {
         DB::table('customers')->insert([
             'id' => $customerId,
             'tenant_id' => $tenant->id,
+            'legal_entity_id' => createTestLegalEntity((string) $tenant->id),
             'customer_number' => 'KD-2025-INVALID',
             'name' => 'Test Customer',
             'billing_address' => json_encode(['street' => 'Test', 'city' => 'Berlin', 'postal_code' => '10115', 'country' => 'DE']),

--- a/tests/Unit/Models/CustomerTest.php
+++ b/tests/Unit/Models/CustomerTest.php
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
 use App\Models\Customer;
+use App\Models\OrganizationalUnit;
 use App\Models\TenantKey;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
@@ -36,10 +37,35 @@ test('customer can be created with factory', function (): void {
     $customer = Customer::factory()->create();
 
     expect($customer->id)->not->toBeNull()
+        ->and($customer->legal_entity_id)->not->toBeNull()
         ->and($customer->customer_number)->not->toBeNull()
         ->and($customer->name)->not->toBeNull()
         ->and($customer->billing_address)->toBeArray()
         ->and($customer->is_active)->toBeTrue();
+});
+
+test('customer has legal entity relationship', function (): void {
+    $legalEntity = OrganizationalUnit::factory()->forTenant((string) $this->tenant->id)->create([
+        'is_legal_entity' => true,
+    ]);
+
+    $customer = Customer::factory()->create([
+        'tenant_id' => $this->tenant->id,
+        'legal_entity_id' => $legalEntity->id,
+    ]);
+
+    expect($customer->legalEntity)->toBeInstanceOf(OrganizationalUnit::class)
+        ->and($customer->legalEntity->id)->toBe($legalEntity->id);
+});
+
+test('customer factory creates a tenant matching legal entity by default', function (): void {
+    $customer = Customer::factory()->create([
+        'tenant_id' => $this->tenant->id,
+    ]);
+
+    expect($customer->legalEntity)->toBeInstanceOf(OrganizationalUnit::class)
+        ->and($customer->legalEntity->tenant_id)->toBe($customer->tenant_id)
+        ->and($customer->legalEntity->is_legal_entity)->toBeTrue();
 });
 
 test('customer number is auto generated with correct format', function (): void {


### PR DESCRIPTION
## Summary

- Persist required tenant-consistent customer Legal Entities and enforce creation authorization.
- Add the minimal customer Legal Entity lookup endpoint.
- Persist, validate, and expose optional customer VAT IDs.

## Validation

- Customer controller tests, Pint, and PHPStan.

## Related workspace PRs

- Contract changes: https://github.com/SecPal/contracts/pull/353
- Frontend integration: https://github.com/SecPal/frontend/pull/1399
