### PR TITLE
fix: honor gitignore in markdownlint preflight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - isolated atomic TenantKey KEK cleanup assertions per test invocation so parallel workers no longer report one another's in-flight temporary files as leftovers (fixes `api#1317`)
 - restricted the draft pull-request reminder workflow to `pull_request` events, preventing issue-event runs from attempting to create a pull-request reminder comment without issue-comment permission (fixes `api#1287`)
-- excluded gitignored `.context` workspace notes from local markdownlint preflight checks so only repository Markdown artifacts are validated (fixes `api#1286`)
+- made local markdownlint preflight honor `.gitignore`, excluding generated `.context` workspace notes and keeping validation scoped to repository Markdown artifacts (fixes `api#1281`, `api#1286`)
 - aligned repository-owned runtime code and asset SPDX metadata with the SecPal Contributors AGPL attribution policy, returned documentation and configuration to their CC0 policy, preserved third-party notices separately, and added license-check regression guards for attribution addendum scope in concluded and in-file SPDX metadata (refs `api#1226`)
 - seed the SecPal Holding organizational unit as both a legal entity and establishment, including repairing the flags when the unit already exists
 - grouped Dependabot updates for `SecPal/.github/.github/workflows/*` under stable `shared-github-workflows` identifiers in `.github/dependabot.yml`, so GitHub derives readable branch names and PR titles from the group name instead of transliterating the full reusable-workflow path into long `SecPal-dot-github-dot-...` strings

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -47,7 +47,7 @@ git fetch origin "$BASE" 2>/dev/null || true
 FORMAT_EXIT=0
 if command -v npx >/dev/null 2>&1; then
   npx --yes prettier --check '**/*.{md,yml,yaml,json,ts,tsx,js,jsx}' || FORMAT_EXIT=1
-  npx --yes --package markdownlint-cli@0.49.0 markdownlint --config .markdownlint.json --dot '**/*.md' --ignore node_modules --ignore vendor --ignore storage --ignore build --ignore .git --ignore .context || FORMAT_EXIT=1
+  npx --yes --package markdownlint-cli@0.49.0 markdownlint --config .markdownlint.json --dot '**/*.md' --ignore-path .gitignore --ignore node_modules --ignore vendor --ignore storage --ignore build --ignore .git || FORMAT_EXIT=1
 fi
 # Workflow linting (part of documented gates)
 # NOTE: actionlint is disabled in local preflight due to known hanging issues

--- a/tests/Unit/PreflightSerialGroupConfigTest.php
+++ b/tests/Unit/PreflightSerialGroupConfigTest.php
@@ -25,5 +25,5 @@ test('preflight excludes serial tests from the parallel run and executes them se
 test('preflight excludes gitignored workspace context notes from markdownlint', function (): void {
     expect(preflightScriptContents())
         ->toContain('markdownlint --config .markdownlint.json --dot \'**/*.md\'')
-        ->toContain('--ignore .context');
+        ->toContain('--ignore-path .gitignore');
 });


### PR DESCRIPTION
## Evidence

The focused regression test failed before this change because the local markdownlint invocation did not load the repository ignore rules. As a result, ignored `.context` workspace notes could still be selected by the recursive Markdown glob and block unrelated pushes.

## Change

- Load `.gitignore` through markdownlint's `--ignore-path` option in the local preflight.
- Keep the existing explicit dependency and build-directory exclusions.
- Update the preflight regression guard and changelog entry.

This makes the preflight scope follow the repository ignore policy, including `/.context/`.

## Validation

- `php artisan test tests/Unit/PreflightSerialGroupConfigTest.php`
- `vendor/bin/pint --dirty`
- `reuse lint`
- `./scripts/preflight.sh`
- Pre-push preflight

## Follow-up before ready

- No linked workspace changes are required.
- Local validation is complete. GitHub CI checks are pending; the default local preflight skips the full test suite, while the focused Pest regression test passed.

Closes #1281
