### PR TITLE
docs: accept SSH commit signatures

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -90,7 +90,7 @@ At minimum verify:
 
 - Treat AI findings and AI-generated fix PRs as hints, not proof.
 - Before merge, prove the defect with a failing test, a reproducible defect, or a stated invariant and why the current code violates it.
-- For commit-signature or author/committer-identity findings, verify that the cited hash belongs to the pull request's actual remote commit set before treating it as repository evidence; never use a temporary review-environment, worktree, or synthetic commit as proof.
+- For commit-signature or author/committer-identity findings, first verify that the cited hash belongs to the pull request's actual remote commit set, then assess it using the hosting provider's verification result or a correctly configured local trust store; never use a temporary review-environment, worktree, or synthetic commit as proof.
 - Green CI alone is not enough for AI-generated changes, especially test, lifecycle, shell, regex, or refactor diffs; review the semantic risk explicitly.
 - Reject AI-generated test or helper mutations that move executable code across Pest scope boundaries or bypass framework wiring.
 - Reject AI-generated refactors that resolve services inside API resources or serializers, move business logic into presentation code, or repeat request-scoped work that should run once per request.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -79,7 +79,7 @@ At minimum verify:
 - `vendor/bin/pint --dirty` ran after PHP changes
 - out-of-scope findings were turned into GitHub issues immediately
 - `CHANGELOG.md` was updated for real changes
-- commits are GPG-signed
+- commits are cryptographically signed with SSH or OpenPGP
 - REUSE compliance was checked when changed files require it
 - when a fix alters observable behavior, state lifecycle, error handling, or security constraints, the corresponding tests were identified and updated in the same commit
 - before pushing behavioral or security-critical changes, affected tests were run locally (`PREFLIGHT_RUN_TESTS=1 git push` or invoke the test runner directly)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -90,6 +90,7 @@ At minimum verify:
 
 - Treat AI findings and AI-generated fix PRs as hints, not proof.
 - Before merge, prove the defect with a failing test, a reproducible defect, or a stated invariant and why the current code violates it.
+- For commit-signature or author/committer-identity findings, verify that the cited hash belongs to the pull request's actual remote commit set before treating it as repository evidence; never use a temporary review-environment, worktree, or synthetic commit as proof.
 - Green CI alone is not enough for AI-generated changes, especially test, lifecycle, shell, regex, or refactor diffs; review the semantic risk explicitly.
 - Reject AI-generated test or helper mutations that move executable code across Pest scope boundaries or bypass framework wiring.
 - Reject AI-generated refactors that resolve services inside API resources or serializers, move business logic into presentation code, or repeat request-scoped work that should run once per request.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@ At minimum verify:
 
 - Treat AI findings and AI-generated fix PRs as hints, not proof.
 - Before merge, prove the defect with a failing test, a reproducible defect, or a stated invariant and why the current code violates it.
-- For commit-signature or author/committer-identity findings, verify that the cited hash belongs to the pull request's actual remote commit set before treating it as repository evidence; never use a temporary review-environment, worktree, or synthetic commit as proof.
+- For commit-signature or author/committer-identity findings, first verify that the cited hash belongs to the pull request's actual remote commit set, then assess it using the hosting provider's verification result or a correctly configured local trust store; never use a temporary review-environment, worktree, or synthetic commit as proof.
 - Green CI alone is not enough for AI-generated changes, especially test, lifecycle, shell, regex, or refactor diffs; review the semantic risk explicitly.
 - Reject AI-generated test or helper mutations that move executable code across Pest scope boundaries or bypass framework wiring.
 - Reject AI-generated refactors that resolve services inside API resources or serializers, move business logic into presentation code, or repeat request-scoped work that should run once per request.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,7 @@ At minimum verify:
 - `vendor/bin/pint --dirty` ran after PHP changes
 - out-of-scope findings were turned into GitHub issues immediately
 - `CHANGELOG.md` was updated for real changes
-- commits are GPG-signed
+- commits are cryptographically signed with SSH or OpenPGP
 - REUSE compliance was checked when changed files require it
 - when a fix alters observable behavior, state lifecycle, error handling, or security constraints, the corresponding tests were identified and updated in the same commit
 - before pushing behavioral or security-critical changes, affected tests were run locally (`PREFLIGHT_RUN_TESTS=1 git push` or invoke the test runner directly)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,7 @@ At minimum verify:
 
 - Treat AI findings and AI-generated fix PRs as hints, not proof.
 - Before merge, prove the defect with a failing test, a reproducible defect, or a stated invariant and why the current code violates it.
+- For commit-signature or author/committer-identity findings, verify that the cited hash belongs to the pull request's actual remote commit set before treating it as repository evidence; never use a temporary review-environment, worktree, or synthetic commit as proof.
 - Green CI alone is not enough for AI-generated changes, especially test, lifecycle, shell, regex, or refactor diffs; review the semantic risk explicitly.
 - Reject AI-generated test or helper mutations that move executable code across Pest scope boundaries or bypass framework wiring.
 - Reject AI-generated refactors that resolve services inside API resources or serializers, move business logic into presentation code, or repeat request-scoped work that should run once per request.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- documented SSH and OpenPGP as supported commit-signing methods, including self-contained setup and verification commands for each format (fixes `api#1303`)
+- documented SSH and OpenPGP as supported commit-signing methods, including self-contained setup and verification commands for each format, and required signature/identity review findings to be checked against the pull request's actual remote commits instead of synthetic review commits (fixes `api#1303`)
 - aligned the OpenTimestamps integration guide's declared license with its CC0-1.0 SPDX metadata and repository REUSE policy (fixes `api#1272`)
 - allowed activity logging for same-tenant records that retain a reference to a soft-deleted organizational unit, so permitted historical record updates remain audit-safe instead of failing with a server error (fixes `api#1268`)
 - scoped the employee auto-logging regression lookup to the employee and tenant created by the test, so activity-log assertions cannot read a matching row leaked by an earlier test (fixes `api#1269`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- documented SSH and OpenPGP as supported commit-signing methods, including self-contained setup and verification commands for each format, and required signature/identity review findings to be checked against the pull request's actual remote commits instead of synthetic review commits (fixes `api#1303`)
+- documented SSH and OpenPGP as supported commit-signing methods, including self-contained setup and verification commands for each format, and required signature/identity review findings to use the pull request's actual remote commits and a configured trust source instead of synthetic review commits or unconfigured local keyrings (fixes `api#1303`)
 - aligned the OpenTimestamps integration guide's declared license with its CC0-1.0 SPDX metadata and repository REUSE policy (fixes `api#1272`)
 - allowed activity logging for same-tenant records that retain a reference to a soft-deleted organizational unit, so permitted historical record updates remain audit-safe instead of failing with a server error (fixes `api#1268`)
 - scoped the employee auto-logging regression lookup to the employee and tenant created by the test, so activity-log assertions cannot read a matching row leaked by an earlier test (fixes `api#1269`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- documented SSH and OpenPGP as supported commit-signing methods, including self-contained setup and verification commands for each format (fixes `api#1303`)
 - aligned the OpenTimestamps integration guide's declared license with its CC0-1.0 SPDX metadata and repository REUSE policy (fixes `api#1272`)
 - allowed activity logging for same-tenant records that retain a reference to a soft-deleted organizational unit, so permitted historical record updates remain audit-safe instead of failing with a server error (fixes `api#1268`)
 - scoped the employee auto-logging regression lookup to the employee and tenant created by the test, so activity-log assertions cannot read a matching row leaked by an earlier test (fixes `api#1269`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -380,7 +380,7 @@ All commits must be cryptographically signed. SSH and OpenPGP are both accepted;
 
 ```bash
 # Generate a dedicated SSH signing key (if you do not already have one)
-ssh-keygen -t ed25519 -C "you@example.com" -f ~/.ssh/id_ed25519_signing
+ssh-keygen -t ed25519 -C "you@secpal.dev" -f ~/.ssh/id_ed25519_signing
 
 # Configure Git to sign commits with the dedicated private key
 git config --global gpg.format ssh
@@ -423,7 +423,7 @@ git log --show-signature -1
 For SSH signatures, configure Git's allowed signers file before running `git verify-commit` so Git can verify the signer's identity:
 
 ```bash
-printf '%s %s\n' "you@example.com" "$(cat ~/.ssh/id_ed25519_signing.pub)" >> ~/.ssh/allowed_signers
+printf '%s %s\n' "you@secpal.dev" "$(cat ~/.ssh/id_ed25519_signing.pub)" >> ~/.ssh/allowed_signers
 git config --global gpg.ssh.allowedSignersFile ~/.ssh/allowed_signers
 git verify-commit HEAD
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -379,6 +379,10 @@ All commits must be cryptographically signed. SSH and OpenPGP are both accepted;
 ### SSH signing
 
 ```bash
+# Create the SSH configuration directory with restricted permissions
+mkdir -p ~/.ssh
+chmod 700 ~/.ssh
+
 # Generate a dedicated SSH signing key (if you do not already have one)
 ssh-keygen -t ed25519 -C "you@secpal.dev" -f ~/.ssh/id_ed25519_signing
 
@@ -414,23 +418,19 @@ gpg --armor --export <YOUR_KEY_ID>
 
 ### Verify a signature
 
-After committing, inspect its signature locally:
-
-```bash
-git log --show-signature -1
-```
-
-For SSH signatures, configure Git's allowed signers file before running `git verify-commit` so Git can verify the signer's identity:
+For SSH signatures, configure Git's allowed signers file before inspecting or verifying the commit so Git can identify the signer:
 
 ```bash
 printf '%s %s\n' "you@secpal.dev" "$(cat ~/.ssh/id_ed25519_signing.pub)" >> ~/.ssh/allowed_signers
 git config --global gpg.ssh.allowedSignersFile ~/.ssh/allowed_signers
+git log --show-signature -1
 git verify-commit HEAD
 ```
 
-For OpenPGP signatures, run:
+For OpenPGP signatures, inspect and verify the commit with:
 
 ```bash
+git log --show-signature -1
 git verify-commit HEAD
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -382,9 +382,9 @@ All commits must be cryptographically signed. SSH and OpenPGP are both accepted;
 # Generate a dedicated SSH signing key (if you do not already have one)
 ssh-keygen -t ed25519 -C "you@example.com" -f ~/.ssh/id_ed25519_signing
 
-# Configure Git to sign commits with the SSH public key
+# Configure Git to sign commits with the dedicated private key
 git config --global gpg.format ssh
-git config --global user.signingkey ~/.ssh/id_ed25519_signing.pub
+git config --global user.signingkey ~/.ssh/id_ed25519_signing
 git config --global commit.gpgSign true
 
 # Copy the public key and add it in GitHub under Settings → SSH and GPG keys
@@ -402,6 +402,7 @@ gpg --gen-key
 gpg --list-secret-keys --keyid-format LONG
 
 # Configure Git to use your key
+git config --global gpg.format openpgp
 git config --global user.signingkey <YOUR_KEY_ID>
 git config --global commit.gpgSign true
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ We welcome contributions to SecPal! Please read our [Code of Conduct](CODE_OF_CO
 
 Ensure you have the following tools installed:
 
-- **Git** with GPG signing configured
+- **Git** with cryptographic commit signing configured (SSH or OpenPGP)
 - **Node.js** (v22.x) and npm/pnpm/yarn
 - **PHP** 8.4 and Composer (for backend projects)
 - **Pre-commit** hooks tool (optional but recommended)
@@ -148,7 +148,7 @@ rm .preflight-allow-large-pr
 2. **Create a feature branch** using our naming convention (see below).
 3. **Write your code** and add tests where applicable.
 4. **Ensure all tests pass** locally by running `./scripts/preflight.sh`.
-5. **Sign your commits** with GPG (see below).
+5. **Cryptographically sign your commits** with SSH or OpenPGP (see below).
 6. **Push your branch** and open a pull request against `main`.
 
 All pull requests will be reviewed by a maintainer and by GitHub Copilot.
@@ -374,7 +374,25 @@ Closes #123"
 
 ## Signing Commits
 
-All commits must be signed with GPG. To set up commit signing:
+All commits must be cryptographically signed. SSH and OpenPGP are both accepted; unsigned commits are not permitted. Configure one of the following methods, then add its public key to your GitHub account as a signing key.
+
+### SSH signing
+
+```bash
+# Generate a dedicated SSH signing key (if you do not already have one)
+ssh-keygen -t ed25519 -C "you@example.com" -f ~/.ssh/id_ed25519_signing
+
+# Configure Git to sign commits with the SSH public key
+git config --global gpg.format ssh
+git config --global user.signingkey ~/.ssh/id_ed25519_signing.pub
+git config --global commit.gpgSign true
+
+# Copy the public key and add it in GitHub under Settings → SSH and GPG keys
+# → New SSH key, choosing the Signing Key type.
+cat ~/.ssh/id_ed25519_signing.pub
+```
+
+### OpenPGP signing
 
 ```bash
 # Generate a GPG key (if you don't have one)
@@ -392,6 +410,32 @@ gpg --armor --export <YOUR_KEY_ID>
 # Copy the entire output (including the BEGIN and END PGP PUBLIC KEY BLOCK lines)
 # and paste it into GitHub under Settings → SSH and GPG keys → New GPG key.
 ```
+
+### Verify a signature
+
+After committing, inspect its signature locally:
+
+```bash
+git log --show-signature -1
+```
+
+For SSH signatures, configure Git's allowed signers file before running `git verify-commit` so Git can verify the signer's identity:
+
+```bash
+printf '%s %s\n' "you@example.com" "$(cat ~/.ssh/id_ed25519_signing.pub)" >> ~/.ssh/allowed_signers
+git config --global gpg.ssh.allowedSignersFile ~/.ssh/allowed_signers
+git verify-commit HEAD
+```
+
+For OpenPGP signatures, run:
+
+```bash
+git verify-commit HEAD
+```
+
+To verify an OpenPGP signature from another contributor, import that contributor's trusted public key into your keyring first.
+
+GitHub also shows whether a commit is verified after the corresponding SSH or OpenPGP public key is added to your account. The protected `main` branch rejects unsigned commits.
 
 ## Pull Request Guidelines
 

--- a/README.md
+++ b/README.md
@@ -523,6 +523,7 @@ Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our code of conduc
 The `main` branch is protected with the following rules:
 
 - Required status checks must pass
+- Cryptographically signed commits are required (SSH or OpenPGP)
 - Pull request reviews required
 - Conversations must be resolved
 - Force pushes are disabled


### PR DESCRIPTION
## Validation

- Reproduced the documentation defect: repository guidance accepted only GPG/OpenPGP despite SSH-signed commits being valid.
- Verified through the GitHub API that all eight actual remote PR commits have valid cryptographic signatures; the hashes cited by the rejected review findings are not part of the PR commit set.
- Confirmed that signed commits are enabled for the protected `main` branch and force pushes are disabled.
- `git diff --check`
- Markdownlint for the changed Markdown files
- `reuse lint`
- Pre-commit checks and the pre-push preflight, including Prettier, Markdownlint, REUSE, Pint, PHPStan, and the domain-policy check

## Summary

- Accept SSH and OpenPGP as cryptographic commit-signing methods in repository governance.
- Document SSH and OpenPGP setup and verification, while retaining the prohibition on unsigned commits.
- Record the matching signed-commit requirement in the branch-protection documentation.
- Require commit-signature and identity review findings to use the PR's actual remote commits and either the hosting provider's verification result or a correctly configured local trust store.

## Current status

- Linked workspaces: none.
- Unresolved local checks: none.
- Unresolved review threads: none.
- All required GitHub checks pass on `535ad14`.

Closes #1303
