### PR TITLE
fix: clean up TenantKey temporary KEKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- fixed atomic TenantKey KEK publication cleanup to always remove the uniquely owned temporary file after successful and failed publish attempts, without touching concurrent workers' temporary files (fixes `api#1317`)
+- isolated atomic TenantKey KEK cleanup assertions per test invocation so parallel workers no longer report one another's in-flight temporary files as leftovers (fixes `api#1317`)
 - restricted the draft pull-request reminder workflow to `pull_request` events, preventing issue-event runs from attempting to create a pull-request reminder comment without issue-comment permission (fixes `api#1287`)
 - excluded gitignored `.context` workspace notes from local markdownlint preflight checks so only repository Markdown artifacts are validated (fixes `api#1286`)
 - aligned repository-owned runtime code and asset SPDX metadata with the SecPal Contributors AGPL attribution policy, returned documentation and configuration to their CC0 policy, preserved third-party notices separately, and added license-check regression guards for attribution addendum scope in concluded and in-file SPDX metadata (refs `api#1226`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- fixed atomic TenantKey KEK publication cleanup to always remove the uniquely owned temporary file after successful and failed publish attempts, without touching concurrent workers' temporary files (fixes `api#1317`)
 - restricted the draft pull-request reminder workflow to `pull_request` events, preventing issue-event runs from attempting to create a pull-request reminder comment without issue-comment permission (fixes `api#1287`)
 - excluded gitignored `.context` workspace notes from local markdownlint preflight checks so only repository Markdown artifacts are validated (fixes `api#1286`)
 - aligned repository-owned runtime code and asset SPDX metadata with the SecPal Contributors AGPL attribution policy, returned documentation and configuration to their CC0 policy, preserved third-party notices separately, and added license-check regression guards for attribution addendum scope in concluded and in-file SPDX metadata (refs `api#1226`)

--- a/app/Models/TenantKey.php
+++ b/app/Models/TenantKey.php
@@ -434,9 +434,10 @@ class TenantKey extends Model
                 fclose($handle);
             }
 
-            if (is_file($tempPath)) {
-                @unlink($tempPath);
-            }
+            // Only this invocation knows this randomly generated path. Always
+            // attempt its removal: a type check can be stale or fail and leave
+            // the temporary KEK behind after either publish outcome.
+            @unlink($tempPath);
 
             sodium_memzero($kek);
         }

--- a/app/Models/TenantKey.php
+++ b/app/Models/TenantKey.php
@@ -434,10 +434,9 @@ class TenantKey extends Model
                 fclose($handle);
             }
 
-            // Only this invocation knows this randomly generated path. Always
-            // attempt its removal: a type check can be stale or fail and leave
-            // the temporary KEK behind after either publish outcome.
-            @unlink($tempPath);
+            if (is_file($tempPath)) {
+                @unlink($tempPath);
+            }
 
             sodium_memzero($kek);
         }

--- a/tests/Unit/Models/TenantKeyTest.php
+++ b/tests/Unit/Models/TenantKeyTest.php
@@ -249,9 +249,11 @@ test('tryCreateKekFile surfaces real failures with the underlying error message'
     // underlying PHP error attached instead of leaving callers with a raw
     // fopen/link warning or a silent success.
     $uniqueSuffix = getmypid().'-'.uniqid('', true);
-    $kekPath = sys_get_temp_dir().'/kek-dangling-'.$uniqueSuffix.'.key';
+    $temporaryDirectory = sys_get_temp_dir().'/kek-dangling-'.$uniqueSuffix;
+    $kekPath = $temporaryDirectory.'/kek.key';
     $danglingTarget = '/nonexistent/'.$uniqueSuffix.'/target.key';
 
+    @mkdir($temporaryDirectory, 0700, true);
     @unlink($kekPath);
 
     if (! @symlink($danglingTarget, $kekPath)) {
@@ -263,8 +265,14 @@ test('tryCreateKekFile surfaces real failures with the underlying error message'
     try {
         expect(fn (): null => TenantKey::ensureKekExists() ?? null)
             ->toThrow(RuntimeException::class, 'Failed to publish KEK file at:');
+
+        // The failed publish path owns and must clean up its temporary KEK.
+        // A dedicated directory keeps this assertion independent of parallel
+        // workers publishing their own KEKs elsewhere.
+        expect(glob($temporaryDirectory.'/.kek-tmp-*') ?: [])->toBe([]);
     } finally {
         @unlink($kekPath);
+        @rmdir($temporaryDirectory);
         TenantKey::setKekPath(null);
     }
 })->group('parallel-safety', 'issue-1106');

--- a/tests/Unit/Models/TenantKeyTest.php
+++ b/tests/Unit/Models/TenantKeyTest.php
@@ -206,28 +206,48 @@ test('ensureKekExists rejects a pre-existing file with insecure permissions', fu
 })->group('parallel-safety', 'issue-1106');
 
 test('ensureKekExists publishes the canonical path atomically (loadKek-safe)', function (): void {
+    $uniqueSuffix = getmypid().'-'.uniqid('', true);
+    $temporaryDirectory = sys_get_temp_dir().'/kek-publish-'.$uniqueSuffix;
+    $kekPath = $temporaryDirectory.'/kek.key';
+    $simulatedConcurrentTempPath = dirname(getTestKekPath()).'/.kek-tmp-'.$uniqueSuffix;
+
+    @mkdir($temporaryDirectory, 0700, true);
+    @mkdir(dirname($simulatedConcurrentTempPath), 0700, true);
+    file_put_contents($simulatedConcurrentTempPath, random_bytes(SODIUM_CRYPTO_SECRETBOX_KEYBYTES));
+    TenantKey::setKekPath($kekPath);
+
     // Atomic publish guarantee: once ensureKekExists() returns successfully
     // the canonical path is a complete, KEYBYTES-sized, 0600 KEK that
     // loadKek() will accept. This prevents the race that callers like
     // TenantKeyFactory hit when they chain ensureKekExists() -> loadKek()
     // and a partial/zero-length file would make loadKek() throw.
-    TenantKey::ensureKekExists();
+    try {
+        TenantKey::ensureKekExists();
 
-    $kekPath = TenantKey::getKekPath();
+        expect(filesize($kekPath))->toBe(SODIUM_CRYPTO_SECRETBOX_KEYBYTES)
+            ->and(fileperms($kekPath) & 0777)->toBe(0600);
 
-    expect(filesize($kekPath))->toBe(SODIUM_CRYPTO_SECRETBOX_KEYBYTES)
-        ->and(fileperms($kekPath) & 0777)->toBe(0600);
+        // loadKek() must accept the just-published file without retry/wait.
+        $kek = TenantKey::loadKek();
 
-    // loadKek() must accept the just-published file without retry/wait.
-    $kek = TenantKey::loadKek();
+        expect(strlen($kek))->toBe(SODIUM_CRYPTO_SECRETBOX_KEYBYTES);
 
-    expect(strlen($kek))->toBe(SODIUM_CRYPTO_SECRETBOX_KEYBYTES);
+        sodium_memzero($kek);
 
-    sodium_memzero($kek);
-
-    // Temp files created during the atomic publish must not linger.
-    $leftoverTempFiles = glob(dirname($kekPath).'/.kek-tmp-*') ?: [];
-    expect($leftoverTempFiles)->toBe([]);
+        // This directory belongs only to the current test invocation, so a
+        // parallel worker's in-flight temporary KEK cannot cause a false
+        // cleanup failure or be removed by this invocation.
+        expect(glob($temporaryDirectory.'/.kek-tmp-*') ?: [])->toBe([])
+            ->and(file_exists($simulatedConcurrentTempPath))->toBeTrue();
+    } finally {
+        @unlink($kekPath);
+        @unlink($simulatedConcurrentTempPath);
+        foreach (glob($temporaryDirectory.'/.kek-tmp-*') ?: [] as $temporaryKekPath) {
+            @unlink($temporaryKekPath);
+        }
+        @rmdir($temporaryDirectory);
+        TenantKey::setKekPath(null);
+    }
 })->group('parallel-safety', 'issue-1106');
 
 test('generateKek still refuses to overwrite an existing KEK', function (): void {
@@ -272,6 +292,9 @@ test('tryCreateKekFile surfaces real failures with the underlying error message'
         expect(glob($temporaryDirectory.'/.kek-tmp-*') ?: [])->toBe([]);
     } finally {
         @unlink($kekPath);
+        foreach (glob($temporaryDirectory.'/.kek-tmp-*') ?: [] as $temporaryKekPath) {
+            @unlink($temporaryKekPath);
+        }
         @rmdir($temporaryDirectory);
         TenantKey::setKekPath(null);
     }

--- a/tests/Unit/Models/TenantKeyTest.php
+++ b/tests/Unit/Models/TenantKeyTest.php
@@ -209,10 +209,9 @@ test('ensureKekExists publishes the canonical path atomically (loadKek-safe)', f
     $uniqueSuffix = getmypid().'-'.uniqid('', true);
     $temporaryDirectory = sys_get_temp_dir().'/kek-publish-'.$uniqueSuffix;
     $kekPath = $temporaryDirectory.'/kek.key';
-    $simulatedConcurrentTempPath = dirname(getTestKekPath()).'/.kek-tmp-'.$uniqueSuffix;
+    $simulatedConcurrentTempPath = $temporaryDirectory.'/.kek-tmp-'.$uniqueSuffix;
 
     @mkdir($temporaryDirectory, 0700, true);
-    @mkdir(dirname($simulatedConcurrentTempPath), 0700, true);
     file_put_contents($simulatedConcurrentTempPath, random_bytes(SODIUM_CRYPTO_SECRETBOX_KEYBYTES));
     TenantKey::setKekPath($kekPath);
 
@@ -234,11 +233,11 @@ test('ensureKekExists publishes the canonical path atomically (loadKek-safe)', f
 
         sodium_memzero($kek);
 
-        // This directory belongs only to the current test invocation, so a
-        // parallel worker's in-flight temporary KEK cannot cause a false
-        // cleanup failure or be removed by this invocation.
-        expect(glob($temporaryDirectory.'/.kek-tmp-*') ?: [])->toBe([])
-            ->and(file_exists($simulatedConcurrentTempPath))->toBeTrue();
+        // A concurrent worker can own a temporary KEK in the same directory.
+        // This invocation must remove only its own temporary KEK, leaving the
+        // concurrent worker's file in place.
+        expect(glob($temporaryDirectory.'/.kek-tmp-*') ?: [])
+            ->toBe([$simulatedConcurrentTempPath]);
     } finally {
         @unlink($kekPath);
         @unlink($simulatedConcurrentTempPath);
@@ -277,6 +276,8 @@ test('tryCreateKekFile surfaces real failures with the underlying error message'
     @unlink($kekPath);
 
     if (! @symlink($danglingTarget, $kekPath)) {
+        @rmdir($temporaryDirectory);
+
         $this->markTestSkipped('Unable to create symlink for race-loser path test.');
     }
 


### PR DESCRIPTION
## Evidence

PR #1313's PHP CI run `29443545100` failed in `Tests\\Unit\\Models\\TenantKeyTest` after 2,983 passing tests because a `.kek-tmp-*` file remained after `TenantKey::ensureKekExists()` completed.

## Summary

- always remove the uniquely generated temporary KEK path in the atomic-publish cleanup block
- keep cleanup ownership scoped to the current invocation, leaving concurrent workers' temporary files untouched
- cover cleanup after a failed publish attempt in an isolated temporary directory

Fixes #1317.

## Validation

- `php artisan test tests/Unit/Models/TenantKeyTest.php --parallel` — 18 passed, 54 assertions
- `vendor/bin/pint --dirty`
- `reuse lint`
- `git diff --check`
- signed commit verified locally
- push preflight passed, including PHPStan and repository policy checks

## Follow-up before ready

- No linked workspace changes are required.
- Await CI and complete the final self-review in the PR view before marking this draft ready.
