### PR TITLE
feat: authorize customer Legal Entity creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- required `POST /v1/customers` to combine `customers.create` with write access on the exact submitted active same-tenant Legal Entity, using inherited organizational scopes and rejecting customer creation when the entity scope is missing or read-only
 - applied the existing `passkey-verify` limiter to `DELETE /v1/me/passkeys/{credentialId}` so wrong `current_password` guesses on passkey deletion now lock out the same way as passkey enrollment verification attempts
 - required current-password step-up before passkey enrollment challenge creation, passkey enrollment verification, and passkey deletion, and defaulted passkey user verification to `required` so newly enrolled passkeys cannot convert a stolen token into an MFA-complete login without a fresh primary-auth proof.
 - single-shot identity-proof enforcement on `POST /v1/onboarding/complete`: a failed date-of-birth check or a name that deviates too far from the HR record now permanently burns the magic link (`invalidated_at`, `invalidated_from_ip`, `invalidated_user_agent`, `invalidation_reason` recorded on `employee_onboarding_tokens`). A single generic 422 is returned for all identity mismatches so an attacker cannot use the response as a per-field oracle. HR must issue a fresh invitation after any failed identity proof.

--- a/app/Http/Controllers/Api/V1/CustomerController.php
+++ b/app/Http/Controllers/Api/V1/CustomerController.php
@@ -13,6 +13,7 @@ use App\Http\Requests\Api\V1\UpdateCustomerRequest;
 use App\Http\Resources\CustomerResource;
 use App\Http\Resources\SiteResource;
 use App\Models\Customer;
+use App\Models\OrganizationalUnit;
 use App\Models\Site;
 use App\Models\TenantKey;
 use App\Models\User;
@@ -140,6 +141,18 @@ class CustomerController extends Controller
         /** @var int $tenantId */
         $tenantId = $request->get('tenant_id');
         $validated['tenant_id'] = $tenantId;
+        /** @var User $user */
+        $user = $request->user();
+        $legalEntity = OrganizationalUnit::query()
+            ->whereKey($validated['legal_entity_id'])
+            ->where('tenant_id', $tenantId)
+            ->where('is_legal_entity', true)
+            ->where('is_active', true)
+            ->firstOrFail();
+
+        if (! $user->hasAccessToUnit($legalEntity, 'write')) {
+            abort(Response::HTTP_FORBIDDEN, __('Insufficient access level. Required: :level', ['level' => 'write']));
+        }
 
         $customer = DB::transaction(function () use ($tenantId, $validated): Customer {
             TenantKey::query()->select('id')->whereKey($tenantId)->lockForUpdate()->firstOrFail();

--- a/tests/Feature/Controllers/Api/V1/CustomerControllerTest.php
+++ b/tests/Feature/Controllers/Api/V1/CustomerControllerTest.php
@@ -382,15 +382,13 @@ describe('POST /v1/customers', function () {
     });
 
     test('returns 403 when user lacks customers.create permission', function (): void {
-        $response = $this->withToken($this->token)->postJson('/v1/customers', [
-            'name' => 'New Customer',
-            'billing_address' => [
-                'street' => 'Main St 1',
-                'city' => 'Berlin',
-                'postal_code' => '10115',
-                'country' => 'DE',
-            ],
+        $legalEntity = OrganizationalUnit::factory()->forTenant((string) $this->tenant->id)->create([
+            'is_legal_entity' => true,
         ]);
+        giveOrganizationalScope($this->user, $legalEntity, accessLevel: 'write');
+
+        $response = $this->withToken($this->token)
+            ->postJson('/v1/customers', customerLegalEntityPayload($legalEntity));
 
         $response->assertStatus(403);
     });
@@ -434,6 +432,7 @@ describe('POST /v1/customers', function () {
         $legalEntity = OrganizationalUnit::factory()->forTenant((string) $this->tenant->id)->create([
             'is_legal_entity' => true,
         ]);
+        giveOrganizationalScope($this->user, $legalEntity, accessLevel: 'write');
 
         $response = $this->withToken($this->token)
             ->postJson('/v1/customers', customerLegalEntityPayload($legalEntity, [
@@ -467,11 +466,28 @@ describe('POST /v1/customers', function () {
         expect($response->json('data.is_active'))->toBeTrue();
     });
 
+    test('creates customer with inherited write scope on the legal entity', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'customers.create');
+        $parentUnit = OrganizationalUnit::factory()->forTenant((string) $this->tenant->id)->create();
+        $legalEntity = OrganizationalUnit::factory()->forTenant((string) $this->tenant->id)->create([
+            'is_legal_entity' => true,
+        ]);
+        $legalEntity->setParent($parentUnit);
+        giveOrganizationalScope($this->user, $parentUnit, accessLevel: 'write');
+
+        $response = $this->withToken($this->token)
+            ->postJson('/v1/customers', customerLegalEntityPayload($legalEntity));
+
+        $response->assertCreated()
+            ->assertJsonPath('data.legal_entity_id', $legalEntity->id);
+    });
+
     test('creates customer with custom customer_number', function (): void {
         givePermissionWithTenant($this->user, $this->tenant->id, 'customers.create');
         $legalEntity = OrganizationalUnit::factory()->forTenant((string) $this->tenant->id)->create([
             'is_legal_entity' => true,
         ]);
+        giveOrganizationalScope($this->user, $legalEntity, accessLevel: 'write');
 
         $response = $this->withToken($this->token)
             ->postJson('/v1/customers', customerLegalEntityPayload($legalEntity, [
@@ -488,6 +504,7 @@ describe('POST /v1/customers', function () {
         $legalEntity = OrganizationalUnit::factory()->forTenant((string) $this->tenant->id)->create([
             'is_legal_entity' => true,
         ]);
+        giveOrganizationalScope($this->user, $legalEntity, accessLevel: 'write');
 
         $response1 = $this->withToken($this->token)
             ->postJson('/v1/customers', customerLegalEntityPayload($legalEntity, [
@@ -518,6 +535,7 @@ describe('POST /v1/customers', function () {
         $legalEntity = OrganizationalUnit::factory()->forTenant((string) $this->tenant->id)->create([
             'is_legal_entity' => true,
         ]);
+        giveOrganizationalScope($this->user, $legalEntity, accessLevel: 'write');
 
         $response = $this->withToken($this->token)
             ->postJson('/v1/customers', customerLegalEntityPayload($legalEntity, [
@@ -549,6 +567,25 @@ describe('POST /v1/customers', function () {
             ->assertJsonValidationErrors(['legal_entity_id']);
     });
 
+    test('rejects customer creation with an unknown legal entity id', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'customers.create');
+
+        $response = $this->withToken($this->token)
+            ->postJson('/v1/customers', [
+                'name' => 'Unknown Legal Entity Customer',
+                'legal_entity_id' => '00000000-0000-4000-8000-000000000000',
+                'billing_address' => [
+                    'street' => 'Street 1',
+                    'city' => 'Berlin',
+                    'postal_code' => '10115',
+                    'country' => 'DE',
+                ],
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['legal_entity_id']);
+    });
+
     test('rejects customer creation with a legal entity from another tenant', function (): void {
         givePermissionWithTenant($this->user, $this->tenant->id, 'customers.create');
         $otherTenant = TenantKey::create(TenantKey::generateEnvelopeKeys());
@@ -558,6 +595,21 @@ describe('POST /v1/customers', function () {
 
         $response = $this->withToken($this->token)
             ->postJson('/v1/customers', customerLegalEntityPayload($foreignLegalEntity));
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['legal_entity_id']);
+    });
+
+    test('rejects customer creation with a soft-deleted legal entity', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'customers.create');
+        $deletedLegalEntity = OrganizationalUnit::factory()->forTenant((string) $this->tenant->id)->create([
+            'is_legal_entity' => true,
+        ]);
+        giveOrganizationalScope($this->user, $deletedLegalEntity, accessLevel: 'write');
+        $deletedLegalEntity->delete();
+
+        $response = $this->withToken($this->token)
+            ->postJson('/v1/customers', customerLegalEntityPayload($deletedLegalEntity));
 
         $response->assertStatus(422)
             ->assertJsonValidationErrors(['legal_entity_id']);
@@ -574,6 +626,39 @@ describe('POST /v1/customers', function () {
 
         $response->assertStatus(422)
             ->assertJsonValidationErrors(['legal_entity_id']);
+    });
+
+    test('rejects customer creation without write scope on the legal entity', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'customers.create');
+        $legalEntity = OrganizationalUnit::factory()->forTenant((string) $this->tenant->id)->create([
+            'is_legal_entity' => true,
+        ]);
+
+        $response = $this->withToken($this->token)
+            ->postJson('/v1/customers', customerLegalEntityPayload($legalEntity));
+
+        $response->assertForbidden();
+        $this->assertDatabaseMissing('customers', [
+            'tenant_id' => $this->tenant->id,
+            'legal_entity_id' => $legalEntity->id,
+        ]);
+    });
+
+    test('rejects customer creation with only read scope on the legal entity', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'customers.create');
+        $legalEntity = OrganizationalUnit::factory()->forTenant((string) $this->tenant->id)->create([
+            'is_legal_entity' => true,
+        ]);
+        giveOrganizationalScope($this->user, $legalEntity, accessLevel: 'read');
+
+        $response = $this->withToken($this->token)
+            ->postJson('/v1/customers', customerLegalEntityPayload($legalEntity));
+
+        $response->assertForbidden();
+        $this->assertDatabaseMissing('customers', [
+            'tenant_id' => $this->tenant->id,
+            'legal_entity_id' => $legalEntity->id,
+        ]);
     });
 });
 

--- a/tests/Feature/Controllers/CustomerSiteNumberConcurrencyTest.php
+++ b/tests/Feature/Controllers/CustomerSiteNumberConcurrencyTest.php
@@ -88,6 +88,7 @@ beforeEach(function (): void {
     $this->customer = Customer::factory()->create([
         'tenant_id' => $this->tenant->id,
     ]);
+    giveOrganizationalScope($this->user, $this->customer->legalEntity, accessLevel: 'write');
 
     $this->organizationalUnit = OrganizationalUnit::factory()->create([
         'tenant_id' => $this->tenant->id,


### PR DESCRIPTION
## Summary

- Authorize customer creation against the exact writable Legal Entity.

## Validation

- Focused customer controller tests, Pint, and PHPStan.


## Related draft PRs

- Contract Legal Entity: https://github.com/SecPal/contracts/pull/354
- API Legal Entity persistence: https://github.com/SecPal/api/pull/1282
- API creation authorization: https://github.com/SecPal/api/pull/1285
- API lookup endpoint: https://github.com/SecPal/api/pull/1284
- Frontend migration decision: https://github.com/SecPal/frontend/pull/1395
- Frontend contract integration: https://github.com/SecPal/frontend/pull/1398
- Frontend lookup client: https://github.com/SecPal/frontend/pull/1396
- Frontend selector: https://github.com/SecPal/frontend/pull/1397
- Contract VAT ID: https://github.com/SecPal/contracts/pull/353
- API VAT ID: https://github.com/SecPal/api/pull/1283
- Frontend VAT ID: https://github.com/SecPal/frontend/pull/1399
