### PR TITLE
fix: remediate GitPython vulnerability alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- upgraded the production image's hash-locked GitPython dependency to 3.1.58,
+  resolving the five high- and one moderate-severity advisories affecting
+  3.1.57, and added policy coverage that rejects regression below the patched
+  version (fixes `api#1405`)
 - made container smoke command-output checks consume complete output before
   asserting it, eliminating successful-run broken-pipe diagnostics (fixes
   `api#1381`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - upgraded the production image's hash-locked GitPython dependency to 3.1.58,
   resolving the five high- and one moderate-severity advisories affecting
-  3.1.57, and added policy coverage that rejects regression below the patched
-  version (fixes `api#1405`)
+  3.1.57 (fixes `api#1405`)
 - made container smoke command-output checks consume complete output before
   asserting it, eliminating successful-run broken-pipe diagnostics (fixes
   `api#1381`)

--- a/docker/python/opentimestamps-requirements.txt
+++ b/docker/python/opentimestamps-requirements.txt
@@ -3,7 +3,7 @@
 
 appdirs==1.4.4 --hash=sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128
 gitdb==4.0.12 --hash=sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf
-gitpython==3.1.57 --hash=sha256:4ccf7d73c10f5c9e76043fbb2675ac5a1b3ff5b41e648f56bcbed5f63792ecaf
+gitpython==3.1.58 --hash=sha256:d331e722577f0fd7fc1f857419b3ecc07af66282b933d2a4d95f84a042fdd50f
 opentimestamps==0.4.5 --hash=sha256:a4912b3bd1b612a3ef5fac925b9137889e6c5cb91cc9e76c8202a2bf8abe26b5
 opentimestamps-client==0.7.2 --hash=sha256:84e604d7f76534da4bab61ab62b211a6559aa988da51438408ae7947b0e8b7ba
 pycryptodomex==3.23.0 \

--- a/tests/Policy/ContainerImageDefinitionTest.php
+++ b/tests/Policy/ContainerImageDefinitionTest.php
@@ -80,6 +80,15 @@ it('defines the production API image contract', function (): void {
     expect($proxyConfig)->toContain('TRUSTED_PROXIES');
 });
 
+it('pins GitPython to a version containing the OpenTimestamps dependency security fixes', function (): void {
+    $requirements = (string) file_get_contents(
+        dirname(__DIR__, 2).'/docker/python/opentimestamps-requirements.txt',
+    );
+
+    expect(preg_match('/^gitpython==(?<version>[^ ]+) /m', $requirements, $matches))->toBe(1)
+        ->and(version_compare($matches['version'], '3.1.58', '>='))->toBeTrue();
+});
+
 it('checks container command output without early-terminating pipelines', function (): void {
     $smokeScript = (string) file_get_contents(dirname(__DIR__, 2).'/tests/docker/smoke.sh');
 

--- a/tests/Policy/ContainerImageDefinitionTest.php
+++ b/tests/Policy/ContainerImageDefinitionTest.php
@@ -80,15 +80,6 @@ it('defines the production API image contract', function (): void {
     expect($proxyConfig)->toContain('TRUSTED_PROXIES');
 });
 
-it('pins GitPython to a version containing the OpenTimestamps dependency security fixes', function (): void {
-    $requirements = (string) file_get_contents(
-        dirname(__DIR__, 2).'/docker/python/opentimestamps-requirements.txt',
-    );
-
-    expect(preg_match('/^gitpython==(?<version>[^ ]+) /m', $requirements, $matches))->toBe(1)
-        ->and(version_compare($matches['version'], '3.1.58', '>='))->toBeTrue();
-});
-
 it('checks container command output without early-terminating pipelines', function (): void {
     $smokeScript = (string) file_get_contents(dirname(__DIR__, 2).'/tests/docker/smoke.sh');
 


### PR DESCRIPTION
## Summary

GitHub reports six open Dependabot vulnerability alerts on the default branch: five high-severity alerts and one moderate-severity alert. All six affect the hash-locked GitPython 3.1.57 dependency in `docker/python/opentimestamps-requirements.txt`, and GitHub identifies 3.1.58 as the first patched version.

GitPython is installed in the production image because `opentimestamps-client` requires it. SecPal does not import GitPython directly, but the affected package is present in the runtime image, so upgrading it is preferable to dismissing valid alerts.

## Changes

- update the hash-locked GitPython wheel from 3.1.57 to 3.1.58
- document the security dependency update in `CHANGELOG.md`

## Validation

- confirmed all six alerts share the vulnerable range `<= 3.1.57` and first patched version `3.1.58`
- confirmed the pinned wheel hash against the published package metadata
- `composer test:container-policy`: 48 tests passed, 370 assertions
- `vendor/bin/pint --dirty` and `vendor/bin/pint --test --dirty`
- `reuse lint`
- hash-enforced pip resolution with `--require-hashes`
- local Docker `extensions` stage build
- verified GitPython 3.1.58 in the built image
- `ots --version`
- `pip check`
- `git diff --check`
- repository pre-commit hooks

## Readiness

No known in-scope code blockers remain. This PR remains draft for the required final self-review in the PR view. The Dependabot alerts will remain open until the patched dependency reaches the default branch.

Closes #1405