### PR TITLE
Clean parallel test bootstrap files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- cleaned generated parallel-test bootstrap environment files after the local preflight test phase, preventing its later REUSE validation from failing on ignored temporary artifacts (fixes `api#1339`)
 - removed stale npm and npx Composer script commands that required an untracked Node manifest while preserving the PHP server, queue worker, and log viewer in the development workflow (fixes `api#1329`)
 - denied Employee Qualification attachment for callers with obsolete organizational-unit scopes, keeping the mutation fail closed until Legal Entity/establishment entitlements are available (fixes `api#1333`)
 - corrected tracked Laravel, Sanctum, and Spatie configuration-template SPDX provenance to retain their MIT licenses and upstream copyright notices, and documented the third-party license audit and distribution obligations (refs `api#1220`)

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -7,6 +7,16 @@ set -euo pipefail
 ROOT_DIR="$(git rev-parse --show-toplevel)"
 cd "$ROOT_DIR"
 
+cleanup_parallel_test_bootstrap_files() {
+  local bootstrap_environment_file
+
+  shopt -s nullglob
+  for bootstrap_environment_file in "$ROOT_DIR"/.env.testing.bootstrap.*; do
+    rm -f -- "$bootstrap_environment_file"
+  done
+  shopt -u nullglob
+}
+
 # Check if pushing from a protected branch
 CURRENT_BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || echo "detached")
 PROTECTED_BRANCHES=("main" "master" "production")
@@ -140,6 +150,8 @@ if [ -f composer.json ]; then
       elif [ -x ./vendor/bin/phpunit ]; then
         ./vendor/bin/phpunit || TEST_EXIT=$?
       fi
+
+      cleanup_parallel_test_bootstrap_files
 
       if [ "$TEST_EXIT" -ne 0 ]; then
         echo "" >&2

--- a/tests/Unit/PreflightSerialGroupConfigTest.php
+++ b/tests/Unit/PreflightSerialGroupConfigTest.php
@@ -60,6 +60,7 @@ function makePreflightFixture(int $parallelExitCode = 0, int $serialExitCode = 9
 echo php "$@" >> COMMAND_LOG
 case "$*" in
   *"artisan test --parallel --exclude-group=serial"*)
+    touch .env.testing.bootstrap.parallel-worker
     exit PARALLEL_EXIT_CODE
     ;;
   *"artisan test --group=serial"*)
@@ -146,6 +147,25 @@ test('preflight preserves a parallel test failure when serial tests pass', funct
         expect($exitCode)->toBe(7)
             ->and($commands)->toContain('php artisan test --parallel --exclude-group=serial')
             ->and($commands)->toContain('php artisan test --group=serial');
+    } finally {
+        File::deleteDirectory($root);
+    }
+});
+
+test('preflight removes generated parallel test bootstrap environment files', function (): void {
+    $root = makePreflightFixture(parallelExitCode: 7, serialExitCode: 0);
+
+    try {
+        $command = sprintf(
+            'cd %s && PATH=%s:$PATH PREFLIGHT_RUN_TESTS=1 bash scripts/preflight.sh 2>&1',
+            escapeshellarg($root),
+            escapeshellarg($root.'/stubs'),
+        );
+
+        exec($command, $output, $exitCode);
+
+        expect($exitCode)->toBe(7)
+            ->and(is_file($root.'/.env.testing.bootstrap.parallel-worker'))->toBeFalse();
     } finally {
         File::deleteDirectory($root);
     }


### PR DESCRIPTION
## Problem and evidence

Running the enabled local preflight tests leaves ignored `.env.testing.bootstrap.<token>` files in the repository root. Those generated files lack SPDX metadata, so a later `reuse lint` invocation fails and blocks an otherwise valid push.

## Change

- Remove root-level generated parallel-test bootstrap files after the enabled test phase.
- Preserve the original test failure status when cleanup runs.
- Add a fixture regression test that leaves a generated file behind during a failing parallel run and verifies the preflight removes it.
- Record the fix in the changelog.

## Validation

- Targeted regression test failed before the cleanup change and passes afterward: `php artisan test tests/Unit/PreflightSerialGroupConfigTest.php`
- `bash -n scripts/preflight.sh`
- `vendor/bin/pint --dirty`
- `reuse lint`
- `git diff --check`
- Commit-time checks: REUSE, Prettier, Markdownlint, ShellCheck, Pint, whitespace checks
- Push preflight: Prettier, Markdownlint, Postgres bootstrap check, REUSE, domain policy, Pint, PHPStan

## Readiness

No in-scope dependencies or unresolved checks prevent review. The pull request remains a draft pending its final PR-view self-review and CI results.

Fixes #1339