### PR TITLE
Remove retired changelog integration

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -44,7 +44,7 @@ Do not assume instructions from sibling repositories or comment-based inheritanc
   pull requests, issues, changelogs, documentation, code comments, UI copy, or release notes unless the task
   explicitly requires documenting AI tooling behavior.
 - Keep `SPDX-FileCopyrightText` years current in edited files or companion `.license` sidecars.
-- Domain policy is strict: `secpal.app` for the public homepage and real email addresses, `changelog.secpal.app` for the public changelog site, `apk.secpal.app` for the canonical Android artifact and release-metadata host, `api.secpal.dev` for the API, `app.secpal.dev` for the PWA/frontend, `secpal.dev` for dev, staging, testing, and examples, and `app.secpal` only as the Android application identifier.
+- Domain policy is strict: `secpal.app` for the public homepage and real email addresses, `apk.secpal.app` for the canonical Android artifact and release-metadata host, `api.secpal.dev` for the API, `app.secpal.dev` for the PWA/frontend, `secpal.dev` for dev, staging, testing, and examples, and `app.secpal` only as the Android application identifier.
 - After every merge, immediately return the local repo to a ready state:
   switch to `main`, pull with fast-forward only, delete the merged topic
   branch, prune remotes, refresh Composer dependencies where applicable, run

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ Do not assume instructions from sibling repositories or comment-based inheritanc
   pull requests, issues, changelogs, documentation, code comments, UI copy, or release notes unless the task
   explicitly requires documenting AI tooling behavior.
 - Keep `SPDX-FileCopyrightText` years current in edited files or companion `.license` sidecars.
-- Domain policy is strict: `secpal.app` for the public homepage and real email addresses, `changelog.secpal.app` for the public changelog site, `apk.secpal.app` for the canonical Android artifact and release-metadata host, `api.secpal.dev` for the API, `app.secpal.dev` for the PWA/frontend, `secpal.dev` for dev, staging, testing, and examples, and `app.secpal` only as the Android application identifier.
+- Domain policy is strict: `secpal.app` for the public homepage and real email addresses, `apk.secpal.app` for the canonical Android artifact and release-metadata host, `api.secpal.dev` for the API, `app.secpal.dev` for the PWA/frontend, `secpal.dev` for dev, staging, testing, and examples, and `app.secpal` only as the Android application identifier.
 - After every merge, immediately return the local repo to a ready state:
   switch to `main`, pull with fast-forward only, delete the merged topic
   branch, prune remotes, refresh Composer dependencies where applicable, run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -515,7 +515,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Onboarding Completion Detection System** (Issue #498, Epic #469)
-
   - **IMPLEMENTED** Automatic detection and tracking of onboarding completion
   - **`OnboardingCompletionService`**: Service class for completion logic
     - `checkCompletion(Employee)`: Detects when all required templates approved, auto-updates `employee.onboarding_completed` and `employee.onboarding_completed_at`
@@ -532,7 +531,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Tests**: 29 comprehensive Pest tests (18 unit + 11 feature) covering all edge cases
 
 - **Standard Onboarding Form Templates Seeder** (Issue #497, Epic #469)
-
   - **IMPLEMENTED** 4 pre-configured onboarding form templates (system-wide)
   - **Templates Created**:
     1. **Personal Information Form** (Required): BewachV § 16 required fields (gender, nationalities, intended activities)
@@ -550,7 +548,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Tests**: 20+ comprehensive Pest tests validating structure, validation rules, and data integrity
 
 - **Magic Link Employee Onboarding System** (Issue #486, Epic #469)
-
   - **IMPLEMENTED** Secure single-use tokens for pre-contract employee onboarding
   - **`employee_onboarding_tokens` Table**: UUID primary key, bcrypt-hashed tokens, 7-day expiry, single-use enforcement, audit trail (IP, user agent)
   - **`EmployeeOnboardingToken` Model**:
@@ -578,7 +575,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Tests**: 16 unit tests (all passing), 7 feature tests (E2E flow validated, 2 pending User accounts)
 
 - **BewachV § 16 Employee Data Fields for BWR Registration** (Issue #468, Epic #469)
-
   - **IMPLEMENTED** Complete BewachV compliance for Bewacherregister (BWR) employee data management
   - **30+ New Fields** across 7 categories:
     - **BWR Tracking**: `bwr_id` (7-digit unique ID), `bwr_status` (5-state enum), `bwr_registered_at`, `bwr_submission_date`, `bwr_notes`
@@ -631,7 +627,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Impact**: Foundation for Issues #471 (BWR Workflow Export), #470 (Automated Data Deletion), #472 (Work Permit Tracking)
 
 - **Activity Log REST API with Scoped Filtering** (Issue #394, Epic #385)
-
   - **IMPLEMENTED** ActivityLogController with 3 RESTful endpoints for activity log access
   - Endpoints:
     - `GET /v1/activity-logs` - Paginated listing with comprehensive filtering
@@ -667,7 +662,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Impact:** Completes Epic #385 Phase 6, unblocks Issue #395 (Frontend Activity Log Viewer), enables BewachV § 21 Abs. 4 compliance
 
 - **ActivityPolicy with Leadership Level Filtering** (Issue #396, Epic #385)
-
   - **IMPLEMENTED** authorization policy for hierarchical activity log access
   - Architecture:
     - `view()` method enforces tenant isolation + organizational scope + leadership filtering
@@ -730,7 +724,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **BWR-ID Format and Validation** (Issue #468)
-
   - **BREAKING CHANGE**: BWR-ID format now strictly enforces 7-digit numeric range: `0000000` - `9999999`
   - Changed from `string(50)` to `string(7)` with regex validation: `/^[0-9]{7}$/`
   - String storage preserves leading zeros (e.g., "0012345") for legal compliance
@@ -748,7 +741,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ⚠️ **BewachV Employee Data Changes** (Issue #468) - Version 0.x.x allows breaking changes to avoid technical debt
 
 - **Address Structure Change**:
-
   - Old: Single `address_encrypted` field with free-text format
   - New: 7 structured fields (`address_street_enc`, `address_house_number_enc`, `address_postal_code_enc`, `address_city_enc`, `address_supplement_enc`, `address_country`, `address_state`)
   - Impact: API responses now include 7 separate address fields instead of 1
@@ -756,7 +748,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Code Changes Required: Update API clients to handle new address structure
 
 - **BWR-ID Validation Change**:
-
   - Old: `string(50)` with no format validation
   - New: Exactly 7 digits (`size:7`, `regex:/^[0-9]{7}$/`), unique constraint
   - Impact: Existing BWR-IDs with ≠7 digits will fail validation
@@ -764,7 +755,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Code Changes Required: Update any hardcoded BWR-ID test data to 7-digit format
 
 - **Sachkunde Expiry Removal**:
-
   - Old: `sachkunde_expiry` date field for tracking qualification expiry
   - New: No expiry field (Sachkunde valid for life)
   - Impact: `sachkunde_expiry` no longer exists in model/database/API
@@ -781,7 +771,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - **Enhanced Encryption for Personal Data** (Issue #468)
-
   - All new BewachV § 16 identity fields use `EncryptedWithDek` cast (encryption at rest)
   - Encrypted fields: `birth_name_enc`, `address_street_enc`, `address_house_number_enc`, `address_postal_code_enc`, `address_city_enc`, `address_supplement_enc`, `id_document_number_enc`
   - Blind indexes maintained for unique constraints (BWR-ID, email, etc.)
@@ -849,14 +838,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Legal Compliance
 
 - **BewachV § 16 Implementation** (Issue #468)
-
   - **Full Compliance**: All mandatory registration fields per BewachV § 16 Bewacherregister
   - Required fields: BWR-ID (7 digits), gender, structured address, nationality, identity documents, Sachkunde (if applicable)
   - Conditional validation: Gender + address required when `bwr_status` is 'pending' or 'active'
   - 5-year address history tracked per BewachV § 16 Abs. 2 Nr. 6
 
 - **BewachV § 21 Abs. 4 Retention** (Issue #468)
-
   - **Automated Retention**: Calculates 3-year retention from end of calendar year
   - Formula: `END_OF_YEAR(termination_date) + 3 years`
   - Auto-calculated via Observer on status change to 'terminated'
@@ -864,14 +851,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Future: Batch deletion queries will use `retention_period_end` for GDPR compliance
 
 - **BewachV § 34a Sachkunde** (Issue #468)
-
   - **Clarification**: Sachkunde qualification valid for life (no expiry per IHK)
   - Tracking: IHK number, exam date, issued date
   - Field removed: `sachkunde_expiry` (incorrect assumption)
   - Compliance: Accurate representation of German security guard qualification rules
 
 - **GDPR Art. 5(1)(e) Storage Limitation** (Issue #468)
-
   - **Auto-Deletion System**: ID document copies automatically deleted when BWR registration complete
   - Trigger: `bwr_status` change to 'active'
   - Action: Physical file deletion + `id_document_copy_deleted_at` timestamp
@@ -888,7 +873,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Documentation
 
 - **BewachV Compliance Documentation** (Issue #468)
-
   - Created `docs/BEWACHV_COMPLIANCE.md` (500+ lines)
   - Sections:
     - Legal Framework: BewachV §16/§21/§34a full text with translations
@@ -932,14 +916,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - **Deprecated Employee Address Fields** (Issue #468)
-
   - **BREAKING CHANGE**: Removed `address_encrypted` single-field storage
   - Replaced by 7 structured address fields: `address_street_enc`, `address_house_number_enc`, `address_postal_code_enc`, `address_city_enc`, `address_supplement_enc`, `address_country`, `address_state`
   - Migration provides backward compatibility via data extraction
   - Computed property `structured_address` provides comma-separated format for backward compatibility
 
 - **Sachkunde Expiry Field** (Issue #468)
-
   - **BREAKING CHANGE**: Removed `sachkunde_expiry` from Employee model
   - Sachkunde qualification never expires (valid for life per IHK)
   - Database column not created in new migrations
@@ -964,7 +946,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **BREAKING: User → Tenant Relationship** (Issue #358, Epic #357)
-
   - Added `users.tenant_id` foreign key to `tenant_keys` table (NOT NULL)
   - Migration includes 3-step process: add nullable column → backfill data → make NOT NULL
   - All existing users automatically assigned to first tenant (backward-compatible for single-tenant deployments)
@@ -977,7 +958,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `2025_12_18_193808_make_user_tenant_id_not_nullable.php`
 
 - **BREAKING: InjectTenantId Middleware - User-Based Resolution** (Issue #359, Epic #357)
-
   - Replaced hardcoded `TenantKey::oldest('id')` with user-based resolution: `$user->tenant_id`
   - Middleware now requires authenticated user (returns 401 for unauthenticated requests to tenant-scoped routes)
   - Security hardening: Client-provided `tenant_id` parameters (query string or request body) are **always removed**
@@ -986,7 +966,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Impact:** All API routes using `tenant.inject` middleware now require authentication and resolve tenant from user
 
 - **BREAKING: Registration/User Creation - Tenant Assignment** (Issue #360, Epic #357)
-
   - User registration now requires or auto-assigns `tenant_id`
   - If no `tenant_id` provided, defaults to first available tenant (MVP behavior)
   - Admin user creation validates that tenant_id matches admin's tenant (cannot create users in other tenants)
@@ -1015,7 +994,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Site CRUD API endpoints** (#314, Phase 4.2 of Epic #210, PR #356)
-
   - Implemented 6 RESTful endpoints for Site management:
     - `GET /v1/sites` - Paginated list with comprehensive filtering
       - Filters: customer_id, organizational_unit_id, type (permanent/temporary), is_active, currently_valid, search
@@ -1044,7 +1022,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Full integration with Customer & Assignment APIs
 
 - **Assignment API endpoints** (#315, Phase 4.3 of Epic #210, PR #363)
-
   - Customer Assignments: Flexible user-to-customer role assignments with tenant-specific terminology
     - `GET /v1/customers/{customer}/assignments` - List assignments for customer (filters: role, active_only)
     - `POST /v1/customers/{customer}/assignments` - Create assignment (prevents duplicates with 409)
@@ -1063,7 +1040,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Full SiteResource implementation replacing placeholder
 
 - **CostCenter API endpoints** (#316, Phase 4.4 of Epic #210, PR #368)
-
   - Implemented 5 RESTful endpoints for CostCenter management (nested under sites):
     - `GET /v1/sites/{site}/cost-centers` - List cost centers for site (filter: active_only)
     - `POST /v1/sites/{site}/cost-centers` - Create cost center
@@ -1111,7 +1087,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Employee Management RESTful API Endpoints** (#323, Phase 5 of Epic #211)
-
   - Implemented 5 REST controllers with 30+ endpoints for complete employee lifecycle management:
     - `EmployeeController`: 7 methods (index, store, show, update, destroy, activate, terminate)
       - GET /v1/employees: Paginated list with filters (status, organizational_unit_id, search)
@@ -1175,7 +1150,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - File upload/download functionality
 
 - **Employee Management Authorization Policies & Middleware** (#322, Phase 4 of Epic #211)
-
   - Implemented 6 authorization policies for employee management resources:
     - `EmployeePolicy`: Scope-based authorization for employee CRUD operations
       - Admin: Full access to all employees
@@ -1222,7 +1196,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Status-based operations (activate, terminate)
 
 - **Employee Management Database Schema** (#319, Phase 1 of Epic #211)
-
   - Created 6 new database tables for comprehensive employee management system:
     - `employees`: Core employee data with encrypted personal information (TenantKey)
     - `qualifications`: System-wide and tenant-specific qualifications (14 predefined)
@@ -1257,7 +1230,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Comprehensive indexes and foreign keys for optimal query performance
 
 - **Organizational Unit Hierarchy Validation** (#301, Part of Epic #283)
-
   - Added backend validation to enforce organizational hierarchy rules
   - Hierarchy ranking: Holding(1) → Company(2) → Region(3) → Branch(4) → Division(5) → Department(6) → Custom(7)
   - Child units must be **lower** in the hierarchy than their parent (child rank > parent rank)
@@ -1278,7 +1250,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Employee Creation Encryption Issue** (#323, resolves #339)
-
   - Fixed NULL constraint violation on encrypted fields (`first_name_enc`, `last_name_enc`) during employee creation
   - Root cause: `$fillable` array only contained `_enc` field names, preventing plaintext mutators from triggering
   - Solution: Added plaintext field names (`first_name`, `last_name`, `date_of_birth`, `address`, `hourly_rate`, `tax_id`, `social_security_number`) to `$fillable` array in Employee model
@@ -1286,19 +1257,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - All 30 EmployeeControllerTest tests now pass (previously 9/30 failing on creation)
 
 - **Newly Created Root Unit Not Visible** (#299, Part of Epic #283)
-
   - Root organizational units created without a parent were not visible to the creator
   - Creator now automatically receives `manage` scope with `include_descendants=true` on new root units
   - Child units continue to inherit access from parent's scope settings
   - Added 3 new tests covering auto-scope assignment and visibility
 
 - **Organizational Unit Eager Loading** (#282, Part of Epic #280)
-
   - Added missing `parent()` relation to `OrganizationalUnit` model for eager loading support
   - Fixes N+1 query issues when loading organizational units with parent relationships
 
 - **PWA Session Restoration After Long Inactivity** (#271)
-
   - Added `RestoreSessionFromRememberToken` middleware to restore sessions from remember token
   - Fixes 401 logout when accessing protected endpoints after hours of inactivity
   - Laravel's remember token functionality only works with SessionGuard on web routes,
@@ -1308,7 +1276,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added tests verifying middleware registration and behavior
 
 - **PWA Session Expiry Handling** (#270)
-
   - SPA login now uses `remember: true` for long-lived sessions (PWA requirement)
   - Users stay logged in until explicit logout instead of 120-minute session timeout
   - Works via Laravel's remember_token cookie for automatic session extension
@@ -1323,7 +1290,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Deployment Documentation** (#245)
-
   - `docs/deployment.md`: Complete production deployment guide with prerequisites, environment setup, KEK generation, database setup, tenant key initialization, health checks, and troubleshooting
   - `docs/deployment-checklist.md`: Quick reference checklist for deployment operators with step-by-step verification
   - `docs/deployment-uberspace.md`: Uberspace shared hosting specific deployment guide with platform-specific commands and service configuration
@@ -1331,7 +1297,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Part of Epic: Application Setup & Health Check System (SecPal/api#241)
 
 - **Tenant Key Setup Command** (#244)
-
   - `php artisan tenant:setup` command for guided tenant key initialization during new deployments
   - Interactive validation of KEK file existence and secure permissions (0600)
   - Idempotent design prevents duplicate tenant key creation
@@ -1340,7 +1305,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Part of Epic: Application Setup & Health Check System (SecPal/api#241)
 
 - **Setup Validation Command** (#243)
-
   - `php artisan app:validate-setup` command for deployment readiness checks
   - Validates database connectivity, tenant keys, KEK file, storage permissions, and PHP extensions
   - Colored console output with ✅/❌ indicators and actionable error messages
@@ -1348,14 +1312,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Part of Epic: Application Setup & Health Check System (SecPal/api#241)
 
 - **Health Check Endpoints** (#242)
-
   - `/health/live` endpoint for liveness probes (minimal process check)
   - `/health/ready` endpoint for readiness probes (database, tenant keys, KEK file)
   - Kubernetes-compatible response format with 200 OK (ready) or 503 Service Unavailable (not ready)
   - Part of Epic: Application Setup & Health Check System (SecPal/api#241)
 
 - **Production Deployment Guide** (#219)
-
   - Complete production deployment checklist with security requirements
   - Nginx and Apache configuration examples with TLS/SSL
   - Rate limiting configuration for login and API endpoints
@@ -1367,7 +1329,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Part of Epic: httpOnly Cookie Authentication Migration (SecPal/api#217)
 
 - **Integration Tests for Sanctum Authentication** (#219)
-
   - 8 comprehensive integration tests in `tests/Feature/Auth/SanctumIntegrationTest.php`
   - CORS credentials and preflight request testing
   - Session performance and concurrent device tests
@@ -1376,7 +1337,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Part of Epic: httpOnly Cookie Authentication Migration (SecPal/api#217)
 
 - **Sanctum SPA Authentication Guide** (#218)
-
   - Comprehensive documentation for httpOnly cookie authentication
   - Architecture diagrams and authentication flow
   - Configuration guide for both development and production
@@ -1387,7 +1347,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Part of Epic: httpOnly Cookie Authentication Migration (SecPal/api#217, SecPal/frontend#205)
 
 - **httpOnly Cookie Authentication Tests & Documentation** (#208)
-
   - Comprehensive test suite in `tests/Feature/Auth/SanctumCookieAuthTest.php`
   - 14 integration tests covering Sanctum authentication configuration
   - Tests verify session cookie configuration (httpOnly, secure, sameSite=lax)
@@ -1433,7 +1392,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **User Language Preference** (#86)
-
   - New `preferred_locale` column in `users` table (VARCHAR(5), nullable)
   - PATCH `/v1/me/language` endpoint to update user's preferred language
   - Supports `en` (English) and `de` (German)
@@ -1463,7 +1421,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Role Management CRUD API** (#108, Phase 4)
-
   - New endpoint: `GET /v1/roles` - List all roles with permission count and user count
   - New endpoint: `POST /v1/roles` - Create new role with permissions
   - New endpoint: `GET /v1/roles/{id}` - Get role details with assigned permissions
@@ -1477,7 +1434,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Part of RBAC Phase 4 Epic (#108), completes role management capabilities
 
 - **Predefined Roles Seeder** (#108, Phase 4)
-
   - New seeder: `RolesAndPermissionsSeeder` - Creates 5 predefined roles with permissions
   - Predefined roles: Admin, Manager, Guard, Client, Works Council
   - Idempotent design: Safe to run multiple times, uses `firstOrCreate`
@@ -1488,7 +1444,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Part of RBAC Phase 4 Epic (#108), provides production-ready role foundation
 
 - **RBAC Documentation** (#108, Phase 4)
-
   - New guide: `docs/guides/role-management.md` - How to create/manage roles (872 lines)
   - New guide: `docs/guides/permission-system.md` - Permission naming conventions and organization (716 lines)
   - New guide: `docs/guides/temporal-roles.md` - Temporal role assignment patterns
@@ -1500,7 +1455,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Part of RBAC Phase 4 Epic (#108), completes RBAC documentation requirements
 
 - **User Direct Permission Assignment API** (#138)
-
   - New endpoint: `GET /v1/users/{user}/permissions` - List all user permissions (direct + inherited from roles)
   - New endpoint: `POST /v1/users/{user}/permissions` - Assign direct permission(s) to user with temporal tracking (audit trail)
   - New endpoint: `DELETE /v1/users/{user}/permissions/{permission}` - Revoke direct permission from user
@@ -1513,7 +1467,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Part of RBAC Phase 4 Epic (#108), enables fine-grained permission control bypassing roles
 
 - **Permission Management CRUD API** (#137)
-
   - New endpoint: `GET /v1/permissions` - List all permissions grouped by resource
   - New endpoint: `POST /v1/permissions` - Create new permission with strict naming validation (resource.action)
   - New endpoint: `GET /v1/permissions/{id}` - Get permission details with assigned roles
@@ -1526,7 +1479,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Part of RBAC Phase 4 Epic (#108), enables Issue #138 (User Direct Permission Assignment)
 
 - **RBAC Architecture Documentation** (#143)
-
   - New file: `docs/rbac-architecture.md` - Central RBAC system documentation
   - System architecture: High-level component diagrams (Users → Roles → Permissions + Direct Permissions)
   - Core concepts: Roles, Permissions, Direct Permissions, Temporal Assignments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- removed the retired standalone changelog host from repository domain policy
+  and AI-instruction guidance
 - changed local and hosted pull-request size reporting to treat 600 changed
   lines as an advisory reviewability threshold, with no override file, approval
   label, or size-triggered push failure
@@ -513,6 +515,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Onboarding Completion Detection System** (Issue #498, Epic #469)
+
   - **IMPLEMENTED** Automatic detection and tracking of onboarding completion
   - **`OnboardingCompletionService`**: Service class for completion logic
     - `checkCompletion(Employee)`: Detects when all required templates approved, auto-updates `employee.onboarding_completed` and `employee.onboarding_completed_at`
@@ -529,6 +532,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Tests**: 29 comprehensive Pest tests (18 unit + 11 feature) covering all edge cases
 
 - **Standard Onboarding Form Templates Seeder** (Issue #497, Epic #469)
+
   - **IMPLEMENTED** 4 pre-configured onboarding form templates (system-wide)
   - **Templates Created**:
     1. **Personal Information Form** (Required): BewachV § 16 required fields (gender, nationalities, intended activities)
@@ -546,6 +550,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Tests**: 20+ comprehensive Pest tests validating structure, validation rules, and data integrity
 
 - **Magic Link Employee Onboarding System** (Issue #486, Epic #469)
+
   - **IMPLEMENTED** Secure single-use tokens for pre-contract employee onboarding
   - **`employee_onboarding_tokens` Table**: UUID primary key, bcrypt-hashed tokens, 7-day expiry, single-use enforcement, audit trail (IP, user agent)
   - **`EmployeeOnboardingToken` Model**:
@@ -573,6 +578,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Tests**: 16 unit tests (all passing), 7 feature tests (E2E flow validated, 2 pending User accounts)
 
 - **BewachV § 16 Employee Data Fields for BWR Registration** (Issue #468, Epic #469)
+
   - **IMPLEMENTED** Complete BewachV compliance for Bewacherregister (BWR) employee data management
   - **30+ New Fields** across 7 categories:
     - **BWR Tracking**: `bwr_id` (7-digit unique ID), `bwr_status` (5-state enum), `bwr_registered_at`, `bwr_submission_date`, `bwr_notes`
@@ -625,6 +631,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Impact**: Foundation for Issues #471 (BWR Workflow Export), #470 (Automated Data Deletion), #472 (Work Permit Tracking)
 
 - **Activity Log REST API with Scoped Filtering** (Issue #394, Epic #385)
+
   - **IMPLEMENTED** ActivityLogController with 3 RESTful endpoints for activity log access
   - Endpoints:
     - `GET /v1/activity-logs` - Paginated listing with comprehensive filtering
@@ -660,6 +667,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Impact:** Completes Epic #385 Phase 6, unblocks Issue #395 (Frontend Activity Log Viewer), enables BewachV § 21 Abs. 4 compliance
 
 - **ActivityPolicy with Leadership Level Filtering** (Issue #396, Epic #385)
+
   - **IMPLEMENTED** authorization policy for hierarchical activity log access
   - Architecture:
     - `view()` method enforces tenant isolation + organizational scope + leadership filtering
@@ -722,6 +730,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **BWR-ID Format and Validation** (Issue #468)
+
   - **BREAKING CHANGE**: BWR-ID format now strictly enforces 7-digit numeric range: `0000000` - `9999999`
   - Changed from `string(50)` to `string(7)` with regex validation: `/^[0-9]{7}$/`
   - String storage preserves leading zeros (e.g., "0012345") for legal compliance
@@ -739,6 +748,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ⚠️ **BewachV Employee Data Changes** (Issue #468) - Version 0.x.x allows breaking changes to avoid technical debt
 
 - **Address Structure Change**:
+
   - Old: Single `address_encrypted` field with free-text format
   - New: 7 structured fields (`address_street_enc`, `address_house_number_enc`, `address_postal_code_enc`, `address_city_enc`, `address_supplement_enc`, `address_country`, `address_state`)
   - Impact: API responses now include 7 separate address fields instead of 1
@@ -746,6 +756,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Code Changes Required: Update API clients to handle new address structure
 
 - **BWR-ID Validation Change**:
+
   - Old: `string(50)` with no format validation
   - New: Exactly 7 digits (`size:7`, `regex:/^[0-9]{7}$/`), unique constraint
   - Impact: Existing BWR-IDs with ≠7 digits will fail validation
@@ -753,6 +764,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Code Changes Required: Update any hardcoded BWR-ID test data to 7-digit format
 
 - **Sachkunde Expiry Removal**:
+
   - Old: `sachkunde_expiry` date field for tracking qualification expiry
   - New: No expiry field (Sachkunde valid for life)
   - Impact: `sachkunde_expiry` no longer exists in model/database/API
@@ -769,6 +781,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - **Enhanced Encryption for Personal Data** (Issue #468)
+
   - All new BewachV § 16 identity fields use `EncryptedWithDek` cast (encryption at rest)
   - Encrypted fields: `birth_name_enc`, `address_street_enc`, `address_house_number_enc`, `address_postal_code_enc`, `address_city_enc`, `address_supplement_enc`, `id_document_number_enc`
   - Blind indexes maintained for unique constraints (BWR-ID, email, etc.)
@@ -836,12 +849,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Legal Compliance
 
 - **BewachV § 16 Implementation** (Issue #468)
+
   - **Full Compliance**: All mandatory registration fields per BewachV § 16 Bewacherregister
   - Required fields: BWR-ID (7 digits), gender, structured address, nationality, identity documents, Sachkunde (if applicable)
   - Conditional validation: Gender + address required when `bwr_status` is 'pending' or 'active'
   - 5-year address history tracked per BewachV § 16 Abs. 2 Nr. 6
 
 - **BewachV § 21 Abs. 4 Retention** (Issue #468)
+
   - **Automated Retention**: Calculates 3-year retention from end of calendar year
   - Formula: `END_OF_YEAR(termination_date) + 3 years`
   - Auto-calculated via Observer on status change to 'terminated'
@@ -849,12 +864,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Future: Batch deletion queries will use `retention_period_end` for GDPR compliance
 
 - **BewachV § 34a Sachkunde** (Issue #468)
+
   - **Clarification**: Sachkunde qualification valid for life (no expiry per IHK)
   - Tracking: IHK number, exam date, issued date
   - Field removed: `sachkunde_expiry` (incorrect assumption)
   - Compliance: Accurate representation of German security guard qualification rules
 
 - **GDPR Art. 5(1)(e) Storage Limitation** (Issue #468)
+
   - **Auto-Deletion System**: ID document copies automatically deleted when BWR registration complete
   - Trigger: `bwr_status` change to 'active'
   - Action: Physical file deletion + `id_document_copy_deleted_at` timestamp
@@ -871,6 +888,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Documentation
 
 - **BewachV Compliance Documentation** (Issue #468)
+
   - Created `docs/BEWACHV_COMPLIANCE.md` (500+ lines)
   - Sections:
     - Legal Framework: BewachV §16/§21/§34a full text with translations
@@ -914,12 +932,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - **Deprecated Employee Address Fields** (Issue #468)
+
   - **BREAKING CHANGE**: Removed `address_encrypted` single-field storage
   - Replaced by 7 structured address fields: `address_street_enc`, `address_house_number_enc`, `address_postal_code_enc`, `address_city_enc`, `address_supplement_enc`, `address_country`, `address_state`
   - Migration provides backward compatibility via data extraction
   - Computed property `structured_address` provides comma-separated format for backward compatibility
 
 - **Sachkunde Expiry Field** (Issue #468)
+
   - **BREAKING CHANGE**: Removed `sachkunde_expiry` from Employee model
   - Sachkunde qualification never expires (valid for life per IHK)
   - Database column not created in new migrations
@@ -944,6 +964,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **BREAKING: User → Tenant Relationship** (Issue #358, Epic #357)
+
   - Added `users.tenant_id` foreign key to `tenant_keys` table (NOT NULL)
   - Migration includes 3-step process: add nullable column → backfill data → make NOT NULL
   - All existing users automatically assigned to first tenant (backward-compatible for single-tenant deployments)
@@ -956,6 +977,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `2025_12_18_193808_make_user_tenant_id_not_nullable.php`
 
 - **BREAKING: InjectTenantId Middleware - User-Based Resolution** (Issue #359, Epic #357)
+
   - Replaced hardcoded `TenantKey::oldest('id')` with user-based resolution: `$user->tenant_id`
   - Middleware now requires authenticated user (returns 401 for unauthenticated requests to tenant-scoped routes)
   - Security hardening: Client-provided `tenant_id` parameters (query string or request body) are **always removed**
@@ -964,6 +986,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Impact:** All API routes using `tenant.inject` middleware now require authentication and resolve tenant from user
 
 - **BREAKING: Registration/User Creation - Tenant Assignment** (Issue #360, Epic #357)
+
   - User registration now requires or auto-assigns `tenant_id`
   - If no `tenant_id` provided, defaults to first available tenant (MVP behavior)
   - Admin user creation validates that tenant_id matches admin's tenant (cannot create users in other tenants)
@@ -992,6 +1015,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Site CRUD API endpoints** (#314, Phase 4.2 of Epic #210, PR #356)
+
   - Implemented 6 RESTful endpoints for Site management:
     - `GET /v1/sites` - Paginated list with comprehensive filtering
       - Filters: customer_id, organizational_unit_id, type (permanent/temporary), is_active, currently_valid, search
@@ -1020,6 +1044,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Full integration with Customer & Assignment APIs
 
 - **Assignment API endpoints** (#315, Phase 4.3 of Epic #210, PR #363)
+
   - Customer Assignments: Flexible user-to-customer role assignments with tenant-specific terminology
     - `GET /v1/customers/{customer}/assignments` - List assignments for customer (filters: role, active_only)
     - `POST /v1/customers/{customer}/assignments` - Create assignment (prevents duplicates with 409)
@@ -1038,6 +1063,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Full SiteResource implementation replacing placeholder
 
 - **CostCenter API endpoints** (#316, Phase 4.4 of Epic #210, PR #368)
+
   - Implemented 5 RESTful endpoints for CostCenter management (nested under sites):
     - `GET /v1/sites/{site}/cost-centers` - List cost centers for site (filter: active_only)
     - `POST /v1/sites/{site}/cost-centers` - Create cost center
@@ -1085,6 +1111,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Employee Management RESTful API Endpoints** (#323, Phase 5 of Epic #211)
+
   - Implemented 5 REST controllers with 30+ endpoints for complete employee lifecycle management:
     - `EmployeeController`: 7 methods (index, store, show, update, destroy, activate, terminate)
       - GET /v1/employees: Paginated list with filters (status, organizational_unit_id, search)
@@ -1148,6 +1175,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - File upload/download functionality
 
 - **Employee Management Authorization Policies & Middleware** (#322, Phase 4 of Epic #211)
+
   - Implemented 6 authorization policies for employee management resources:
     - `EmployeePolicy`: Scope-based authorization for employee CRUD operations
       - Admin: Full access to all employees
@@ -1194,6 +1222,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Status-based operations (activate, terminate)
 
 - **Employee Management Database Schema** (#319, Phase 1 of Epic #211)
+
   - Created 6 new database tables for comprehensive employee management system:
     - `employees`: Core employee data with encrypted personal information (TenantKey)
     - `qualifications`: System-wide and tenant-specific qualifications (14 predefined)
@@ -1228,6 +1257,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Comprehensive indexes and foreign keys for optimal query performance
 
 - **Organizational Unit Hierarchy Validation** (#301, Part of Epic #283)
+
   - Added backend validation to enforce organizational hierarchy rules
   - Hierarchy ranking: Holding(1) → Company(2) → Region(3) → Branch(4) → Division(5) → Department(6) → Custom(7)
   - Child units must be **lower** in the hierarchy than their parent (child rank > parent rank)
@@ -1248,6 +1278,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Employee Creation Encryption Issue** (#323, resolves #339)
+
   - Fixed NULL constraint violation on encrypted fields (`first_name_enc`, `last_name_enc`) during employee creation
   - Root cause: `$fillable` array only contained `_enc` field names, preventing plaintext mutators from triggering
   - Solution: Added plaintext field names (`first_name`, `last_name`, `date_of_birth`, `address`, `hourly_rate`, `tax_id`, `social_security_number`) to `$fillable` array in Employee model
@@ -1255,16 +1286,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - All 30 EmployeeControllerTest tests now pass (previously 9/30 failing on creation)
 
 - **Newly Created Root Unit Not Visible** (#299, Part of Epic #283)
+
   - Root organizational units created without a parent were not visible to the creator
   - Creator now automatically receives `manage` scope with `include_descendants=true` on new root units
   - Child units continue to inherit access from parent's scope settings
   - Added 3 new tests covering auto-scope assignment and visibility
 
 - **Organizational Unit Eager Loading** (#282, Part of Epic #280)
+
   - Added missing `parent()` relation to `OrganizationalUnit` model for eager loading support
   - Fixes N+1 query issues when loading organizational units with parent relationships
 
 - **PWA Session Restoration After Long Inactivity** (#271)
+
   - Added `RestoreSessionFromRememberToken` middleware to restore sessions from remember token
   - Fixes 401 logout when accessing protected endpoints after hours of inactivity
   - Laravel's remember token functionality only works with SessionGuard on web routes,
@@ -1274,6 +1308,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added tests verifying middleware registration and behavior
 
 - **PWA Session Expiry Handling** (#270)
+
   - SPA login now uses `remember: true` for long-lived sessions (PWA requirement)
   - Users stay logged in until explicit logout instead of 120-minute session timeout
   - Works via Laravel's remember_token cookie for automatic session extension
@@ -1288,6 +1323,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Deployment Documentation** (#245)
+
   - `docs/deployment.md`: Complete production deployment guide with prerequisites, environment setup, KEK generation, database setup, tenant key initialization, health checks, and troubleshooting
   - `docs/deployment-checklist.md`: Quick reference checklist for deployment operators with step-by-step verification
   - `docs/deployment-uberspace.md`: Uberspace shared hosting specific deployment guide with platform-specific commands and service configuration
@@ -1295,6 +1331,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Part of Epic: Application Setup & Health Check System (SecPal/api#241)
 
 - **Tenant Key Setup Command** (#244)
+
   - `php artisan tenant:setup` command for guided tenant key initialization during new deployments
   - Interactive validation of KEK file existence and secure permissions (0600)
   - Idempotent design prevents duplicate tenant key creation
@@ -1303,6 +1340,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Part of Epic: Application Setup & Health Check System (SecPal/api#241)
 
 - **Setup Validation Command** (#243)
+
   - `php artisan app:validate-setup` command for deployment readiness checks
   - Validates database connectivity, tenant keys, KEK file, storage permissions, and PHP extensions
   - Colored console output with ✅/❌ indicators and actionable error messages
@@ -1310,12 +1348,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Part of Epic: Application Setup & Health Check System (SecPal/api#241)
 
 - **Health Check Endpoints** (#242)
+
   - `/health/live` endpoint for liveness probes (minimal process check)
   - `/health/ready` endpoint for readiness probes (database, tenant keys, KEK file)
   - Kubernetes-compatible response format with 200 OK (ready) or 503 Service Unavailable (not ready)
   - Part of Epic: Application Setup & Health Check System (SecPal/api#241)
 
 - **Production Deployment Guide** (#219)
+
   - Complete production deployment checklist with security requirements
   - Nginx and Apache configuration examples with TLS/SSL
   - Rate limiting configuration for login and API endpoints
@@ -1327,6 +1367,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Part of Epic: httpOnly Cookie Authentication Migration (SecPal/api#217)
 
 - **Integration Tests for Sanctum Authentication** (#219)
+
   - 8 comprehensive integration tests in `tests/Feature/Auth/SanctumIntegrationTest.php`
   - CORS credentials and preflight request testing
   - Session performance and concurrent device tests
@@ -1335,6 +1376,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Part of Epic: httpOnly Cookie Authentication Migration (SecPal/api#217)
 
 - **Sanctum SPA Authentication Guide** (#218)
+
   - Comprehensive documentation for httpOnly cookie authentication
   - Architecture diagrams and authentication flow
   - Configuration guide for both development and production
@@ -1345,6 +1387,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Part of Epic: httpOnly Cookie Authentication Migration (SecPal/api#217, SecPal/frontend#205)
 
 - **httpOnly Cookie Authentication Tests & Documentation** (#208)
+
   - Comprehensive test suite in `tests/Feature/Auth/SanctumCookieAuthTest.php`
   - 14 integration tests covering Sanctum authentication configuration
   - Tests verify session cookie configuration (httpOnly, secure, sameSite=lax)
@@ -1390,6 +1433,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **User Language Preference** (#86)
+
   - New `preferred_locale` column in `users` table (VARCHAR(5), nullable)
   - PATCH `/v1/me/language` endpoint to update user's preferred language
   - Supports `en` (English) and `de` (German)
@@ -1419,6 +1463,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Role Management CRUD API** (#108, Phase 4)
+
   - New endpoint: `GET /v1/roles` - List all roles with permission count and user count
   - New endpoint: `POST /v1/roles` - Create new role with permissions
   - New endpoint: `GET /v1/roles/{id}` - Get role details with assigned permissions
@@ -1432,6 +1477,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Part of RBAC Phase 4 Epic (#108), completes role management capabilities
 
 - **Predefined Roles Seeder** (#108, Phase 4)
+
   - New seeder: `RolesAndPermissionsSeeder` - Creates 5 predefined roles with permissions
   - Predefined roles: Admin, Manager, Guard, Client, Works Council
   - Idempotent design: Safe to run multiple times, uses `firstOrCreate`
@@ -1442,6 +1488,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Part of RBAC Phase 4 Epic (#108), provides production-ready role foundation
 
 - **RBAC Documentation** (#108, Phase 4)
+
   - New guide: `docs/guides/role-management.md` - How to create/manage roles (872 lines)
   - New guide: `docs/guides/permission-system.md` - Permission naming conventions and organization (716 lines)
   - New guide: `docs/guides/temporal-roles.md` - Temporal role assignment patterns
@@ -1453,6 +1500,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Part of RBAC Phase 4 Epic (#108), completes RBAC documentation requirements
 
 - **User Direct Permission Assignment API** (#138)
+
   - New endpoint: `GET /v1/users/{user}/permissions` - List all user permissions (direct + inherited from roles)
   - New endpoint: `POST /v1/users/{user}/permissions` - Assign direct permission(s) to user with temporal tracking (audit trail)
   - New endpoint: `DELETE /v1/users/{user}/permissions/{permission}` - Revoke direct permission from user
@@ -1465,6 +1513,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Part of RBAC Phase 4 Epic (#108), enables fine-grained permission control bypassing roles
 
 - **Permission Management CRUD API** (#137)
+
   - New endpoint: `GET /v1/permissions` - List all permissions grouped by resource
   - New endpoint: `POST /v1/permissions` - Create new permission with strict naming validation (resource.action)
   - New endpoint: `GET /v1/permissions/{id}` - Get permission details with assigned roles
@@ -1477,6 +1526,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Part of RBAC Phase 4 Epic (#108), enables Issue #138 (User Direct Permission Assignment)
 
 - **RBAC Architecture Documentation** (#143)
+
   - New file: `docs/rbac-architecture.md` - Central RBAC system documentation
   - System architecture: High-level component diagrams (Users → Roles → Permissions + Direct Permissions)
   - Core concepts: Roles, Permissions, Direct Permissions, Temporal Assignments

--- a/scripts/check-domains.sh
+++ b/scripts/check-domains.sh
@@ -16,10 +16,9 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 echo -e "${BLUE}=== Domain Policy Check ===${NC}"
-echo "Allowed: secpal.app, changelog.secpal.app, apk.secpal.app, secpal.dev"
+echo "Allowed: secpal.app, apk.secpal.app, secpal.dev"
 echo "Active web hosts: api.secpal.dev, app.secpal.dev"
 echo "Android artifact host: apk.secpal.app"
-echo "Changelog site: changelog.secpal.app"
 echo "Identifier-only: app.secpal (Android application ID)"
 echo "Deprecated web hosts: api.secpal.app"
 echo "Forbidden: secpal.com, secpal.org, secpal.net, secpal.io, secpal.example, ANY other"
@@ -53,7 +52,7 @@ matches=$(grep -r -n -E "secpal\.[A-Za-z0-9.-]+" \
 # api.secpal.app (reported separately below).
 # This catches unknown domains (e.g. secpal.xyz) that a denylist-only check would miss.
 violations=$(printf '%s\n' "$matches" | \
-    grep -Ev '(^|[^A-Za-z0-9.-])secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])changelog\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])apk\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])(\*\.|\.)?([A-Za-z0-9-]+\.)*secpal\.dev(\.[A-Za-z0-9_-]+)*($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])api\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)' | \
+    grep -Ev '(^|[^A-Za-z0-9.-])secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])apk\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])(\*\.|\.)?([A-Za-z0-9-]+\.)*secpal\.dev(\.[A-Za-z0-9_-]+)*($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])api\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)' | \
     grep -v -- '.evil.example' | \
     grep -E 'secpal\.' || true)
 
@@ -104,7 +103,6 @@ else
     fi
     echo -e "${YELLOW}Policy:${NC}"
     echo "  - secpal.app: public homepage and real email addresses"
-    echo "  - changelog.secpal.app: public changelog site"
     echo "  - apk.secpal.app: canonical Android artifact and release-metadata host"
     echo "  - api.secpal.dev: live API host"
     echo "  - app.secpal.dev: live PWA/frontend host"

--- a/scripts/check-domains.sh
+++ b/scripts/check-domains.sh
@@ -51,10 +51,16 @@ matches=$(grep -r -n -E "secpal\.[A-Za-z0-9.-]+" \
 # secpal.dev (including api/app subdomains), and deprecated-but-allowed
 # api.secpal.app (reported separately below).
 # This catches unknown domains (e.g. secpal.xyz) that a denylist-only check would miss.
-violations=$(printf '%s\n' "$matches" | \
+retired_changelog_hosts=$(printf '%s\n' "$matches" | \
+    grep -E '(^|[^A-Za-z0-9.-])changelog\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)' || true)
+
+other_violations=$(printf '%s\n' "$matches" | \
     grep -Ev '(^|[^A-Za-z0-9.-])secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])apk\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])(\*\.|\.)?([A-Za-z0-9-]+\.)*secpal\.dev(\.[A-Za-z0-9_-]+)*($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)|(^|[^A-Za-z0-9.-])api\.secpal\.app($|[^A-Za-z0-9._-]|\.[^A-Za-z0-9_-]|\.$)' | \
     grep -v -- '.evil.example' | \
     grep -E 'secpal\.' || true)
+
+violations=$(printf '%s\n%s\n' "$retired_changelog_hosts" "$other_violations" | \
+    awk 'NF && !seen[$0]++')
 
 deprecated_web_hosts=$(printf '%s\n' "$matches" | \
     grep -E 'api\.secpal\.app' | \

--- a/tests/Unit/DomainPolicyCheckScriptTest.php
+++ b/tests/Unit/DomainPolicyCheckScriptTest.php
@@ -74,6 +74,22 @@ test('domain policy check rejects the retired standalone changelog host', functi
     }
 });
 
+test('domain policy check rejects the retired host when an allowed host shares its line', function (): void {
+    $root = makeDomainPolicyCheckFixture();
+
+    try {
+        $host = retiredChangelogHost();
+        file_put_contents($root.'/README.md', 'https://secpal.app https://'.$host.'/releases');
+
+        $result = runDomainPolicyCheck($root);
+
+        expect($result['exit_code'])->toBe(1)
+            ->and($result['stdout'])->toContain($host);
+    } finally {
+        File::deleteDirectory($root);
+    }
+});
+
 test('domain policy check allows active SecPal hosts', function (): void {
     $root = makeDomainPolicyCheckFixture();
 

--- a/tests/Unit/DomainPolicyCheckScriptTest.php
+++ b/tests/Unit/DomainPolicyCheckScriptTest.php
@@ -1,0 +1,90 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+
+function makeDomainPolicyCheckFixture(): string
+{
+    $root = sys_get_temp_dir().'/secpal-domain-policy-check-'.Str::uuid();
+
+    mkdir($root, 0777, true);
+
+    return $root;
+}
+
+function retiredChangelogHost(): string
+{
+    return 'changelog.'.'sec'.'pal.app';
+}
+
+function runDomainPolicyCheck(string $root): array
+{
+    if (! function_exists('proc_open')) {
+        test()->markTestSkipped('proc_open is required for domain policy check coverage.');
+    }
+
+    $process = proc_open(
+        ['bash', base_path('scripts/check-domains.sh')],
+        [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ],
+        $pipes,
+        $root,
+        ['LC_ALL' => 'C'],
+    );
+
+    expect($process)->toBeResource();
+
+    fclose($pipes[0]);
+
+    $stdout = stream_get_contents($pipes[1]);
+    $stderr = stream_get_contents($pipes[2]);
+
+    fclose($pipes[1]);
+    fclose($pipes[2]);
+
+    return [
+        'exit_code' => proc_close($process),
+        'stdout' => $stdout,
+        'stderr' => $stderr,
+    ];
+}
+
+test('domain policy check rejects the retired standalone changelog host', function (): void {
+    $root = makeDomainPolicyCheckFixture();
+
+    try {
+        $host = retiredChangelogHost();
+        file_put_contents($root.'/README.md', 'https://'.$host.'/releases');
+
+        $result = runDomainPolicyCheck($root);
+
+        expect($result['exit_code'])->toBe(1)
+            ->and($result['stdout'])->toContain('Domain Policy Check FAILED')
+            ->and($result['stdout'])->toContain($host);
+    } finally {
+        File::deleteDirectory($root);
+    }
+});
+
+test('domain policy check allows active SecPal hosts', function (): void {
+    $root = makeDomainPolicyCheckFixture();
+
+    try {
+        file_put_contents($root.'/README.md', 'https://api.secpal.dev/health');
+
+        $result = runDomainPolicyCheck($root);
+
+        expect($result['exit_code'])->toBe(0)
+            ->and($result['stdout'])->toContain('Domain Policy Check PASSED');
+    } finally {
+        File::deleteDirectory($root);
+    }
+});


### PR DESCRIPTION
## Summary

- remove the retired standalone changelog host from API repository domain policy
- remove the obsolete host from repository AI guidance
- document the policy cleanup in the unreleased changelog

## Why

The standalone changelog site has been permanently retired, so it must no longer appear as a special domain-policy exception.

## Validation

- `bash scripts/check-domains.sh`
- `reuse lint`
- repository pre-commit hooks
- repository pre-push preflight, including Prettier, PHPStan, and Pint
