### PR TITLE
fix: isolate container policy tests from PostgreSQL

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -15,8 +15,13 @@ on:
       - "tests/docker/**"
       - "tests/container/**"
       - "tests/fixtures/**"
-      - "tests/Unit/ContainerPublishingWorkflowTest.php"
-      - "composer.*"
+      - "tests/Policy/**"
+      - "tests/Feature/Console/ScheduleListWithoutDatabaseTest.php"
+      - "tests/Regression/ContainerPolicyIsolationTest.php"
+      - "composer.json"
+      - "composer.lock"
+      - "phpunit.xml"
+      - "tests/Pest.php"
       - "app/**"
       - "bootstrap/**"
       - "config/**"
@@ -46,6 +51,20 @@ jobs:
       - name: Checkout repository
         # v7.0.1
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - name: Set up PHP
+        # 2.37.2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240
+        with:
+          php-version: "8.4"
+          coverage: none
+          tools: composer:2.10.2
+
+      - name: Install PHP dependencies
+        run: composer install --no-interaction --no-progress --prefer-dist
+
+      - name: Run database-free container policy tests
+        run: composer test:container-policy
+
       - name: Lint Dockerfile
         run: >-
           docker run --rm -i

--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -67,9 +67,6 @@ jobs:
       - name: Test GHCR index promotion contract
         run: tests/container/promote-ghcr-index-contract.sh
 
-      - name: Build and test the API image
-        run: tests/docker/smoke.sh
-
   publish:
     name: Publish API Image
     needs: validate

--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -45,8 +45,8 @@ jobs:
       - name: Install PHP dependencies
         run: composer install --no-interaction --no-progress --prefer-dist
 
-      - name: Run container policy tests
-        run: php artisan test tests/Unit/ContainerImageDefinitionTest.php tests/Unit/ContainerPublishingWorkflowTest.php
+      - name: Run database-free container policy tests
+        run: composer test:container-policy
 
       - name: Lint Dockerfile
         run: >-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- isolated the publisher's static container policy suite from Laravel's
+  PostgreSQL-backed test case and made pull-request container validation run
+  the same database-free policy command before any post-merge registry write
 - removed the retired standalone changelog host from repository domain policy
   and AI-instruction guidance
 - changed local and hosted pull-request size reporting to treat 600 changed

--- a/composer.json
+++ b/composer.json
@@ -66,6 +66,9 @@
       "@php artisan test --parallel --exclude-group=serial",
       "@php artisan test --group=serial"
     ],
+    "test:container-policy": [
+      "pest --no-coverage tests/Policy/ContainerImageDefinitionTest.php tests/Policy/ContainerPublishingWorkflowTest.php"
+    ],
     "analyse": "@php -d memory_limit=512M ./vendor/bin/phpstan analyse",
     "post-autoload-dump": [
       "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",

--- a/composer.json.license
+++ b/composer.json.license
@@ -1,3 +1,3 @@
-SPDX-FileCopyrightText: 2025 SecPal Contributors
+SPDX-FileCopyrightText: 2025-2026 SecPal Contributors
 
 SPDX-License-Identifier: CC0-1.0

--- a/docs/containers.md
+++ b/docs/containers.md
@@ -43,6 +43,11 @@ and publish `ghcr.io/secpal/api` as an OCI image index for `linux/amd64` and
 `sha-<full-40-character-commit-SHA>`. It does not publish `latest`, a branch
 tag, a SemVer tag, or a release tag.
 
+The publisher's static container policy suite is isolated from the Laravel
+database test case and runs without PostgreSQL. Pull-request validation runs
+the same database-free policy command used by the post-merge publisher before
+any registry write is permitted.
+
 The canonical consumption reference is always the returned index digest:
 
 ```text

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -21,6 +21,9 @@ SPDX-License-Identifier: CC0-1.0
         <testsuite name="Regression">
             <directory>tests/Regression</directory>
         </testsuite>
+        <testsuite name="Policy">
+            <directory>tests/Policy</directory>
+        </testsuite>
     </testsuites>
     <source>
         <include>

--- a/tests/Feature/Console/ScheduleListWithoutDatabaseTest.php
+++ b/tests/Feature/Console/ScheduleListWithoutDatabaseTest.php
@@ -1,0 +1,17 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+
+it('lists scheduled tasks without a database connection', function (): void {
+    expect(Illuminate\Support\Facades\Artisan::call('schedule:list', ['--json' => true]))->toBe(0);
+
+    $process = new Symfony\Component\Process\Process(
+        [PHP_BINARY, 'artisan', 'schedule:list', '--json'], base_path(),
+        ['APP_ENV' => 'production', 'CACHE_STORE' => 'database', 'DB_CONNECTION' => 'pgsql', 'DB_HOST' => 'unreachable.invalid'],
+    );
+    $process->setTimeout(10)->run();
+
+    expect($process->isSuccessful())->toBeTrue($process->getErrorOutput())
+        ->and(json_decode($process->getOutput(), true))->toBeArray()->not->toBeEmpty();
+});

--- a/tests/Policy/ContainerImageDefinitionTest.php
+++ b/tests/Policy/ContainerImageDefinitionTest.php
@@ -3,17 +3,6 @@
 // SPDX-FileCopyrightText: 2026 SecPal Contributors
 // SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
 
-it('lists scheduled tasks without a database connection', function (): void {
-    expect(Illuminate\Support\Facades\Artisan::call('schedule:list', ['--json' => true]))->toBe(0);
-
-    $process = new Symfony\Component\Process\Process(
-        [PHP_BINARY, 'artisan', 'schedule:list', '--json'], base_path(),
-        ['APP_ENV' => 'production', 'CACHE_STORE' => 'database', 'DB_CONNECTION' => 'pgsql', 'DB_HOST' => 'unreachable.invalid'],
-    );
-    $process->setTimeout(10)->run();
-    expect($process->isSuccessful())->toBeTrue($process->getErrorOutput())
-        ->and(json_decode($process->getOutput(), true))->toBeArray()->not->toBeEmpty();
-});
 it('defines the production API image contract', function (): void {
     $root = dirname(__DIR__, 2);
     $artifacts = ['Dockerfile', '.dockerignore', 'docker/frankenphp/Caddyfile', 'docker/php/conf.d/production.ini',

--- a/tests/Policy/ContainerPublishingWorkflowTest.php
+++ b/tests/Policy/ContainerPublishingWorkflowTest.php
@@ -185,7 +185,7 @@ it('validates before publishing without registry credentials or write operations
         );
 });
 
-it('keeps container policy validation independent from PostgreSQL', function (): void {
+it('keeps static container policy validation independent from Laravel PostgreSQL bootstrap', function (): void {
     $root = dirname(__DIR__, 2);
     $publishWorkflow = containerPublishingWorkflow();
     $pullRequestWorkflow = Yaml::parseFile($root.'/.github/workflows/container-image.yml');

--- a/tests/Policy/ContainerPublishingWorkflowTest.php
+++ b/tests/Policy/ContainerPublishingWorkflowTest.php
@@ -5,6 +5,10 @@
 
 use Symfony\Component\Yaml\Yaml;
 
+it('does not use the Laravel database test case', function (): void {
+    expect($this)->not->toBeInstanceOf(Tests\TestCase::class);
+});
+
 function containerPublishingWorkflowPath(): string
 {
     return dirname(__DIR__, 2).'/.github/workflows/publish-container.yml';
@@ -55,6 +59,20 @@ function containerPublishingRunScripts(array $job): string
         static fn (array $step): string => (string) ($step['run'] ?? ''),
         $job['steps'],
     ));
+}
+
+/** @return list<string> */
+function containerPolicyComposerScript(): array
+{
+    $composer = json_decode(
+        (string) file_get_contents(dirname(__DIR__, 2).'/composer.json'),
+        true,
+        flags: JSON_THROW_ON_ERROR,
+    );
+
+    expect($composer)->toBeArray();
+
+    return $composer['scripts']['test:container-policy'] ?? [];
 }
 
 function containerPublishingForbiddenCommandPattern(): string
@@ -156,7 +174,8 @@ it('validates before publishing without registry credentials or write operations
         ->toContain('scripts/promote-ghcr-index.sh')
         ->toContain('tests/container/promote-ghcr-index-contract.sh')
         ->toContain('tests/fixtures/fake-ghcr-curl.sh')
-        ->toContain('php artisan test tests/Unit/ContainerImageDefinitionTest.php tests/Unit/ContainerPublishingWorkflowTest.php')
+        ->toContain('composer test:container-policy')
+        ->not->toContain('php artisan test')
         ->not->toContain('docker login')
         ->not->toContain('docker push')
         ->and($uses)->not->toContain(
@@ -164,6 +183,44 @@ it('validates before publishing without registry credentials or write operations
             'docker/build-push-action',
             'actions/attest',
         );
+});
+
+it('keeps container policy validation independent from PostgreSQL', function (): void {
+    $root = dirname(__DIR__, 2);
+    $publishWorkflow = containerPublishingWorkflow();
+    $pullRequestWorkflow = Yaml::parseFile($root.'/.github/workflows/container-image.yml');
+    $publishValidate = $publishWorkflow['jobs']['validate'];
+    $pullRequestValidate = $pullRequestWorkflow['jobs']['build-and-test'];
+    $pestConfiguration = (string) file_get_contents($root.'/tests/Pest.php');
+    $phpunitConfiguration = (string) file_get_contents($root.'/phpunit.xml');
+    $workflowDefinitions = json_encode(
+        [$publishWorkflow, $pullRequestWorkflow],
+        JSON_THROW_ON_ERROR,
+    );
+
+    expect(containerPolicyComposerScript())->toBe([
+        'pest --no-coverage tests/Policy/ContainerImageDefinitionTest.php tests/Policy/ContainerPublishingWorkflowTest.php',
+    ])->and($publishValidate)
+        ->not->toHaveKeys(['services', 'env'])
+        ->and($pullRequestValidate)->not->toHaveKeys(['services', 'env'])
+        ->and(containerPublishingRunScripts($publishValidate))
+        ->toContain('composer test:container-policy')
+        ->not->toContain('php artisan test')
+        ->and(containerPublishingRunScripts($pullRequestValidate))
+        ->toContain('composer test:container-policy')
+        ->not->toContain('php artisan test')
+        ->and($workflowDefinitions)
+        ->not->toMatch('/DB_[A-Z_]+/')
+        ->not->toContain(
+            'tests/Unit/ContainerImageDefinitionTest.php',
+            'tests/Unit/ContainerPublishingWorkflowTest.php',
+        )
+        ->and($phpunitConfiguration)
+        ->toContain('<testsuite name="Policy">', '<directory>tests/Policy</directory>')
+        ->and($pestConfiguration)
+        ->not->toMatch('/->in\([^;]*[\'\"]Policy[\'\"]/s')
+        ->and($pullRequestWorkflow['permissions'])->toBe(['contents' => 'read'])
+        ->and($pullRequestValidate)->not->toHaveKey('permissions');
 });
 
 it('pins every container validation tool to an immutable version or image digest', function (): void {
@@ -174,8 +231,15 @@ it('pins every container validation tool to an immutable version or image digest
     $pullRequestWorkflow = Yaml::parseFile(dirname(__DIR__, 2).'/.github/workflows/container-image.yml');
     $pullRequestValidate = $pullRequestWorkflow['jobs']['build-and-test'];
     $setupPhp = containerPublishingNamedStep($publishingValidate, 'Set up PHP');
+    $pullRequestSetupPhp = containerPublishingNamedStep($pullRequestValidate, 'Set up PHP');
 
-    expect($setupPhp['with']['tools'])->toBe('composer:2.10.2');
+    expect($setupPhp['with']['tools'])->toBe('composer:2.10.2')
+        ->and($pullRequestSetupPhp['uses'])->toBe('shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240')
+        ->and($pullRequestSetupPhp['with'])->toBe([
+            'php-version' => '8.4',
+            'coverage' => 'none',
+            'tools' => 'composer:2.10.2',
+        ]);
 
     foreach ([$publishingValidate, $pullRequestValidate] as $job) {
         $scripts = containerPublishingRunScripts($job);
@@ -923,10 +987,18 @@ it('keeps the pull-request container workflow read-only', function (): void {
             'scripts/promote-ghcr-index.sh',
             'tests/container/**',
             'tests/fixtures/**',
-            'tests/Unit/ContainerPublishingWorkflowTest.php',
+            'tests/Policy/**',
+            'tests/Feature/Console/ScheduleListWithoutDatabaseTest.php',
+            'tests/Regression/ContainerPolicyIsolationTest.php',
+            'composer.json',
+            'composer.lock',
+            'phpunit.xml',
+            'tests/Pest.php',
         )
+        ->not->toContain('tests/Unit/ContainerPublishingWorkflowTest.php')
         ->and(containerPublishingRunScripts($workflow['jobs']['build-and-test']))
         ->toContain('tests/container/promote-ghcr-index-contract.sh')
         ->toContain('scripts/promote-ghcr-index.sh')
+        ->toContain('composer test:container-policy')
         ->and($checkout['uses'])->toBe('actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1');
 });

--- a/tests/Policy/ContainerPublishingWorkflowTest.php
+++ b/tests/Policy/ContainerPublishingWorkflowTest.php
@@ -191,6 +191,8 @@ it('keeps container policy validation independent from PostgreSQL', function ():
     $pullRequestWorkflow = Yaml::parseFile($root.'/.github/workflows/container-image.yml');
     $publishValidate = $publishWorkflow['jobs']['validate'];
     $pullRequestValidate = $pullRequestWorkflow['jobs']['build-and-test'];
+    $publishValidateRuns = array_column($publishValidate['steps'], 'run');
+    $pullRequestValidateRuns = array_column($pullRequestValidate['steps'], 'run');
     $pestConfiguration = (string) file_get_contents($root.'/tests/Pest.php');
     $phpunitConfiguration = (string) file_get_contents($root.'/phpunit.xml');
     $workflowDefinitions = json_encode(
@@ -209,6 +211,10 @@ it('keeps container policy validation independent from PostgreSQL', function ():
         ->and(containerPublishingRunScripts($pullRequestValidate))
         ->toContain('composer test:container-policy')
         ->not->toContain('php artisan test')
+        ->and($publishValidateRuns)
+        ->not->toContain('tests/docker/smoke.sh')
+        ->and($pullRequestValidateRuns)
+        ->toContain('tests/docker/smoke.sh')
         ->and($workflowDefinitions)
         ->not->toMatch('/DB_[A-Z_]+/')
         ->not->toContain(

--- a/tests/Regression/ContainerPolicyIsolationTest.php
+++ b/tests/Regression/ContainerPolicyIsolationTest.php
@@ -1,0 +1,25 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+
+use Symfony\Component\Process\Process;
+
+it('runs the container policy contract without PostgreSQL', function (): void {
+    $process = new Process(
+        ['composer', 'test:container-policy'],
+        dirname(__DIR__, 2),
+        [
+            'APP_ENV' => 'testing',
+            'DB_CONNECTION' => 'pgsql',
+            'DB_HOST' => 'unreachable.invalid',
+            'DB_PORT' => '5432',
+            'DB_DATABASE' => 'testing',
+            'DB_USERNAME' => 'invalid',
+            'DB_PASSWORD' => 'invalid',
+        ],
+    );
+    $process->setTimeout(60)->run();
+
+    expect($process->isSuccessful())->toBeTrue($process->getErrorOutput().$process->getOutput());
+});


### PR DESCRIPTION
## Problem and evidence

The first post-merge `Publish Container` run, [30773102993](https://github.com/SecPal/api/actions/runs/30773102993), failed in `Validate API Image` while running the container policy tests:

```text
Unable to connect to a PostgreSQL maintenance database for test bootstrap.
```

`tests/Pest.php` bound `tests/Unit` to `Tests\TestCase`, whose class bootstrap initializes PostgreSQL because `phpunit.xml` forces the testing PostgreSQL connection. The static container policy files therefore attempted database bootstrap before executing any assertions.

The publisher intentionally has no PostgreSQL Actions service or database credentials. Adding either would hide the incorrect test boundary and weaken the fail-closed validation contract.

## Change

- move static image-definition and publishing-policy coverage into a plain, database-free `tests/Policy` suite
- keep the Laravel-dependent schedule command check in the Feature suite
- define `composer test:container-policy` as the shared policy command for pull-request CI and the post-merge publisher
- add a regression subprocess that proves the command succeeds with `DB_HOST=unreachable.invalid`
- prevent the publisher's Validate job from executing the database-backed integration smoke while retaining that full smoke in pull-request CI and for both published runtime manifests
- lock the separation in policy tests: the publisher may not execute `tests/docker/smoke.sh`, while pull-request validation must continue to execute it

No candidate, promotion, multi-architecture, SBOM, provenance, attestation, immutable-tag, or digest-only consumption contract was changed.

## Validation

- reproduced the original red state with the former publisher command and `DB_HOST=unreachable.invalid`
- proved the final isolation invariant red before the workflow correction: 1 expected failure and 70 passing policy tests
- `composer test:container-policy` with unreachable and invalid PostgreSQL settings: 71 tests, 511 assertions
- `php artisan test tests/Feature/Console/ScheduleListWithoutDatabaseTest.php`
- `php artisan test tests/Regression/ContainerPolicyIsolationTest.php`
- full `composer test`: 3,120 parallel tests passed with 1 skipped, then 35 serial tests passed
- `composer analyse`: 431 files, no errors
- Pint, Actionlint, Yamllint, Shellcheck, the GHCR promotion contract, REUSE lint, all pre-commit hooks, `git diff --check`, and repository preflight against `main` passed
- the container build completed; the full smoke passed from a permission-normalized temporary build context because the local workspace applies restrictive ACL metadata that is not present in a GitHub checkout
- both commits are cryptographically signed and verify locally

Run `30773102993` was not retried. No registry, image, tag, package, attestation, package-visibility, or deployment state was changed.

## Readiness

There is no unresolved in-scope implementation dependency or untracked follow-up finding. This pull request remains a draft until its hosted checks complete and a final self-review in the pull-request view confirms that no new issue prevents readiness.

After merge, the new push to `main` will create a new publish run for this pull request's merge commit. That new commit—not `7026c84119780f074face4e58e0a819ce3f18582`—will be the source identity for the recovered candidate, verification, attestation, and final SHA tag.
