### PR TITLE
Keep public discovery endpoints stateless

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- kept public bootstrap, release, and source responses outside Sanctum's stateful SPA and remember-session middleware, preventing XSRF or session cookies on discovery requests while leaving SPA authentication unchanged (fixes `api#1362`).
+- kept public bootstrap, release, and source responses outside identity-resolving API middleware, preventing discovery requests from creating cookies, restoring sessions, or authenticating and touching bearer tokens while leaving SPA and protected-route authentication unchanged (fixes `api#1362`).
 - normalized customer identifiers are enforced by database-generated values and tenant/Legal-Entity-scoped unique indexes, preventing concurrent duplicate creation; duplicate conflicts intentionally disclose neither the matched field nor an existing customer identifier (US-003).
 - pinned the shared Dependabot auto-merge reusable workflow to immutable commit `d90b56d4bca7c0d6e7fe1520d69b1f98eca22f5e`, preventing later movement of its `v1` tag from changing API automation without a reviewed dependency update (fixes `api#1300`)
 - pinned the six organization-owned reusable GitHub workflows previously referenced through `main` to immutable shared-repository commits, preventing unreviewed default-branch changes from altering API automation (fixes `api#1294`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- kept public bootstrap, release, and source responses outside Sanctum's stateful SPA and remember-session middleware, preventing XSRF or session cookies on discovery requests while leaving SPA authentication unchanged (fixes `api#1362`).
 - normalized customer identifiers are enforced by database-generated values and tenant/Legal-Entity-scoped unique indexes, preventing concurrent duplicate creation; duplicate conflicts intentionally disclose neither the matched field nor an existing customer identifier (US-003).
 - pinned the shared Dependabot auto-merge reusable workflow to immutable commit `d90b56d4bca7c0d6e7fe1520d69b1f98eca22f5e`, preventing later movement of its `v1` tag from changing API automation without a reviewed dependency update (fixes `api#1300`)
 - pinned the six organization-owned reusable GitHub workflows previously referenced through `main` to immutable shared-repository commits, preventing unreviewed default-branch changes from altering API automation (fixes `api#1294`)

--- a/routes/api.php
+++ b/routes/api.php
@@ -30,8 +30,10 @@ use App\Http\Controllers\AuthController;
 use App\Http\Controllers\PersonController;
 use App\Http\Controllers\RoleController;
 use App\Http\Middleware\EnsureBrowserSessionLoginContext;
+use App\Http\Middleware\RestoreSessionFromRememberToken;
 use App\Models\User;
 use Illuminate\Support\Facades\Route;
+use Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful;
 
 /*
 |--------------------------------------------------------------------------
@@ -46,12 +48,17 @@ use Illuminate\Support\Facades\Route;
 
 // API v1 routes
 Route::prefix('v1')->group(function () {
-    Route::get('/bootstrap', [BootstrapController::class, 'show'])
-        ->middleware('throttle:bootstrap');
-    Route::get('/release', [ReleaseController::class, 'show'])
-        ->middleware('throttle:release');
-    Route::get('/source', [SourceController::class, 'show'])
-        ->middleware('throttle:source-offer');
+    Route::withoutMiddleware([
+        EnsureFrontendRequestsAreStateful::class,
+        RestoreSessionFromRememberToken::class,
+    ])->group(function (): void {
+        Route::get('/bootstrap', [BootstrapController::class, 'show'])
+            ->middleware('throttle:bootstrap');
+        Route::get('/release', [ReleaseController::class, 'show'])
+            ->middleware('throttle:release');
+        Route::get('/source', [SourceController::class, 'show'])
+            ->middleware('throttle:source-offer');
+    });
 
     // Authentication routes (public)
     // SPA Login (session-based, for web browsers)

--- a/routes/api.php
+++ b/routes/api.php
@@ -30,7 +30,9 @@ use App\Http\Controllers\AuthController;
 use App\Http\Controllers\PersonController;
 use App\Http\Controllers\RoleController;
 use App\Http\Middleware\EnsureBrowserSessionLoginContext;
+use App\Http\Middleware\InjectTenantId;
 use App\Http\Middleware\RestoreSessionFromRememberToken;
+use App\Http\Middleware\SetLocaleFromHeader;
 use App\Models\User;
 use Illuminate\Support\Facades\Route;
 use Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful;
@@ -51,6 +53,8 @@ Route::prefix('v1')->group(function () {
     Route::withoutMiddleware([
         EnsureFrontendRequestsAreStateful::class,
         RestoreSessionFromRememberToken::class,
+        SetLocaleFromHeader::class,
+        InjectTenantId::class,
     ])->group(function (): void {
         Route::get('/bootstrap', [BootstrapController::class, 'show'])
             ->middleware('throttle:bootstrap');

--- a/tests/Feature/Api/V1/BootstrapApiTest.php
+++ b/tests/Feature/Api/V1/BootstrapApiTest.php
@@ -6,8 +6,13 @@
 declare(strict_types=1);
 
 use App\Models\Permission;
+use App\Models\User;
+use Illuminate\Auth\Events\Login;
+use Illuminate\Auth\SessionGuard;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Schema;
+use Laravel\Sanctum\Events\TokenAuthenticated;
 
 use function Pest\Laravel\getJson;
 
@@ -140,6 +145,7 @@ test('public bootstrap returns web push runtime metadata for browser clients wit
 test('public browser bootstrap remains stateless for the configured spa origin', function (): void {
     $response = $this->withHeaders(spaHeaders([
         'Accept' => 'application/json',
+        'Accept-Language' => 'de',
     ]))->getJson('/v1/bootstrap?client_platform=browser');
 
     $response->assertOk()
@@ -149,6 +155,7 @@ test('public browser bootstrap remains stateless for the configured spa origin',
         ->assertHeader('Content-Type', 'application/json');
 
     expect($response->headers->get('Access-Control-Allow-Origin'))->not->toBe('*');
+    expect(app()->getLocale())->toBe('de');
     expectNoSetCookieHeaders($response);
 });
 
@@ -218,14 +225,53 @@ test('public bootstrap remains stateless for a stateful referer without an origi
 });
 
 test('public bootstrap does not refresh synthetic incoming session or xsrf cookies', function (): void {
-    $response = $this->withCookies([
-        (string) config('session.cookie') => 'synthetic-session-cookie',
-        SPA_XSRF_COOKIE_NAME => 'synthetic-xsrf-cookie',
-    ])->withHeaders(spaHeaders())
+    $response = $this->withCredentials()
+        ->withCookies([
+            (string) config('session.cookie') => 'synthetic-session-cookie',
+            SPA_XSRF_COOKIE_NAME => 'synthetic-xsrf-cookie',
+        ])->withHeaders(spaHeaders())
         ->getJson('/v1/bootstrap?client_platform=browser');
 
     $response->assertOk();
 
+    expectNoSetCookieHeaders($response);
+});
+
+test('public bootstrap does not resolve a plaintext remember-token identity', function (): void {
+    $rememberToken = 'public-discovery-remember-token';
+    $user = User::factory()->create([
+        'remember_token' => $rememberToken,
+    ]);
+    $rememberCookieName = 'remember_web_'.sha1(SessionGuard::class);
+
+    Event::fake([Login::class]);
+
+    $response = $this->withCredentials()
+        ->withUnencryptedCookies([
+            $rememberCookieName => $user->getAuthIdentifier().'|'.$rememberToken.'|unused-password-hash',
+        ])->withHeaders(spaHeaders())
+        ->getJson('/v1/bootstrap?client_platform=browser');
+
+    $response->assertOk();
+
+    Event::assertNotDispatched(Login::class);
+    expectNoSetCookieHeaders($response);
+});
+
+test('public bootstrap does not authenticate or touch a bearer token', function (): void {
+    $user = User::factory()->create();
+    $accessToken = $user->createToken('public-discovery');
+
+    Event::fake([TokenAuthenticated::class]);
+
+    $response = $this->withToken($accessToken->plainTextToken)
+        ->withHeaders(spaHeaders())
+        ->getJson('/v1/bootstrap?client_platform=browser');
+
+    $response->assertOk();
+
+    Event::assertNotDispatched(TokenAuthenticated::class);
+    expect($accessToken->accessToken->fresh()->last_used_at)->toBeNull();
     expectNoSetCookieHeaders($response);
 });
 

--- a/tests/Feature/Api/V1/BootstrapApiTest.php
+++ b/tests/Feature/Api/V1/BootstrapApiTest.php
@@ -237,7 +237,7 @@ test('public bootstrap does not refresh synthetic incoming session or xsrf cooki
     expectNoSetCookieHeaders($response);
 });
 
-test('public bootstrap does not resolve a plaintext remember-token identity', function (): void {
+test('public bootstrap does not resolve an encrypted remember-token identity', function (): void {
     $rememberToken = 'public-discovery-remember-token';
     $user = User::factory()->create([
         'remember_token' => $rememberToken,
@@ -247,7 +247,7 @@ test('public bootstrap does not resolve a plaintext remember-token identity', fu
     Event::fake([Login::class]);
 
     $response = $this->withCredentials()
-        ->withUnencryptedCookies([
+        ->withCookies([
             $rememberCookieName => $user->getAuthIdentifier().'|'.$rememberToken.'|unused-password-hash',
         ])->withHeaders(spaHeaders())
         ->getJson('/v1/bootstrap?client_platform=browser');

--- a/tests/Feature/Api/V1/BootstrapApiTest.php
+++ b/tests/Feature/Api/V1/BootstrapApiTest.php
@@ -137,6 +137,111 @@ test('public bootstrap returns web push runtime metadata for browser clients wit
     expect($response->getContent())->not->toContain('public-client-api-key-demo-1234567890');
 });
 
+test('public browser bootstrap remains stateless for the configured spa origin', function (): void {
+    $response = $this->withHeaders(spaHeaders([
+        'Accept' => 'application/json',
+    ]))->getJson('/v1/bootstrap?client_platform=browser');
+
+    $response->assertOk()
+        ->assertHeader('Access-Control-Allow-Origin', spaOrigin())
+        ->assertHeader('X-Frame-Options', 'DENY')
+        ->assertHeader('X-Content-Type-Options', 'nosniff')
+        ->assertHeader('Content-Type', 'application/json');
+
+    expect($response->headers->get('Access-Control-Allow-Origin'))->not->toBe('*');
+    expectNoSetCookieHeaders($response);
+});
+
+test('public android bootstrap remains stateless for the configured spa origin', function (): void {
+    $response = $this->withHeaders(spaHeaders([
+        'Accept' => 'application/json',
+    ]))->getJson('/v1/bootstrap?client_platform=android&app_version=1.4.0&app_build=10400');
+
+    $response->assertOk()
+        ->assertHeader('Access-Control-Allow-Origin', spaOrigin());
+
+    expectNoSetCookieHeaders($response);
+});
+
+test('unavailable public bootstrap remains stateless for the configured spa origin', function (): void {
+    config([
+        'bootstrap.public_enabled' => false,
+        'bootstrap.retryable' => true,
+        'bootstrap.retry_after_seconds' => 120,
+    ]);
+
+    $response = $this->withHeaders(spaHeaders())
+        ->getJson('/v1/bootstrap?client_platform=browser');
+
+    $response->assertStatus(503)
+        ->assertJsonPath('code', 'BOOTSTRAP_CONFIG_UNAVAILABLE');
+
+    expectNoSetCookieHeaders($response);
+});
+
+test('unsupported public bootstrap client remains stateless for the configured spa origin', function (): void {
+    $response = $this->withHeaders(spaHeaders())
+        ->getJson('/v1/bootstrap?client_platform=android&app_version=1.3.2&app_build=10302');
+
+    $response->assertStatus(426)
+        ->assertJsonPath('code', 'UNSUPPORTED_CLIENT_VERSION');
+
+    expectNoSetCookieHeaders($response);
+});
+
+test('invalid public bootstrap state remains stateless for the configured spa origin', function (): void {
+    config([
+        'app.name' => '',
+        'app.url' => '',
+        'bootstrap.minimum_supported_app_version' => null,
+        'bootstrap.minimum_supported_app_build' => null,
+    ]);
+
+    $response = $this->withHeaders(spaHeaders())
+        ->getJson('/v1/bootstrap?client_platform=browser');
+
+    $response->assertInternalServerError()
+        ->assertJsonPath('code', 'BOOTSTRAP_STATE_INVALID');
+
+    expectNoSetCookieHeaders($response);
+});
+
+test('public bootstrap remains stateless for a stateful referer without an origin', function (): void {
+    $response = $this->withHeaders([
+        'Referer' => spaReferer(),
+        'Accept' => 'application/json',
+    ])->getJson('/v1/bootstrap?client_platform=browser');
+
+    $response->assertOk();
+
+    expectNoSetCookieHeaders($response);
+});
+
+test('public bootstrap does not refresh synthetic incoming session or xsrf cookies', function (): void {
+    $response = $this->withCookies([
+        (string) config('session.cookie') => 'synthetic-session-cookie',
+        SPA_XSRF_COOKIE_NAME => 'synthetic-xsrf-cookie',
+    ])->withHeaders(spaHeaders())
+        ->getJson('/v1/bootstrap?client_platform=browser');
+
+    $response->assertOk();
+
+    expectNoSetCookieHeaders($response);
+});
+
+test('public bootstrap does not allow an unconfigured cors origin', function (): void {
+    $response = $this->withHeaders([
+        'Origin' => 'https://untrusted.secpal.dev',
+        'Referer' => 'https://untrusted.secpal.dev/',
+        'Accept' => 'application/json',
+    ])->getJson('/v1/bootstrap?client_platform=browser');
+
+    $response->assertOk()
+        ->assertHeaderMissing('Access-Control-Allow-Origin');
+
+    expectNoSetCookieHeaders($response);
+});
+
 test('public bootstrap omits notification channel metadata when authenticated installation registration is disabled', function (): void {
     config([
         'bootstrap.features.notification_channels.android_fcm' => false,

--- a/tests/Feature/Api/V1/PublicDiscoveryMiddlewareTest.php
+++ b/tests/Feature/Api/V1/PublicDiscoveryMiddlewareTest.php
@@ -14,7 +14,7 @@ use Illuminate\Routing\Middleware\ThrottleRequests;
 use Illuminate\Routing\Router;
 use Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful;
 
-test('public discovery routes exclude stateful middleware while retaining api behavior', function (string $path, string $throttleName): void {
+test('public discovery routes exclude identity-resolving middleware while retaining public api behavior', function (string $path, string $throttleName): void {
     /** @var Router $router */
     $router = app('router');
     $route = $router->getRoutes()->match(Request::create($path, 'GET'));
@@ -23,9 +23,9 @@ test('public discovery routes exclude stateful middleware while retaining api be
     expect($middleware)
         ->not->toContain(EnsureFrontendRequestsAreStateful::class)
         ->not->toContain(RestoreSessionFromRememberToken::class)
+        ->not->toContain(SetLocaleFromHeader::class)
+        ->not->toContain(InjectTenantId::class)
         ->toContain(ForceJsonResponse::class)
-        ->toContain(SetLocaleFromHeader::class)
-        ->toContain(InjectTenantId::class)
         ->toContain(ThrottleRequests::class.':'.$throttleName);
 })->with([
     'bootstrap' => ['/v1/bootstrap', 'bootstrap'],

--- a/tests/Feature/Api/V1/PublicDiscoveryMiddlewareTest.php
+++ b/tests/Feature/Api/V1/PublicDiscoveryMiddlewareTest.php
@@ -1,0 +1,47 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+
+declare(strict_types=1);
+
+use App\Http\Middleware\ForceJsonResponse;
+use App\Http\Middleware\InjectTenantId;
+use App\Http\Middleware\RestoreSessionFromRememberToken;
+use App\Http\Middleware\SetLocaleFromHeader;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Middleware\ThrottleRequests;
+use Illuminate\Routing\Router;
+use Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful;
+
+test('public discovery routes exclude stateful middleware while retaining api behavior', function (string $path, string $throttleName): void {
+    /** @var Router $router */
+    $router = app('router');
+    $route = $router->getRoutes()->match(Request::create($path, 'GET'));
+    $middleware = $router->gatherRouteMiddleware($route);
+
+    expect($middleware)
+        ->not->toContain(EnsureFrontendRequestsAreStateful::class)
+        ->not->toContain(RestoreSessionFromRememberToken::class)
+        ->toContain(ForceJsonResponse::class)
+        ->toContain(SetLocaleFromHeader::class)
+        ->toContain(InjectTenantId::class)
+        ->toContain(ThrottleRequests::class.':'.$throttleName);
+})->with([
+    'bootstrap' => ['/v1/bootstrap', 'bootstrap'],
+    'release' => ['/v1/release', 'release'],
+    'source' => ['/v1/source', 'source-offer'],
+]);
+
+test('spa login and protected routes retain stateful middleware', function (string $path, string $method): void {
+    /** @var Router $router */
+    $router = app('router');
+    $route = $router->getRoutes()->match(Request::create($path, $method));
+
+    expect($router->gatherRouteMiddleware($route))
+        ->toContain(EnsureFrontendRequestsAreStateful::class)
+        ->toContain(RestoreSessionFromRememberToken::class);
+})->with([
+    'spa login' => ['/v1/auth/login', 'POST'],
+    'protected me' => ['/v1/me', 'GET'],
+]);

--- a/tests/Feature/Api/V1/ReleaseApiTest.php
+++ b/tests/Feature/Api/V1/ReleaseApiTest.php
@@ -66,10 +66,11 @@ test('invalid public release state remains stateless for the configured spa orig
 });
 
 test('public release does not refresh synthetic incoming cookies', function (): void {
-    $response = $this->withCookies([
-        (string) config('session.cookie') => 'synthetic-session-cookie',
-        SPA_XSRF_COOKIE_NAME => 'synthetic-xsrf-cookie',
-    ])->withHeaders(spaHeaders())
+    $response = $this->withCredentials()
+        ->withCookies([
+            (string) config('session.cookie') => 'synthetic-session-cookie',
+            SPA_XSRF_COOKIE_NAME => 'synthetic-xsrf-cookie',
+        ])->withHeaders(spaHeaders())
         ->getJson('/v1/release');
 
     $response->assertOk();

--- a/tests/Feature/Api/V1/ReleaseApiTest.php
+++ b/tests/Feature/Api/V1/ReleaseApiTest.php
@@ -40,6 +40,43 @@ test('public release endpoint returns the configured api release metadata', func
         ]);
 });
 
+test('public release response remains stateless for the configured spa origin', function (): void {
+    $response = $this->withHeaders(spaHeaders())
+        ->getJson('/v1/release');
+
+    $response->assertOk()
+        ->assertHeader('Access-Control-Allow-Origin', spaOrigin())
+        ->assertHeader('X-Frame-Options', 'DENY');
+
+    expectNoSetCookieHeaders($response);
+});
+
+test('invalid public release state remains stateless for the configured spa origin', function (): void {
+    config([
+        'bootstrap.api_release.version' => " \n ",
+    ]);
+
+    $response = $this->withHeaders(spaHeaders())
+        ->getJson('/v1/release');
+
+    $response->assertInternalServerError()
+        ->assertJsonPath('code', 'RELEASE_STATE_INVALID');
+
+    expectNoSetCookieHeaders($response);
+});
+
+test('public release does not refresh synthetic incoming cookies', function (): void {
+    $response = $this->withCookies([
+        (string) config('session.cookie') => 'synthetic-session-cookie',
+        SPA_XSRF_COOKIE_NAME => 'synthetic-xsrf-cookie',
+    ])->withHeaders(spaHeaders())
+        ->getJson('/v1/release');
+
+    $response->assertOk();
+
+    expectNoSetCookieHeaders($response);
+});
+
 test('public release endpoint fails closed when the release version is missing', function (): void {
     config([
         'bootstrap.api_release.version' => " \n ",

--- a/tests/Feature/Api/V1/SourceApiTest.php
+++ b/tests/Feature/Api/V1/SourceApiTest.php
@@ -86,6 +86,41 @@ test('public source endpoint returns license and corresponding source metadata',
         ]);
 });
 
+test('public source response remains stateless for the configured spa origin', function (): void {
+    $response = $this->withHeaders(spaHeaders())
+        ->getJson('/v1/source');
+
+    $response->assertOk()
+        ->assertHeader('Access-Control-Allow-Origin', spaOrigin())
+        ->assertHeader('X-Frame-Options', 'DENY');
+
+    expectNoSetCookieHeaders($response);
+});
+
+test('invalid public source state remains stateless for the configured spa origin', function (): void {
+    config(['app.url' => 'http://localhost']);
+
+    $response = $this->withHeaders(spaHeaders())
+        ->getJson('/v1/source');
+
+    $response->assertInternalServerError()
+        ->assertJsonPath('code', 'SOURCE_STATE_INVALID');
+
+    expectNoSetCookieHeaders($response);
+});
+
+test('public source does not refresh synthetic incoming cookies', function (): void {
+    $response = $this->withCookies([
+        (string) config('session.cookie') => 'synthetic-session-cookie',
+        SPA_XSRF_COOKIE_NAME => 'synthetic-xsrf-cookie',
+    ])->withHeaders(spaHeaders())
+        ->getJson('/v1/source');
+
+    $response->assertOk();
+
+    expectNoSetCookieHeaders($response);
+});
+
 test('public source endpoint is reachable without authentication and contains the expected source offer references', function (): void {
     getJson('/v1/source')
         ->assertOk()

--- a/tests/Feature/Api/V1/SourceApiTest.php
+++ b/tests/Feature/Api/V1/SourceApiTest.php
@@ -110,10 +110,11 @@ test('invalid public source state remains stateless for the configured spa origi
 });
 
 test('public source does not refresh synthetic incoming cookies', function (): void {
-    $response = $this->withCookies([
-        (string) config('session.cookie') => 'synthetic-session-cookie',
-        SPA_XSRF_COOKIE_NAME => 'synthetic-xsrf-cookie',
-    ])->withHeaders(spaHeaders())
+    $response = $this->withCredentials()
+        ->withCookies([
+            (string) config('session.cookie') => 'synthetic-session-cookie',
+            SPA_XSRF_COOKIE_NAME => 'synthetic-xsrf-cookie',
+        ])->withHeaders(spaHeaders())
         ->getJson('/v1/source');
 
     $response->assertOk();

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -103,6 +103,11 @@ function spaHeaders(array $headers = []): array
 
 const SPA_XSRF_COOKIE_NAME = 'XSRF-TOKEN';
 
+function expectNoSetCookieHeaders(Illuminate\Testing\TestResponse $response): void
+{
+    expect($response->headers->all('set-cookie'))->toHaveCount(0);
+}
+
 function issueSpaCsrfToken(Tests\TestCase $testCase): string
 {
     $response = $testCase->withHeaders(spaHeaders())


### PR DESCRIPTION
Closes #1362.

## Problem

Public discovery requests carrying the configured SPA origin entered Sanctum's stateful middleware pipeline and emitted XSRF and session cookies.

A focused pre-fix feature test reproduced the issue with a successful browser bootstrap request and found both `XSRF-TOKEN` and the configured session cookie. No cookie values were stored or copied into this pull request.

## Root cause

`EnsureFrontendRequestsAreStateful` and `RestoreSessionFromRememberToken` were applied through the API middleware group without excluding public pre-login discovery routes.

## Fix

The public bootstrap, release, and source routes bypass stateful and identity-resolving API middleware while retaining CORS, throttling, JSON responses, global `Accept-Language` locale handling, and security headers. Public discovery intentionally skips user-based tenant-context injection.

## Security properties

- no `Set-Cookie` on public discovery responses
- no session or CSRF lifecycle for those routes
- no remember-token identity restoration on those routes
- no Bearer-token authentication or token usage update on those routes
- SPA login remains stateful
- `/sanctum/csrf-cookie` remains functional
- Bearer-token authentication remains functional on protected routes
- Remember-token restoration remains active on stateful paths

## Validation

- failing test before the fix, passing after the route exclusion
- bootstrap tests: 34 passed, 138 assertions
- release tests: 8 passed, 33 assertions
- source tests: 8 passed, 35 assertions
- middleware structure tests: 5 passed, 22 assertions
- Sanctum cookie/session/Bearer tests: 26 passed, 74 assertions
- remember-session restoration tests: 6 passed, 14 assertions
- full test suite: 3,067 passed, 1 skipped, 11,955 assertions
- PHPStan: no errors
- Pint dirty/full checks: passed
- REUSE 3.3: compliant, 808/808 files licensed
- manual local HTTP check: bootstrap, release, and source returned HTTP 200 with exact allowed CORS origin and no `Set-Cookie`; `/sanctum/csrf-cookie` returned HTTP 204 with the expected XSRF and session cookie names

## Scope

No deployment, environment, database migration, dependency, frontend, Android, or CORS configuration changes are included.

The public-route audit found separate authentication-lifecycle questions for onboarding token validation (#1363) and email verification (#1364). They are intentionally excluded from this discovery-only change.
