### PR TITLE
Keep onboarding token validation stateless

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- kept public onboarding token validation stateless for SPA-origin requests because token and email are its complete authorization context, preventing validation responses from creating or refreshing session/CSRF cookies, restoring remembered users, or authenticating bearer tokens while preserving stateful onboarding completion (fixes `api#1363`).
 - kept public bootstrap, release, and source responses outside identity-resolving API middleware, preventing discovery requests from creating cookies, restoring sessions, or authenticating and touching bearer tokens while leaving SPA and protected-route authentication unchanged (fixes `api#1362`).
 - normalized customer identifiers are enforced by database-generated values and tenant/Legal-Entity-scoped unique indexes, preventing concurrent duplicate creation; duplicate conflicts intentionally disclose neither the matched field nor an existing customer identifier (US-003).
 - pinned the shared Dependabot auto-merge reusable workflow to immutable commit `d90b56d4bca7c0d6e7fe1520d69b1f98eca22f5e`, preventing later movement of its `v1` tag from changing API automation without a reviewed dependency update (fixes `api#1300`)

--- a/routes/api.php
+++ b/routes/api.php
@@ -91,9 +91,21 @@ Route::prefix('v1')->group(function () {
         ->whereUuid('id')
         ->name('verification.verify');
 
-    // Onboarding completion (public, token-authenticated)
+    // Token validation is public and stateless: token + email are the complete
+    // authorization context, so browser identity/session middleware must not run.
+    // The global locale, CORS, JSON, security-header, and API throttle middleware
+    // still apply.
     Route::get('/onboarding/validate-token', [OnboardingController::class, 'validateToken'])
+        ->withoutMiddleware([
+            EnsureFrontendRequestsAreStateful::class,
+            RestoreSessionFromRememberToken::class,
+            SetLocaleFromHeader::class,
+            InjectTenantId::class,
+        ])
         ->middleware('throttle:onboarding-validate');
+
+    // Completion intentionally stays stateful because a successful identity proof
+    // logs the invitee into the browser session and rotates the session identifier.
     Route::post('/onboarding/complete', [OnboardingController::class, 'complete'])
         ->middleware(['throttle:onboarding-complete', 'web']);
 

--- a/tests/Feature/OnboardingTokenValidationTest.php
+++ b/tests/Feature/OnboardingTokenValidationTest.php
@@ -5,11 +5,25 @@
 
 declare(strict_types=1);
 
+use App\Http\Middleware\ForceJsonResponse;
+use App\Http\Middleware\InjectTenantId;
+use App\Http\Middleware\RestoreSessionFromRememberToken;
+use App\Http\Middleware\SetLocaleFromHeader;
 use App\Models\Employee;
 use App\Models\EmployeeOnboardingToken;
 use App\Models\TenantKey;
 use App\Models\User;
+use Illuminate\Auth\Events\Login;
+use Illuminate\Auth\SessionGuard;
+use Illuminate\Foundation\Http\Middleware\PreventRequestForgery;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Middleware\ThrottleRequests;
+use Illuminate\Routing\Router;
+use Illuminate\Session\Middleware\StartSession;
+use Illuminate\Support\Facades\Event;
+use Laravel\Sanctum\Events\TokenAuthenticated;
+use Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful;
 
 use function Pest\Laravel\getJson;
 
@@ -45,14 +59,48 @@ test('validates token with correct email and returns minimal data only', functio
     $tokenData = EmployeeOnboardingToken::generate($employee);
     $plainToken = $tokenData['plain'];
 
-    $response = getJson('/v1/onboarding/validate-token?token='.urlencode($plainToken).'&email='.urlencode('test@secpal.dev'));
+    $response = $this->withHeaders(spaHeaders())
+        ->getJson('/v1/onboarding/validate-token?token='.urlencode($plainToken).'&email='.urlencode('test@secpal.dev'));
 
     $response->assertOk()
+        ->assertHeader('Access-Control-Allow-Origin', spaOrigin())
+        ->assertHeader('X-Frame-Options', 'DENY')
         ->assertExactJson([
             'data' => [
                 'valid' => true,
             ],
         ]);
+
+    expectNoSetCookieHeaders($response);
+});
+
+test('token validation excludes browser identity middleware while completion keeps its session and csrf lifecycle', function (): void {
+    /** @var Router $router */
+    $router = app('router');
+
+    $validationRoute = $router->getRoutes()->match(
+        Request::create('/v1/onboarding/validate-token', 'GET')
+    );
+    $validationMiddleware = $router->gatherRouteMiddleware($validationRoute);
+
+    expect($validationMiddleware)
+        ->not->toContain(EnsureFrontendRequestsAreStateful::class)
+        ->not->toContain(RestoreSessionFromRememberToken::class)
+        ->not->toContain(SetLocaleFromHeader::class)
+        ->not->toContain(InjectTenantId::class)
+        ->toContain(ForceJsonResponse::class)
+        ->toContain(ThrottleRequests::class.':onboarding-validate');
+
+    $completionRoute = $router->getRoutes()->match(
+        Request::create('/v1/onboarding/complete', 'POST')
+    );
+
+    expect($router->gatherRouteMiddleware($completionRoute))
+        ->toContain(EnsureFrontendRequestsAreStateful::class)
+        ->toContain(RestoreSessionFromRememberToken::class)
+        ->toContain(StartSession::class)
+        ->toContain(PreventRequestForgery::class)
+        ->toContain(ThrottleRequests::class.':onboarding-complete');
 });
 
 test('SECURITY: validate-token does not leak personal data even when token is valid', function () {
@@ -177,6 +225,72 @@ test('rejects invalid token with localized message when german locale is request
         ->assertJson([
             'message' => 'Ungültiger oder abgelaufener Onboarding-Link. Bitte fordern Sie eine neue Einladung an.',
         ]);
+});
+
+test('validation errors remain stateless for the configured spa origin', function (): void {
+    $response = $this->withHeaders(spaHeaders([
+        'Accept-Language' => 'de',
+    ]))->getJson('/v1/onboarding/validate-token?email=synthetic-invitee@secpal.dev');
+
+    $response->assertUnprocessable()
+        ->assertJsonValidationErrors(['token'])
+        ->assertHeader('Access-Control-Allow-Origin', spaOrigin())
+        ->assertHeader('X-Frame-Options', 'DENY')
+        ->assertHeader('Content-Type', 'application/json');
+
+    expect(app()->getLocale())->toBe('de');
+    expectNoSetCookieHeaders($response);
+});
+
+test('token validation does not refresh synthetic incoming session or xsrf cookies', function (): void {
+    $response = $this->withCredentials()
+        ->withCookies([
+            (string) config('session.cookie') => 'synthetic-session-cookie',
+            SPA_XSRF_COOKIE_NAME => 'synthetic-xsrf-cookie',
+        ])->withHeaders(spaHeaders())
+        ->getJson('/v1/onboarding/validate-token?token=synthetic-invalid-token&email=synthetic-invitee@secpal.dev');
+
+    $response->assertUnprocessable();
+
+    expectNoSetCookieHeaders($response);
+});
+
+test('token validation does not restore a synthetic remember-token identity', function (): void {
+    $rememberToken = 'synthetic-onboarding-remember-token';
+    $user = User::factory()->create([
+        'remember_token' => $rememberToken,
+    ]);
+    $rememberCookieName = 'remember_web_'.sha1(SessionGuard::class);
+
+    Event::fake([Login::class]);
+
+    $response = $this->withCredentials()
+        ->withCookies([
+            $rememberCookieName => $user->getAuthIdentifier().'|'.$rememberToken.'|synthetic-password-hash',
+        ])->withHeaders(spaHeaders())
+        ->getJson('/v1/onboarding/validate-token?token=synthetic-invalid-token&email=synthetic-invitee@secpal.dev');
+
+    $response->assertUnprocessable();
+
+    Event::assertNotDispatched(Login::class);
+    expectNoSetCookieHeaders($response);
+});
+
+test('token validation does not authenticate or touch a synthetic bearer token', function (): void {
+    $user = User::factory()->create();
+    $accessToken = $user->createToken('synthetic-onboarding-validation');
+
+    Event::fake([TokenAuthenticated::class]);
+
+    $response = $this->withToken($accessToken->plainTextToken)
+        ->withHeaders(spaHeaders())
+        ->getJson('/v1/onboarding/validate-token?token=synthetic-invalid-token&email=synthetic-invitee@secpal.dev');
+
+    $response->assertUnprocessable();
+
+    Event::assertNotDispatched(TokenAuthenticated::class);
+    expect($accessToken->accessToken->fresh()->last_used_at)->toBeNull();
+    expectNoSetCookieHeaders($response);
 });
 
 test('rejects expired token', function () {

--- a/tests/Feature/OnboardingTokenValidationTest.php
+++ b/tests/Feature/OnboardingTokenValidationTest.php
@@ -21,6 +21,7 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\Middleware\ThrottleRequests;
 use Illuminate\Routing\Router;
 use Illuminate\Session\Middleware\StartSession;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Event;
 use Laravel\Sanctum\Events\TokenAuthenticated;
 use Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful;
@@ -260,7 +261,9 @@ test('token validation does not restore a synthetic remember-token identity', fu
     $user = User::factory()->create([
         'remember_token' => $rememberToken,
     ]);
-    $rememberCookieName = 'remember_web_'.sha1(SessionGuard::class);
+    /** @var SessionGuard $guard */
+    $guard = Auth::guard('web');
+    $rememberCookieName = $guard->getRecallerName();
 
     Event::fake([Login::class]);
 


### PR DESCRIPTION
## Summary

- keep `GET /v1/onboarding/validate-token` outside browser identity and session middleware
- preserve locale resolution, CORS, JSON responses, security headers, and the dedicated validation throttle
- keep `POST /v1/onboarding/complete` stateful with session authentication, CSRF protection, remember-cookie handling, and its separate throttle
- document the security decision and add focused lifecycle regression coverage

## Problem and evidence

`GET /v1/onboarding/validate-token` is a public pre-login route, but requests carrying the configured SPA `Origin` and `Referer` entered Sanctum's stateful frontend pipeline. A focused regression reproduced the reported behavior before the change: a synthetic `422` validation response emitted two `Set-Cookie` headers.

The endpoint only validates the onboarding token and invitee email and does not require an authenticated browser identity. Running session, CSRF, remember-token restoration, or bearer-token authentication lifecycle for this request adds state without contributing to token validation.

## Change

The validation route now excludes `EnsureFrontendRequestsAreStateful`, `RestoreSessionFromRememberToken`, the authenticated-user locale pass, and tenant injection. The global locale pass remains active, while the API JSON middleware, CORS, security headers, route bindings, and `onboarding-validate` throttle continue to apply.

The completion route is intentionally unchanged and remains stateful because successful onboarding logs the invitee into the browser session and rotates the session identifier.

Regression coverage verifies successful and error responses, incoming session and CSRF cookies, remember-token restoration, bearer-token authentication, middleware topology, locale handling, CORS, security headers, and the preserved completion lifecycle. All request and cookie inputs used by the new coverage are synthetic; response cookie values are not inspected or recorded.

## Validation

- TDD regression: failed before the route change with two `Set-Cookie` headers, then passed after the implementation
- focused onboarding, middleware, and locale coverage: 78 tests, 352 assertions
- complete non-serial suite: 3,037 passed, 1 skipped, 11,779 assertions
- complete serial suite: 35 passed, 215 assertions
- `composer analyse`
- `vendor/bin/pint --dirty`
- `reuse lint`
- `git diff --check`
- signed commit verification
- local four-pass review covering correctness, security, privacy, lifecycle ordering, test completeness, DRY, KISS, YAGNI, SOLID, and issue management

## Readiness

The final self-review in the GitHub pull request view found zero issues. No in-scope dependency or unresolved local check prevents readiness. Remote CI is still in progress, so the pull request remains draft as requested.

Closes #1363