### PR TITLE
test: cover customer legal entity reassignment access

### DIFF
--- a/tests/Feature/Controllers/Api/V1/CustomerControllerTest.php
+++ b/tests/Feature/Controllers/Api/V1/CustomerControllerTest.php
@@ -1066,8 +1066,27 @@ describe('PATCH /v1/customers/{customer}', function () {
         expect($customer->refresh()->vat_id)->toBeNull();
     });
 
+    test('changes a customer legal entity when the user has write scope on it', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'customers.update');
+        $customer = Customer::factory()->create(['tenant_id' => $this->tenant->id]);
+        $writableLegalEntity = OrganizationalUnit::factory()->forTenant((string) $this->tenant->id)->create([
+            'is_legal_entity' => true,
+        ]);
+        giveOrganizationalScope($this->user, $writableLegalEntity, accessLevel: 'write');
+
+        $this->withToken($this->token)
+            ->patchJson("/v1/customers/{$customer->id}", [
+                'legal_entity_id' => $writableLegalEntity->id,
+            ])
+            ->assertOk()
+            ->assertJsonPath('data.legal_entity_id', $writableLegalEntity->id);
+
+        expect($customer->refresh()->legal_entity_id)->toBe($writableLegalEntity->id);
+    });
+
     test('rejects changing a customer legal entity without write scope on it', function (): void {
         $customer = Customer::factory()->create(['tenant_id' => $this->tenant->id]);
+        $originalLegalEntityId = $customer->legal_entity_id;
         $unwritableLegalEntity = OrganizationalUnit::factory()->forTenant((string) $this->tenant->id)->create([
             'is_legal_entity' => true,
         ]);
@@ -1085,7 +1104,7 @@ describe('PATCH /v1/customers/{customer}', function () {
             ])
             ->assertForbidden();
 
-        expect($customer->refresh()->legal_entity_id)->not->toBe($unwritableLegalEntity->id);
+        expect($customer->refresh()->legal_entity_id)->toBe($originalLegalEntityId);
     });
 
     test('rejects changing a customer legal entity to an unassignable unit', function (): void {


### PR DESCRIPTION
## Validation

- `php artisan test tests/Feature/Controllers/Api/V1/CustomerControllerTest.php`
- `vendor/bin/pint --dirty`
- `reuse lint`
- `git diff --check`
- Pre-push checks: Prettier, Markdownlint, PHPStan, REUSE, domain policy, and Pint

## Summary

- Cover successful customer Legal Entity reassignment when the caller has write scope on the same-tenant target unit.
- Assert a rejected reassignment preserves the customer's original Legal Entity.
- The existing update service locks the active target Legal Entity and enforces organizational write access before persistence.

Closes #1290

## Follow-up

No linked workspace changes or unresolved local checks. Keep this PR as a draft until CI completes and the final PR-view self-review finds no issues.
