### PR TITLE
fix: avoid broken-pipe noise in container smoke checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- made container smoke command-output checks consume complete output before
+  asserting it, eliminating successful-run broken-pipe diagnostics (fixes
+  `api#1381`)
 - pinned the remaining in-scope GitHub Actions and third-party Actions to
   immutable commit SHAs with adjacent release-version comments, and added
   workflow policy coverage that rejects future moving tags; advanced PHP and

--- a/tests/Policy/ContainerImageDefinitionTest.php
+++ b/tests/Policy/ContainerImageDefinitionTest.php
@@ -63,7 +63,7 @@ it('defines the production API image contract', function (): void {
     expect($documentation)->toContain('/app/storage/app/private')->toContain('persistent')->and($dockerignore)->toMatch('/^storage\/app$/m');
     expect($dockerignore)->toMatch('/^\*\*\/\*\.sqlite\*$/m');
     expect($smokeScript)
-        ->toContain('php --ini | grep -Fq "/usr/local/etc/php/conf.d/zz-secpal-production.ini"')
+        ->toContain('assert_output_contains "$php_ini_output" \'/usr/local/etc/php/conf.d/zz-secpal-production.ini\'')
         ->toContain('test -r "$ini"')
         ->toContain('test ! -w "$ini"')
         ->toContain('test "$(stat -c "%U:%G %a" "$ini")" = "root:root 644"')
@@ -78,6 +78,19 @@ it('defines the production API image contract', function (): void {
         ->toContain('chmod 0444 "$port_probe"')
         ->toContain('-v "${port_probe}:/tmp/assert-port-closed.php:ro"');
     expect($proxyConfig)->toContain('TRUSTED_PROXIES');
+});
+
+it('checks container command output without early-terminating pipelines', function (): void {
+    $smokeScript = (string) file_get_contents(dirname(__DIR__, 2).'/tests/docker/smoke.sh');
+
+    expect($smokeScript)
+        ->toContain('php_version=$(docker run --rm "$image" php -v)')
+        ->toContain('frankenphp_version=$(docker run --rm "$image" frankenphp version)')
+        ->toContain('php_modules=$(docker run --rm "$image" php -m)')
+        ->toContain('redis_info=$(docker run --rm "$image" php --ri redis)')
+        ->toContain('php_ini_output=$(docker run --rm "$image" php --ini)')
+        ->toContain('ots_version=$(docker run --rm "$image" ots --version)')
+        ->not->toMatch('/docker run[^\n]*\\|[ \t]*grep\\b/');
 });
 
 it('distinguishes a listening TCP port from a closed port', function (): void {

--- a/tests/docker/smoke.sh
+++ b/tests/docker/smoke.sh
@@ -57,6 +57,28 @@ wait_for_http() {
     docker logs "$api" >&2
     return 1
 }
+assert_output_starts_with() {
+    case "$1" in
+        "$2"*) ;;
+        *) return 1 ;;
+    esac
+}
+assert_output_contains() {
+    case "$1" in
+        *"$2"*) ;;
+        *) return 1 ;;
+    esac
+}
+assert_output_has_line() {
+    case "
+$1
+" in
+        *"
+$2
+"*) ;;
+        *) return 1 ;;
+    esac
+}
 
 printf 'container build-context exclusion probe\n' >"$sqlite_probe"
 if [ "${SKIP_BUILD:-0}" = 1 ]; then
@@ -64,13 +86,18 @@ if [ "${SKIP_BUILD:-0}" = 1 ]; then
 else
     docker build --tag "$image" .
 fi
-docker run --rm "$image" php -v | grep -q '^PHP 8\.4\.23'
-docker run --rm "$image" frankenphp version | grep -q 'FrankenPHP v1\.12\.6'
-docker run --rm "$image" php -m | grep -qx redis
-docker run --rm "$image" php --ri redis | grep -q 'Redis Version => 6\.3\.0'
+php_version=$(docker run --rm "$image" php -v)
+assert_output_starts_with "$php_version" 'PHP 8.4.23'
+frankenphp_version=$(docker run --rm "$image" frankenphp version)
+assert_output_contains "$frankenphp_version" 'FrankenPHP v1.12.6'
+php_modules=$(docker run --rm "$image" php -m)
+assert_output_has_line "$php_modules" redis
+redis_info=$(docker run --rm "$image" php --ri redis)
+assert_output_contains "$redis_info" 'Redis Version => 6.3.0'
 docker run --rm "$image" php -r 'exit(extension_loaded("redis") ? 0 : 1);'
 docker run --rm "$image" php -r 'exit(ini_get("upload_max_filesize") === "10M" && ini_get("post_max_size") === "12M" ? 0 : 1);'
-docker run --rm "$image" php --ini | grep -Fq "/usr/local/etc/php/conf.d/zz-secpal-production.ini"
+php_ini_output=$(docker run --rm "$image" php --ini)
+assert_output_contains "$php_ini_output" '/usr/local/etc/php/conf.d/zz-secpal-production.ini'
 docker run --rm "$image" sh -eu -c '
     ini=/usr/local/etc/php/conf.d/zz-secpal-production.ini
     test -r "$ini"
@@ -94,7 +121,8 @@ docker run --rm "$image" php artisan --version
 docker run --rm "$image" php artisan schedule:list
 docker run --rm "$image" php artisan queue:work --help >/dev/null
 docker run --rm "$image" php artisan schedule:work --help >/dev/null
-docker run --rm "$image" ots --version | grep -q 'v0\.7\.2'
+ots_version=$(docker run --rm "$image" ots --version)
+assert_output_contains "$ots_version" v0.7.2
 docker run --rm "$image" python3 -c 'import opentimestamps'
 docker run --rm "$image" frankenphp fmt --diff --config /etc/frankenphp/Caddyfile >/dev/null
 docker run --rm "$image" frankenphp validate --config /etc/frankenphp/Caddyfile


### PR DESCRIPTION
## Problem and evidence

The documented local and digest-based container smoke contract piped `docker run` output into quiet `grep` checks. Once a match was found, `grep` could exit before the container client finished writing, producing `write /dev/stdout: broken pipe` during an otherwise successful smoke run. The same producer/consumer risk also applied to the PHP configuration-path assertion added with the runtime-permissions fix.

## Change

- Capture complete container command output before evaluating PHP, FrankenPHP, Redis, PHP configuration, and OpenTimestamps assertions.
- Preserve the existing prefix, substring, and exact-line coverage with POSIX shell helpers that remain fail-fast under `set -eu`.
- Add policy coverage for every migrated command and reject future single-line `docker run ... | grep` pipelines in the smoke contract.
- Record the change in the changelog.

## Validation

- Confirmed the focused policy test failed before implementation and passed afterward.
- `composer test:container-policy` — 48 tests, 370 assertions passed.
- `vendor/bin/pint --dirty` passed.
- Pinned ShellCheck validation passed for both container shell scripts.
- `tests/docker/smoke.sh` passed end to end without broken-pipe diagnostics.
- Explicit positive and negative shell checks confirmed assertion coverage and fail-fast behavior.
- `reuse lint` and `git diff --check` passed.
- Commit hooks passed REUSE, markdownlint, ShellCheck, Pint, whitespace, and conflict checks.

## Readiness

The runtime artifact-permissions fix from #1406 is already present on the `main` base and the complete smoke contract passes with it. No unresolved in-scope dependency or local check prevents review. This pull request is intentionally opened as a draft; readiness will be assessed separately after the required final review in the pull request view.

Closes #1381
