### PR TITLE
Clarify reusable workflow timeout rule

### DIFF
--- a/.github/instructions/github-workflows.instructions.md
+++ b/.github/instructions/github-workflows.instructions.md
@@ -10,7 +10,7 @@ applyTo: ".github/workflows/**/*.yml,.github/workflows/**/*.yaml,.github/dependa
 
 Applies when editing GitHub Actions workflows and Dependabot configuration in this repository.
 
-- Always set `timeout-minutes` on every job.
+- Always set `timeout-minutes` on every job that runs steps. Jobs that directly call a reusable workflow with `uses` are the required exception: GitHub Actions does not permit `timeout-minutes` on them, so omit it rather than adding invalid syntax.
 - Set explicit `permissions` on every workflow and start with the least privilege needed.
 - Pin third-party actions to immutable versions. GitHub-maintained `actions/*` may use supported major tags in this org.
 - Use reusable workflows from the organization templates when they fit the task.


### PR DESCRIPTION
## Validation

- `actionlint .github/workflows/*.yml`
- `pre-commit run markdownlint --files .github/instructions/github-workflows.instructions.md`
- `reuse lint`
- `git diff --check`

## Summary

- Clarify that jobs running steps must define `timeout-minutes`.
- Document the required exception for direct reusable-workflow callers using `uses`, where `timeout-minutes` is invalid.

Closes #1296

## Follow-up before ready

- No linked workspaces were changed.
- Complete the final self-review in the PR view and confirm zero findings before marking this draft ready.
