### PR TITLE
test: cover cross-tenant customer reassignment

### DIFF
--- a/tests/Feature/Controllers/Api/V1/CustomerControllerTest.php
+++ b/tests/Feature/Controllers/Api/V1/CustomerControllerTest.php
@@ -1110,6 +1110,7 @@ describe('PATCH /v1/customers/{customer}', function () {
     test('rejects changing a customer legal entity to another tenant', function (): void {
         givePermissionWithTenant($this->user, $this->tenant->id, 'customers.update');
         $customer = Customer::factory()->create(['tenant_id' => $this->tenant->id]);
+        $originalLegalEntityId = $customer->legal_entity_id;
         $otherTenant = TenantKey::create(TenantKey::generateEnvelopeKeys());
         $foreignLegalEntity = OrganizationalUnit::factory()->forTenant((string) $otherTenant->id)->create([
             'is_legal_entity' => true,
@@ -1122,7 +1123,7 @@ describe('PATCH /v1/customers/{customer}', function () {
             ->assertUnprocessable()
             ->assertJsonValidationErrors(['legal_entity_id']);
 
-        expect($customer->refresh()->legal_entity_id)->not->toBe($foreignLegalEntity->id);
+        expect($customer->refresh()->legal_entity_id)->toBe($originalLegalEntityId);
     });
 
     test('allows an unchanged legal entity after it becomes unassignable', function (): void {

--- a/tests/Feature/Controllers/Api/V1/CustomerControllerTest.php
+++ b/tests/Feature/Controllers/Api/V1/CustomerControllerTest.php
@@ -1107,6 +1107,24 @@ describe('PATCH /v1/customers/{customer}', function () {
         expect($customer->refresh()->legal_entity_id)->not->toBe($unassignableLegalEntity->id);
     });
 
+    test('rejects changing a customer legal entity to another tenant', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'customers.update');
+        $customer = Customer::factory()->create(['tenant_id' => $this->tenant->id]);
+        $otherTenant = TenantKey::create(TenantKey::generateEnvelopeKeys());
+        $foreignLegalEntity = OrganizationalUnit::factory()->forTenant((string) $otherTenant->id)->create([
+            'is_legal_entity' => true,
+        ]);
+
+        $this->withToken($this->token)
+            ->patchJson("/v1/customers/{$customer->id}", [
+                'legal_entity_id' => $foreignLegalEntity->id,
+            ])
+            ->assertUnprocessable()
+            ->assertJsonValidationErrors(['legal_entity_id']);
+
+        expect($customer->refresh()->legal_entity_id)->not->toBe($foreignLegalEntity->id);
+    });
+
     test('allows an unchanged legal entity after it becomes unassignable', function (): void {
         givePermissionWithTenant($this->user, $this->tenant->id, 'customers.update');
         $legalEntity = OrganizationalUnit::factory()->forTenant((string) $this->tenant->id)->create([


### PR DESCRIPTION
## Validation

The new regression test verifies that `PATCH /v1/customers/{customer}` rejects a Legal Entity owned by another tenant with `422` and leaves the customer's assignment unchanged.

- `php artisan test --compact --filter='rejects changing a customer legal entity to another tenant' tests/Feature/Controllers/Api/V1/CustomerControllerTest.php`
- `php artisan test --compact tests/Feature/Migrations/AddCustomerLegalEntityMigrationTest.php`
- Customer controller suite: 76 passed (259 assertions)
- Legal Entity lifecycle and Customer model suites: 21 passed (41 assertions)
- `vendor/bin/pint --dirty`
- Push preflight: formatting, REUSE, domain policy, Pint, and PHPStan passed.

## Summary

- Add API regression coverage for rejecting cross-tenant Legal Entity reassignment during customer updates.
- Preserve the existing migration guard: populated customer data blocks migration until a product-approved deterministic, tenant-consistent backfill rule exists; no default Legal Entity is assigned.

Closes #1278

## Linked work and follow-up before ready

- Related epic: SecPal/frontend#1391. The frontend migration-decision document remains the source of the product approval dependency; no linked-workspace change is required by this PR.
- Keep this PR as a draft pending CI and final review. Do not mark it ready until the final PR review finds no issues. A product-approved deterministic backfill rule remains a separate dependency before any existing customer data can be migrated.
