### PR TITLE
Add YAML document start to project automation

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 # SPDX-License-Identifier: CC0-1.0
 
+---
 name: Project Board Automation
 
 on:


### PR DESCRIPTION
## Validation

`yamllint .github/workflows/project-automation.yml` reproduced the reported `document-start` warning at line 4 before this change. The warning is resolved after adding the YAML document start.

## Change

- Add `---` before the workflow document in `.github/workflows/project-automation.yml`.

## Checks

- `yamllint .github/workflows/project-automation.yml`
- `actionlint .github/workflows/project-automation.yml`
- `npx --yes prettier@4.0.0-alpha.8 --check .github/workflows/project-automation.yml`
- `git diff --check`
- Signed commit hooks: REUSE, Prettier, YAML lint, Actions workflow lint, and whitespace checks
- Push preflight: formatting, licensing, domain policy, Pint, and PHPStan

## Follow-up

- Linked workspaces: none.
- Unresolved checks before marking ready: none.

Closes #1292
