### PR TITLE
Fix draft reminder issue-event execution

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -34,6 +34,7 @@ jobs:
 
   draft-reminder:
     name: Draft PR Reminder
+    if: github.event_name == 'pull_request'
     uses: SecPal/.github/.github/workflows/draft-pr-reminder.yml@main
     permissions:
       issues: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- restricted the draft pull-request reminder workflow to `pull_request` events, preventing issue-event runs from attempting to create a pull-request reminder comment without issue-comment permission (fixes `api#1287`)
 - excluded gitignored `.context` workspace notes from local markdownlint preflight checks so only repository Markdown artifacts are validated (fixes `api#1286`)
 - aligned repository-owned runtime code and asset SPDX metadata with the SecPal Contributors AGPL attribution policy, returned documentation and configuration to their CC0 policy, preserved third-party notices separately, and added license-check regression guards for attribution addendum scope in concluded and in-file SPDX metadata (refs `api#1226`)
 - seed the SecPal Holding organizational unit as both a legal entity and establishment, including repairing the flags when the unit already exists

--- a/tests/Unit/ProjectAutomationWorkflowTest.php
+++ b/tests/Unit/ProjectAutomationWorkflowTest.php
@@ -8,11 +8,16 @@ declare(strict_types=1);
 test('draft reminder only runs for pull request events', function (): void {
     $contents = file_get_contents(base_path('.github/workflows/project-automation.yml'));
 
-    expect($contents)
-        ->not->toBeFalse()
-        ->toContain(implode("\n", [
-            '  draft-reminder:',
-            '    name: Draft PR Reminder',
-            "    if: github.event_name == 'pull_request'",
-        ]));
+    expect($contents)->not->toBeFalse();
+
+    $normalizedContents = str_replace(["\r\n", "\r"], "\n", $contents);
+    $jobWasFound = preg_match(
+        '/^  draft-reminder:\n(?<job>(?: {4}.*(?:\n|$))*)/m',
+        $normalizedContents,
+        $matches,
+    );
+
+    expect($jobWasFound)->toBe(1)
+        ->and($matches['job'])
+        ->toMatch("/^    if: github\\.event_name == 'pull_request'$/m");
 });

--- a/tests/Unit/ProjectAutomationWorkflowTest.php
+++ b/tests/Unit/ProjectAutomationWorkflowTest.php
@@ -1,0 +1,18 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+
+declare(strict_types=1);
+
+test('draft reminder only runs for pull request events', function (): void {
+    $contents = file_get_contents(base_path('.github/workflows/project-automation.yml'));
+
+    expect($contents)
+        ->not->toBeFalse()
+        ->toContain(implode("\n", [
+            '  draft-reminder:',
+            '    name: Draft PR Reminder',
+            "    if: github.event_name == 'pull_request'",
+        ]));
+});


### PR DESCRIPTION
## Reproduced defect

[Actions run 29349499595](https://github.com/SecPal/api/actions/runs/29349499595), triggered while handling #1286, ran the draft reminder for an `issues` event. The reusable reminder workflow then attempted `issues.createComment` with a token that lacked issue-comment permission and failed with 403.

## Change

- Restrict `draft-reminder` to `pull_request` events while leaving project automation available for its configured issue and pull-request events.
- Record the behavior fix in the Unreleased changelog.

Fixes #1287.

## Validation

- `actionlint .github/workflows/project-automation.yml`
- `yamllint .github/workflows/project-automation.yml` (existing document-start warning tracked in #1292)
- `reuse lint`
- Commit hooks: Prettier, Markdownlint, YAML lint, Actions workflow lint, and REUSE checks
- `PREFLIGHT_RUN_TESTS=1 git push -u origin restrict-draft-reminder`: formatting, static analysis, licensing, domain-policy, Pint, and test-suite checks

## Follow-up before ready

- Confirm required CI checks and complete the final PR self-review.
- #1292 tracks the pre-existing YAML document-start warning.
- #1296 tracks clarification of the timeout rule for reusable-workflow caller jobs; GitHub Actions does not permit `timeout-minutes` on this job type.
- No linked workspaces were changed.
