### PR TITLE
fix: stabilize parallel Pest bootstrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .DS_Store
 .env
 .env.testing.bootstrap
+.env.testing.bootstrap.*
 .env.backup
 .env.production
 .phpactor.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 SecPal Contributors
+# SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 # SPDX-License-Identifier: CC0-1.0
 
 *.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - replaced the Prettier and Markdownlint Node hooks with pinned npm hooks, so pre-commit no longer invokes its incompatible Node environment installer with current npm versions, and added Linux and macOS npm 12 CI smoke tests that install and execute both hooks (fixes `api#1308`, `api#1309`)
+- isolated each parallel Pest worker's generated bootstrap environment file by test token, preventing process-specific PostgreSQL schema configuration from being overwritten by another worker (fixes `api#1298`)
 - documented SSH and OpenPGP as supported commit-signing methods, including self-contained setup and verification commands for each format, and required signature/identity review findings to use the pull request's actual remote commits and a configured trust source instead of synthetic review commits or unconfigured local keyrings (fixes `api#1303`)
 - aligned the OpenTimestamps integration guide's declared license with its CC0-1.0 SPDX metadata and repository REUSE policy (fixes `api#1272`)
 - allowed activity logging for same-tenant records that retain a reference to a soft-deleted organizational unit, so permitted historical record updates remain audit-safe instead of failing with a server error (fixes `api#1268`)

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -254,10 +254,10 @@ abstract class TestCase extends BaseTestCase
 
     protected static function isolatedTestDatabaseName(string $databaseName): string
     {
-        $testToken = getenv('TEST_TOKEN');
+        $testTokenSuffix = self::parallelTestTokenSuffix();
 
-        if (is_string($testToken) && preg_match('/\A\d+\z/', $testToken) === 1) {
-            return $databaseName.'_test_'.$testToken;
+        if ($testTokenSuffix !== null) {
+            return $databaseName.'_test_'.$testTokenSuffix;
         }
 
         return $databaseName;
@@ -573,10 +573,10 @@ abstract class TestCase extends BaseTestCase
     protected static function bootstrapEnvironmentFileName(): string
     {
         if (self::isRunningInParallelWorker()) {
-            $testToken = $_SERVER['TEST_TOKEN'] ?? getenv('TEST_TOKEN');
+            $testTokenSuffix = self::parallelTestTokenSuffix();
 
-            if (is_string($testToken) && preg_match('/\A[0-9]+\z/', $testToken) === 1) {
-                return self::TEST_BOOTSTRAP_ENVIRONMENT_FILE.'.'.$testToken;
+            if ($testTokenSuffix !== null) {
+                return self::TEST_BOOTSTRAP_ENVIRONMENT_FILE.'.'.$testTokenSuffix;
             }
         }
 
@@ -688,12 +688,26 @@ abstract class TestCase extends BaseTestCase
     private static function isRunningInParallelWorker(): bool
     {
         $parallelTesting = $_SERVER['LARAVEL_PARALLEL_TESTING'] ?? getenv('LARAVEL_PARALLEL_TESTING');
-        $testToken = $_SERVER['TEST_TOKEN'] ?? getenv('TEST_TOKEN');
 
         return ! empty($parallelTesting)
-            && $testToken !== false
-            && $testToken !== null
-            && (string) $testToken !== '';
+            && self::parallelTestTokenSuffix() !== null;
+    }
+
+    private static function parallelTestTokenSuffix(): ?string
+    {
+        $testToken = $_SERVER['TEST_TOKEN'] ?? getenv('TEST_TOKEN');
+
+        if ($testToken === false || $testToken === null || (string) $testToken === '') {
+            return null;
+        }
+
+        $testToken = (string) $testToken;
+
+        if (preg_match('/\A[0-9]{1,20}\z/', $testToken) === 1) {
+            return $testToken;
+        }
+
+        return substr(hash('sha256', $testToken), 0, 32);
     }
 
     protected static function resetBootstrapEnvironmentState(): void

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -572,6 +572,14 @@ abstract class TestCase extends BaseTestCase
 
     protected static function bootstrapEnvironmentFileName(): string
     {
+        if (self::isRunningInParallelWorker()) {
+            $testToken = $_SERVER['TEST_TOKEN'] ?? getenv('TEST_TOKEN');
+
+            if (is_string($testToken) && preg_match('/\A[0-9]+\z/', $testToken) === 1) {
+                return self::TEST_BOOTSTRAP_ENVIRONMENT_FILE.'.'.$testToken;
+            }
+        }
+
         return self::TEST_BOOTSTRAP_ENVIRONMENT_FILE;
     }
 
@@ -670,10 +678,6 @@ abstract class TestCase extends BaseTestCase
             return;
         }
 
-        if (self::isRunningInParallelWorker() && self::usesSharedBootstrapEnvironmentFile()) {
-            return;
-        }
-
         if (is_file(self::$temporaryBootstrapEnvironmentFile)) {
             unlink(self::$temporaryBootstrapEnvironmentFile);
         }
@@ -690,11 +694,6 @@ abstract class TestCase extends BaseTestCase
             && $testToken !== false
             && $testToken !== null
             && (string) $testToken !== '';
-    }
-
-    private static function usesSharedBootstrapEnvironmentFile(): bool
-    {
-        return self::$temporaryBootstrapEnvironmentFile === dirname(__DIR__).'/'.self::TEST_BOOTSTRAP_ENVIRONMENT_FILE;
     }
 
     protected static function resetBootstrapEnvironmentState(): void

--- a/tests/Unit/TestCaseBootstrapEnvironmentFileTest.php
+++ b/tests/Unit/TestCaseBootstrapEnvironmentFileTest.php
@@ -82,25 +82,32 @@ test('publishes bootstrap env updates via atomic file replacement', function ():
     rmdir($probeDirectory);
 });
 
-test('parallel workers use and clean up token-specific bootstrap env files', function (): void {
+test('parallel workers use and clean up path-safe token-specific bootstrap env files', function (
+    string $testToken,
+    string $expectedFileName,
+): void {
+    $probeDirectory = storage_path('framework/testing/bootstrap-env-'.Str::uuid());
     $originalParallelTesting = getenv('LARAVEL_PARALLEL_TESTING');
     $originalTestToken = getenv('TEST_TOKEN');
-    $environmentFile = dirname(__DIR__, 2).'/.env.testing.bootstrap.7';
+    $environmentFile = $probeDirectory.'/'.$expectedFileName;
+
+    mkdir($probeDirectory, 0700, true);
 
     try {
+        TestCaseBootstrapEnvironmentProbe::useProbeEnvironmentPath($probeDirectory);
         TestCaseBootstrapEnvironmentProbe::resetBootstrapEnvironmentState();
 
         putenv('LARAVEL_PARALLEL_TESTING=1');
-        putenv('TEST_TOKEN=7');
+        putenv('TEST_TOKEN='.$testToken);
         $_ENV['LARAVEL_PARALLEL_TESTING'] = '1';
         $_SERVER['LARAVEL_PARALLEL_TESTING'] = '1';
-        $_ENV['TEST_TOKEN'] = '7';
-        $_SERVER['TEST_TOKEN'] = '7';
+        $_ENV['TEST_TOKEN'] = $testToken;
+        $_SERVER['TEST_TOKEN'] = $testToken;
 
         TestCaseBootstrapEnvironmentProbe::createBootstrapEnvironmentStub();
 
         expect(TestCaseBootstrapEnvironmentProbe::bootstrapEnvironmentFileName())
-            ->toBe('.env.testing.bootstrap.7')
+            ->toBe($expectedFileName)
             ->and(is_file($environmentFile))->toBeTrue();
 
         TestCaseBootstrapEnvironmentProbe::removeBootstrapEnvironmentStub();
@@ -128,8 +135,14 @@ test('parallel workers use and clean up token-specific bootstrap env files', fun
         if (is_file(TestCaseBootstrapEnvironmentProbe::bootstrapEnvironmentLockFilePath())) {
             unlink(TestCaseBootstrapEnvironmentProbe::bootstrapEnvironmentLockFilePath());
         }
+
+        TestCaseBootstrapEnvironmentProbe::clearProbeEnvironmentPath();
+        rmdir($probeDirectory);
     }
-});
+})->with([
+    'numeric token' => ['7', '.env.testing.bootstrap.7'],
+    'path-unsafe token' => ['worker/../seven', '.env.testing.bootstrap.92571565c912ae2175fe2b710272b483'],
+]);
 
 test('reapplies the bootstrap env before each application boot when process vars leak', function (): void {
     $probeDirectory = storage_path('framework/testing/bootstrap-env-'.Str::uuid());

--- a/tests/Unit/TestCaseBootstrapEnvironmentFileTest.php
+++ b/tests/Unit/TestCaseBootstrapEnvironmentFileTest.php
@@ -24,7 +24,7 @@ test('creates a dedicated test env file when no local env files exist', function
     mkdir($probeDirectory, 0700, true);
     TestCaseBootstrapEnvironmentProbe::useProbeEnvironmentPath($probeDirectory);
 
-    $environmentFile = $probeDirectory.'/.env.testing.bootstrap';
+    $environmentFile = $probeDirectory.'/'.TestCaseBootstrapEnvironmentProbe::bootstrapEnvironmentFileName();
 
     expect(is_file($probeDirectory.'/.env'))->toBeFalse()
         ->and(is_file($environmentFile))->toBeFalse();
@@ -53,7 +53,7 @@ test('publishes bootstrap env updates via atomic file replacement', function ():
     mkdir($probeDirectory, 0700, true);
     TestCaseBootstrapEnvironmentProbe::useProbeEnvironmentPath($probeDirectory);
 
-    $environmentFile = $probeDirectory.'/.env.testing.bootstrap';
+    $environmentFile = $probeDirectory.'/'.TestCaseBootstrapEnvironmentProbe::bootstrapEnvironmentFileName();
 
     TestCaseBootstrapEnvironmentProbe::createBootstrapEnvironmentStub();
 
@@ -306,7 +306,7 @@ test('isolates the generated test env file and runtime env state from inherited 
         TestCaseBootstrapEnvironmentProbe::resetBootstrapEnvironmentState();
         TestCaseBootstrapEnvironmentProbe::createBootstrapEnvironmentStub();
 
-        $environmentFile = $probeDirectory.'/.env.testing.bootstrap';
+        $environmentFile = $probeDirectory.'/'.TestCaseBootstrapEnvironmentProbe::bootstrapEnvironmentFileName();
         $contents = file_get_contents($environmentFile);
 
         expect(is_file($environmentFile))->toBeTrue()

--- a/tests/Unit/TestCaseBootstrapEnvironmentFileTest.php
+++ b/tests/Unit/TestCaseBootstrapEnvironmentFileTest.php
@@ -82,14 +82,13 @@ test('publishes bootstrap env updates via atomic file replacement', function ():
     rmdir($probeDirectory);
 });
 
-test('parallel workers do not delete the shared bootstrap env file during cleanup', function (): void {
+test('parallel workers use and clean up token-specific bootstrap env files', function (): void {
     $originalParallelTesting = getenv('LARAVEL_PARALLEL_TESTING');
     $originalTestToken = getenv('TEST_TOKEN');
-    $environmentFile = dirname(__DIR__, 2).'/.env.testing.bootstrap';
+    $environmentFile = dirname(__DIR__, 2).'/.env.testing.bootstrap.7';
 
     try {
         TestCaseBootstrapEnvironmentProbe::resetBootstrapEnvironmentState();
-        TestCaseBootstrapEnvironmentProbe::createBootstrapEnvironmentStub();
 
         putenv('LARAVEL_PARALLEL_TESTING=1');
         putenv('TEST_TOKEN=7');
@@ -98,9 +97,15 @@ test('parallel workers do not delete the shared bootstrap env file during cleanu
         $_ENV['TEST_TOKEN'] = '7';
         $_SERVER['TEST_TOKEN'] = '7';
 
+        TestCaseBootstrapEnvironmentProbe::createBootstrapEnvironmentStub();
+
+        expect(TestCaseBootstrapEnvironmentProbe::bootstrapEnvironmentFileName())
+            ->toBe('.env.testing.bootstrap.7')
+            ->and(is_file($environmentFile))->toBeTrue();
+
         TestCaseBootstrapEnvironmentProbe::removeBootstrapEnvironmentStub();
 
-        expect(is_file($environmentFile))->toBeTrue();
+        expect(is_file($environmentFile))->toBeFalse();
     } finally {
         foreach ([
             'LARAVEL_PARALLEL_TESTING' => $originalParallelTesting,

--- a/tests/Unit/TestCasePhpUnitEnvironmentOverridesTest.php
+++ b/tests/Unit/TestCasePhpUnitEnvironmentOverridesTest.php
@@ -104,6 +104,29 @@ test('parallel test token wins over process-based isolated database naming', fun
     }
 });
 
+test('non-numeric parallel test tokens produce path-safe isolated database names', function (): void {
+    $originalTestToken = getenv('TEST_TOKEN');
+    $testToken = 'worker/../seven';
+
+    try {
+        putenv('TEST_TOKEN='.$testToken);
+        $_ENV['TEST_TOKEN'] = $testToken;
+        $_SERVER['TEST_TOKEN'] = $testToken;
+
+        expect(TestCaseBootstrapEnvironmentProbe::isolatedTestDatabaseName('testing'))
+            ->toBe('testing_test_'.substr(hash('sha256', $testToken), 0, 32));
+    } finally {
+        if ($originalTestToken === false) {
+            putenv('TEST_TOKEN');
+            unset($_ENV['TEST_TOKEN'], $_SERVER['TEST_TOKEN']);
+        } else {
+            putenv('TEST_TOKEN='.$originalTestToken);
+            $_ENV['TEST_TOKEN'] = $originalTestToken;
+            $_SERVER['TEST_TOKEN'] = $originalTestToken;
+        }
+    }
+});
+
 test('phpunit environment overrides preserve a caller-provided isolated schema override', function (): void {
     $originalForcedTestSchema = getenv('SECPAL_TEST_SCHEMA');
     $originalForcedTestDatabase = getenv('SECPAL_TEST_DATABASE');


### PR DESCRIPTION
Closes #1298

## Reproduced defect

`php artisan test --parallel --exclude-group=serial` could fail unrelated feature tests intermittently. One observed failure surfaced `Undefined array key "clientDataJSON"` while verifying a passkey authentication request.

The generated bootstrap environment file was shared by all parallel workers even though it contained worker-specific PostgreSQL schema configuration. A worker could therefore load configuration written by another process.

## Change

- derive the generated bootstrap environment filename from the parallel test token;
- clean up the worker-specific file and ignore generated tokenized files;
- cover token-specific creation and cleanup in the bootstrap environment test;
- record the fix in the changelog.

## Validation

- `vendor/bin/pint --dirty`
- `reuse lint`
- `php artisan test tests/Unit/TestCaseBootstrapEnvironmentFileTest.php`
- `php artisan test --parallel --exclude-group=serial --compact`
- pre-commit hooks, PHPStan, and the standard pre-push preflight

## Before marking ready

- No linked workspace changes are required.
- Await CI and complete the final self-review in the PR view.
