### PR TITLE
chore: align Markdown baseline with Prettier

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -118,20 +118,24 @@ All PRs automatically run:
 ### Secure Development Guidelines
 
 1. **Never commit secrets:**
+
    - Use environment variables (`.env`)
    - Utilize secret management services
    - Enable push protection (automatically enabled)
 
 2. **Keep dependencies updated:**
+
    - Dependabot creates PRs daily (04:00 CET)
    - Security updates have priority
    - Review and merge promptly
 
 3. **Follow OWASP Top 10:**
+
    - [OWASP Top Ten](https://owasp.org/www-project-top-ten/)
    - Regular security training encouraged
 
 4. **Validate all inputs:**
+
    - Server-side validation (never trust client)
    - Sanitize outputs to prevent XSS
    - Use framework's built-in protection (Laravel, React)

--- a/docs/BEWACHV_COMPLIANCE.md
+++ b/docs/BEWACHV_COMPLIANCE.md
@@ -745,18 +745,21 @@ if ($employee->retention_period_end < now()) {
 For production deployment, verify:
 
 1. **Database**
+
    - [ ] All 30+ BewachV fields present in `employees` table
    - [ ] Indexes created: `bwr_status`, `retention_period_end`, `bwr_registered_at`
    - [ ] Enum constraint on `bwr_status` allows only 5 valid values
    - [ ] `sachkunde_expiry` column does NOT exist
 
 2. **Observer Logic**
+
    - [ ] Create employee with ID document → Change bwr_status to 'active' → File deleted
    - [ ] Activity log contains "ID document copy automatically deleted (BWR active)"
    - [ ] Terminate employee → `retention_period_end` auto-calculated correctly
    - [ ] Activity log contains "Retention period calculated (BewachV §21..."
 
 3. **Validation**
+
    - [ ] BWR-ID with 6 digits rejected
    - [ ] BWR-ID with letters rejected
    - [ ] Duplicate BWR-ID rejected
@@ -765,6 +768,7 @@ For production deployment, verify:
    - [ ] Address fields required when bwr_status = 'pending' or 'active'
 
 4. **API Response**
+
    - [ ] `/api/employees/{id}` includes all BewachV fields
    - [ ] `structured_address` computed property present
    - [ ] Encrypted field names (\_enc suffix) NOT exposed

--- a/docs/guides/multi-tenant-deployment.md
+++ b/docs/guides/multi-tenant-deployment.md
@@ -748,11 +748,13 @@ Before going live:
 After successful multi-tenant deployment:
 
 1. **Phase 2 Enhancements (Optional):**
+
    - Subdomain-based tenant resolution (`tenant1.secpal.dev`)
    - Tenant management API (CRUD, usage stats)
    - Multi-tenant user access (consultant scenario)
 
 2. **Operational Excellence:**
+
    - Tenant-aware monitoring dashboards
    - Automated tenant provisioning pipeline
    - Data export/migration tools (GDPR)

--- a/docs/guides/sanctum-spa-auth.md
+++ b/docs/guides/sanctum-spa-auth.md
@@ -501,18 +501,22 @@ curl -b cookies.txt \
 ### Checklist
 
 - [ ] **HTTPS Enabled**
+
   - `SESSION_SECURE_COOKIE=true`
   - `APP_URL=https://api.secpal.dev`
 
 - [ ] **Domain Configuration**
+
   - `SESSION_DOMAIN=.secpal.dev` (for subdomains)
   - `SANCTUM_STATEFUL_DOMAINS=app.secpal.dev`
 
 - [ ] **CORS Configuration**
+
   - `CORS_ALLOWED_ORIGINS=https://app.secpal.dev`
   - `CORS_SUPPORTS_CREDENTIALS=true`
 
 - [ ] **Session Security**
+
   - `SESSION_DRIVER=database` (or redis for scale)
   - `SESSION_LIFETIME=120` (or as required)
   - `SESSION_ENCRYPT=true` (encrypt the stored session payload)


### PR DESCRIPTION
## Summary

Updates the committed Markdown baseline to match the repository's configured Prettier output.

Closes #1382.

## Problem and evidence

Running `pre-commit run --all-files` on the committed baseline caused the Prettier hook to rewrite nested-list spacing in `SECURITY.md`, `docs/BEWACHV_COMPLIANCE.md`, `docs/guides/multi-tenant-deployment.md`, and `docs/guides/sanctum-spa-auth.md`. Because the hook modified tracked files, it exited non-zero and prevented clean repository-wide validation.

## Change

Applies the required blank-line spacing before nested list content in the four affected Markdown files. No document content or application behavior changes.

## Validation

- `pre-commit run --all-files`
- `git diff --check`
- Push preflight: Prettier, REUSE, domain-policy check, Pint, and PHPStan

## Readiness

There are no in-scope dependencies or unresolved checks. The final self-review found no issues; this PR remains a draft as requested.
