### PR TITLE
Keep email verification responses stateless

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- kept signed email-verification responses stateless because the signed URL is the complete authorization proof, preventing successful and error responses from creating or refreshing session/CSRF cookies, restoring remembered users, or authenticating and touching bearer tokens while preserving signature validation, throttling, JSON, locale, CORS, and security headers (fixes `api#1364`).
 - kept public onboarding token validation stateless for SPA-origin requests because token and email are its complete authorization context, preventing validation responses from creating or refreshing session/CSRF cookies, restoring remembered users, or authenticating bearer tokens while preserving stateful onboarding completion (fixes `api#1363`).
 - kept public bootstrap, release, and source responses outside identity-resolving API middleware, preventing discovery requests from creating cookies, restoring sessions, or authenticating and touching bearer tokens while leaving SPA and protected-route authentication unchanged (fixes `api#1362`).
 - normalized customer identifiers are enforced by database-generated values and tenant/Legal-Entity-scoped unique indexes, preventing concurrent duplicate creation; duplicate conflicts intentionally disclose neither the matched field nor an existing customer identifier (US-003).

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -97,6 +97,13 @@ class AppServiceProvider extends ServiceProvider
             return Limit::perMinutes(60, 5)->by($request->ip());
         });
 
+        // A signed verification URL is its own authorization proof. Keying only
+        // by source IP preserves the existing six-per-minute limit without
+        // resolving session or bearer-token identity on this public route.
+        RateLimiter::for('email-verification', function (Request $request) {
+            return Limit::perMinute(6)->by($request->ip());
+        });
+
         RateLimiter::for('bootstrap', function (Request $request) {
             return Limit::perMinutes(5, 5)
                 ->by($this->bootstrapThrottleKey($request))

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -100,7 +100,7 @@ class AppServiceProvider extends ServiceProvider
         // A signed verification URL is its own authorization proof. Keying only
         // by source IP preserves the existing six-per-minute limit without
         // resolving session or bearer-token identity on this public route.
-        RateLimiter::for('email-verification', function (Request $request) {
+        RateLimiter::for('email-verification', function (Request $request): Limit {
             return Limit::perMinute(6)->by($request->ip());
         });
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -86,8 +86,19 @@ Route::prefix('v1')->group(function () {
         ->middleware('throttle:password-reset');
     Route::post('/auth/password/reset', [AuthController::class, 'passwordReset'])
         ->middleware('throttle:password-reset');
+
+    // The signed URL is the complete authorization proof for email verification.
+    // Verification neither reads nor establishes browser identity, so keep the
+    // route outside session, CSRF, remember-cookie, and bearer-token resolution.
+    // Global locale, CORS, JSON, and security-header middleware still apply.
     Route::get('/auth/email/verify/{id}/{hash}', [AuthController::class, 'verifyEmail'])
-        ->middleware(['signed', 'throttle:6,1'])
+        ->withoutMiddleware([
+            EnsureFrontendRequestsAreStateful::class,
+            RestoreSessionFromRememberToken::class,
+            SetLocaleFromHeader::class,
+            InjectTenantId::class,
+        ])
+        ->middleware(['signed', 'throttle:email-verification'])
         ->whereUuid('id')
         ->name('verification.verify');
 

--- a/tests/Feature/Auth/EmailVerificationResponseTest.php
+++ b/tests/Feature/Auth/EmailVerificationResponseTest.php
@@ -1,0 +1,180 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+
+declare(strict_types=1);
+
+use App\Http\Middleware\ForceJsonResponse;
+use App\Http\Middleware\InjectTenantId;
+use App\Http\Middleware\RestoreSessionFromRememberToken;
+use App\Http\Middleware\SetLocaleFromHeader;
+use App\Models\User;
+use Illuminate\Auth\Events\Login;
+use Illuminate\Auth\SessionGuard;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Middleware\ThrottleRequests;
+use Illuminate\Routing\Middleware\ValidateSignature;
+use Illuminate\Routing\Router;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\URL;
+use Laravel\Sanctum\Events\TokenAuthenticated;
+use Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful;
+
+uses(RefreshDatabase::class);
+
+/**
+ * @return non-empty-string
+ */
+function signedEmailVerificationPath(User $user): string
+{
+    $url = URL::temporarySignedRoute('verification.verify', now()->addMinutes(60), [
+        'id' => $user->id,
+        'hash' => sha1($user->getEmailForVerification()),
+    ]);
+
+    $path = (string) parse_url($url, PHP_URL_PATH);
+    $query = (string) parse_url($url, PHP_URL_QUERY);
+
+    return "{$path}?{$query}";
+}
+
+test('signed email verification uses its signed link without browser identity middleware', function (): void {
+    /** @var Router $router */
+    $router = app('router');
+    $route = $router->getRoutes()->match(
+        Request::create(
+            '/v1/auth/email/verify/00000000-0000-4000-8000-000000000001/synthetic-hash',
+            'GET',
+        ),
+    );
+
+    expect($router->gatherRouteMiddleware($route))
+        ->not->toContain(EnsureFrontendRequestsAreStateful::class)
+        ->not->toContain(RestoreSessionFromRememberToken::class)
+        ->not->toContain(SetLocaleFromHeader::class)
+        ->not->toContain(InjectTenantId::class)
+        ->toContain(ForceJsonResponse::class)
+        ->toContain(ValidateSignature::class)
+        ->toContain(ThrottleRequests::class.':email-verification');
+});
+
+test('successful signed email verification is stateless and preserves response middleware', function (): void {
+    $user = User::factory()->unverified()->create([
+        'email' => 'synthetic-verification-success@secpal.dev',
+    ]);
+
+    $response = $this->withHeaders(spaHeaders([
+        'Accept-Language' => 'de',
+    ]))->getJson(signedEmailVerificationPath($user));
+
+    $response->assertOk()
+        ->assertJson([
+            'message' => 'E-Mail-Adresse erfolgreich verifiziert.',
+        ])
+        ->assertHeader('Access-Control-Allow-Origin', spaOrigin())
+        ->assertHeader('Content-Type', 'application/json')
+        ->assertHeader('X-Frame-Options', 'DENY');
+
+    expect(app()->getLocale())->toBe('de')
+        ->and($user->fresh()->hasVerifiedEmail())->toBeTrue();
+    expectNoSetCookieHeaders($response);
+});
+
+test('signed email verification remains limited to six requests per minute', function (): void {
+    $user = User::factory()->unverified()->create([
+        'email' => 'synthetic-throttled-verification@secpal.dev',
+    ]);
+    $path = signedEmailVerificationPath($user);
+
+    for ($attempt = 0; $attempt < 6; $attempt++) {
+        $response = $this->withHeaders(spaHeaders())->getJson($path);
+
+        $response->assertOk();
+        expectNoSetCookieHeaders($response);
+    }
+
+    $response = $this->withHeaders(spaHeaders())->getJson($path);
+
+    $response->assertTooManyRequests()
+        ->assertHeader('Content-Type', 'application/json');
+    expectNoSetCookieHeaders($response);
+});
+
+test('invalid email verification signatures stay stateless for the configured spa origin', function (): void {
+    $response = $this->withCredentials()
+        ->withCookies([
+            (string) config('session.cookie') => 'synthetic-session-cookie',
+            SPA_XSRF_COOKIE_NAME => 'synthetic-xsrf-cookie',
+        ])->withHeaders(spaHeaders([
+            'Accept-Language' => 'de',
+        ]))->getJson(
+            '/v1/auth/email/verify/00000000-0000-4000-8000-000000000002/synthetic-hash'
+            .'?expires=2000000000&signature=synthetic-invalid-signature',
+        );
+
+    $response->assertForbidden()
+        ->assertHeader('Access-Control-Allow-Origin', spaOrigin())
+        ->assertHeader('Content-Type', 'application/json')
+        ->assertHeader('X-Frame-Options', 'DENY');
+
+    expect(app()->getLocale())->toBe('de');
+    expectNoSetCookieHeaders($response);
+});
+
+test('signed email verification does not restore a remember-token identity', function (): void {
+    $rememberToken = 'synthetic-email-verification-remember-token';
+    $rememberedUser = User::factory()->create([
+        'email' => 'synthetic-remembered-user@secpal.dev',
+        'password' => bcrypt('synthetic-password'),
+        'remember_token' => $rememberToken,
+    ]);
+    $verificationUser = User::factory()->unverified()->create([
+        'email' => 'synthetic-remember-verification@secpal.dev',
+    ]);
+
+    /** @var SessionGuard $guard */
+    $guard = Auth::guard('web');
+    $rememberCookieName = $guard->getRecallerName();
+
+    Event::fake([Login::class]);
+
+    $response = $this->withCredentials()
+        ->withCookies([
+            $rememberCookieName => $rememberedUser->getAuthIdentifier()
+                .'|'.$rememberToken
+                .'|'.$rememberedUser->getAuthPassword(),
+        ])->withHeaders(spaHeaders())
+        ->getJson(signedEmailVerificationPath($verificationUser));
+
+    $response->assertOk();
+
+    Event::assertNotDispatched(Login::class);
+    expect($verificationUser->fresh()->hasVerifiedEmail())->toBeTrue();
+    expectNoSetCookieHeaders($response);
+});
+
+test('signed email verification does not authenticate or touch a bearer token', function (): void {
+    $tokenUser = User::factory()->create([
+        'email' => 'synthetic-token-user@secpal.dev',
+    ]);
+    $accessToken = $tokenUser->createToken('synthetic-email-verification');
+    $verificationUser = User::factory()->unverified()->create([
+        'email' => 'synthetic-token-verification@secpal.dev',
+    ]);
+
+    Event::fake([TokenAuthenticated::class]);
+
+    $response = $this->withToken($accessToken->plainTextToken)
+        ->withHeaders(spaHeaders())
+        ->getJson(signedEmailVerificationPath($verificationUser));
+
+    $response->assertOk();
+
+    Event::assertNotDispatched(TokenAuthenticated::class);
+    expect($accessToken->accessToken->fresh()->last_used_at)->toBeNull()
+        ->and($verificationUser->fresh()->hasVerifiedEmail())->toBeTrue();
+    expectNoSetCookieHeaders($response);
+});


### PR DESCRIPTION
## Problem and evidence

`GET /v1/auth/email/verify/{id}/{hash}` is a public signed-link endpoint, but it inherited the stateful API middleware path. A request with the configured SPA `Origin` and `Referer` could therefore return an invalid-signature `403` while still emitting session-related `Set-Cookie` headers.

The verification controller uses the signed user identifier and email hash as its complete authorization proof. It does not read or establish an authenticated browser session. The generic numeric throttle also resolved request authentication while deriving its key, which could authenticate and touch an otherwise unrelated bearer token.

## Change

- Exclude the email-verification route from stateful SPA, remember-token restoration, authenticated locale lookup, and tenant identity middleware.
- Preserve global locale handling, CORS, forced JSON responses, security headers, signed-link validation, and the existing six-requests-per-minute limit.
- Replace the generic numeric throttle with an equivalent IP-scoped `email-verification` limiter that does not resolve session or bearer-token identity.
- Add focused regression coverage for successful verification, invalid signatures, incoming synthetic cookies, remember-token isolation, bearer-token isolation, middleware composition, and throttling.
- Document the security decision in `CHANGELOG.md`.

## Validation

- TDD: the route-composition regression failed before implementation because stateful SPA middleware was present; the bearer-token regression then exposed authentication performed by the generic throttle before the named limiter was added.
- `php artisan test tests/Feature/Auth/EmailVerificationResponseTest.php tests/Feature/AuthTest.php --filter='Email Verification|signed email verification' --stop-on-failure` — 13 tests passed, 76 assertions.
- `vendor/bin/pint --test --dirty`
- `vendor/bin/phpstan analyse app/Providers/AppServiceProvider.php routes/api.php tests/Feature/Auth/EmailVerificationResponseTest.php --no-progress`
- `reuse lint` — 809 of 809 files compliant.
- `git diff --check`
- Commit `3d625d1` is signed with the configured ED25519 signing key.

## Readiness

No in-scope dependency or unresolved local validation check remains. This PR remains draft until the required final self-review is completed in the PR view. GitHub-hosted checks were not inspected as part of this publish step.

Closes #1364