### PR TITLE
Reject compliance status on employee collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- restricted `compliance_status` validation to
+  `GET /v1/employees/compliance-alerts`; the standard employee collection now
+  rejects that unsupported filter instead of silently returning unfiltered
+  results (fixes `api#1337`)
 - upgraded the production image's hash-locked GitPython dependency to 3.1.58,
   resolving the five high- and one moderate-severity advisories affecting
   3.1.57 (fixes `api#1405`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - restricted `compliance_status` validation to
   `GET /v1/employees/compliance-alerts`; the standard employee collection now
   rejects that unsupported filter instead of silently returning unfiltered
-  results (fixes `api#1337`)
+  results, while the compliance-alert collection rejects empty and non-scalar
+  filter values (fixes `api#1337`)
 - upgraded the production image's hash-locked GitPython dependency to 3.1.58,
   resolving the five high- and one moderate-severity advisories affecting
   3.1.57 (fixes `api#1405`)

--- a/app/Http/Controllers/Api/V1/EmployeeController.php
+++ b/app/Http/Controllers/Api/V1/EmployeeController.php
@@ -8,6 +8,7 @@ namespace App\Http\Controllers\Api\V1;
 use App\Exceptions\BewacherregisterExportNotReadyException;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\ExportEmployeeBwrRequest;
+use App\Http\Requests\IndexEmployeeComplianceAlertsRequest;
 use App\Http\Requests\IndexEmployeeRequest;
 use App\Http\Requests\StoreEmployeeRequest;
 use App\Http\Requests\UpdateEmployeeBwrStatusRequest;
@@ -69,7 +70,7 @@ class EmployeeController extends Controller
     /**
      * Display employees with active compliance alerts for overview use cases.
      */
-    public function complianceAlerts(IndexEmployeeRequest $request, EmployeeComplianceService $complianceService): AnonymousResourceCollection
+    public function complianceAlerts(IndexEmployeeComplianceAlertsRequest $request, EmployeeComplianceService $complianceService): AnonymousResourceCollection
     {
         $this->authorize('viewAny', Employee::class);
 

--- a/app/Http/Requests/IndexEmployeeComplianceAlertsRequest.php
+++ b/app/Http/Requests/IndexEmployeeComplianceAlertsRequest.php
@@ -1,0 +1,43 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+
+namespace App\Http\Requests;
+
+use App\Services\EmployeeComplianceService;
+use Illuminate\Validation\Rule;
+
+/**
+ * IndexEmployeeComplianceAlertsRequest validates employee compliance alert filters.
+ */
+class IndexEmployeeComplianceAlertsRequest extends IndexEmployeeRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            ...parent::rules(),
+            'compliance_status' => ['nullable', Rule::in(EmployeeComplianceService::ALERT_STATUSES)],
+        ];
+    }
+
+    /**
+     * Get custom messages for validator errors.
+     *
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            ...parent::messages(),
+            'compliance_status.in' => __('Compliance status filter must be one of: :statuses.', [
+                'statuses' => implode(', ', EmployeeComplianceService::ALERT_STATUSES),
+            ]),
+        ];
+    }
+}

--- a/app/Http/Requests/IndexEmployeeComplianceAlertsRequest.php
+++ b/app/Http/Requests/IndexEmployeeComplianceAlertsRequest.php
@@ -22,7 +22,12 @@ class IndexEmployeeComplianceAlertsRequest extends IndexEmployeeRequest
     {
         return [
             ...parent::rules(),
-            'compliance_status' => ['nullable', Rule::in(EmployeeComplianceService::ALERT_STATUSES)],
+            'compliance_status' => [
+                'sometimes',
+                'required',
+                'string',
+                Rule::in(EmployeeComplianceService::ALERT_STATUSES),
+            ],
         ];
     }
 
@@ -33,11 +38,15 @@ class IndexEmployeeComplianceAlertsRequest extends IndexEmployeeRequest
      */
     public function messages(): array
     {
+        $complianceStatusMessage = __('Compliance status filter must be one of: :statuses.', [
+            'statuses' => implode(', ', EmployeeComplianceService::ALERT_STATUSES),
+        ]);
+
         return [
             ...parent::messages(),
-            'compliance_status.in' => __('Compliance status filter must be one of: :statuses.', [
-                'statuses' => implode(', ', EmployeeComplianceService::ALERT_STATUSES),
-            ]),
+            'compliance_status.required' => $complianceStatusMessage,
+            'compliance_status.string' => $complianceStatusMessage,
+            'compliance_status.in' => $complianceStatusMessage,
         ];
     }
 }

--- a/app/Http/Requests/IndexEmployeeRequest.php
+++ b/app/Http/Requests/IndexEmployeeRequest.php
@@ -6,7 +6,6 @@
 namespace App\Http\Requests;
 
 use App\Models\Employee;
-use App\Services\EmployeeComplianceService;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
@@ -32,7 +31,7 @@ class IndexEmployeeRequest extends FormRequest
     {
         return [
             'status' => ['nullable', Rule::in(Employee::VALID_STATUSES)],
-            'compliance_status' => ['nullable', Rule::in(EmployeeComplianceService::ALERT_STATUSES)],
+            'compliance_status' => ['missing'],
             'legal_entity_id' => [
                 'nullable',
                 'uuid',
@@ -57,9 +56,7 @@ class IndexEmployeeRequest extends FormRequest
             'status.in' => __('Status filter must be one of: :statuses.', [
                 'statuses' => implode(', ', Employee::VALID_STATUSES),
             ]),
-            'compliance_status.in' => __('Compliance status filter must be one of: :statuses.', [
-                'statuses' => implode(', ', EmployeeComplianceService::ALERT_STATUSES),
-            ]),
+            'compliance_status.missing' => __('Compliance status filtering is only supported by the compliance alerts endpoint.'),
         ];
     }
 }

--- a/tests/Feature/Controllers/EmployeeControllerTest.php
+++ b/tests/Feature/Controllers/EmployeeControllerTest.php
@@ -169,6 +169,26 @@ describe('GET /v1/employees', function () {
         expect($response->json('data'))->toHaveCount(1);
     });
 
+    test('rejects compliance status filtering on the standard employee collection', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'employee.read');
+
+        $response = $this->withToken($this->token)
+            ->getJson('/v1/employees?compliance_status=warning');
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['compliance_status']);
+    });
+
+    test('rejects an empty compliance status parameter on the standard employee collection', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'employee.read');
+
+        $response = $this->withToken($this->token)
+            ->getJson('/v1/employees?compliance_status=');
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['compliance_status']);
+    });
+
     test('filters employees by establishment_id', function (): void {
         givePermissionWithTenant($this->user, $this->tenant->id, 'employee.read');
 

--- a/tests/Feature/Controllers/EmployeeControllerTest.php
+++ b/tests/Feature/Controllers/EmployeeControllerTest.php
@@ -189,6 +189,16 @@ describe('GET /v1/employees', function () {
             ->assertJsonValidationErrors(['compliance_status']);
     });
 
+    test('rejects an array compliance status parameter on the standard employee collection', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'employee.read');
+
+        $response = $this->withToken($this->token)
+            ->getJson('/v1/employees?compliance_status[]=warning');
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['compliance_status']);
+    });
+
     test('filters employees by establishment_id', function (): void {
         givePermissionWithTenant($this->user, $this->tenant->id, 'employee.read');
 
@@ -395,6 +405,20 @@ describe('GET /v1/employees', function () {
 
         $response->assertStatus(422)
             ->assertJsonValidationErrors(['compliance_status']);
+    });
+
+    test('rejects empty or non-scalar employee compliance alert status filters', function (): void {
+        givePermissionWithTenant($this->user, $this->tenant->id, 'employee.read');
+
+        foreach ([
+            '/v1/employees/compliance-alerts?compliance_status=',
+            '/v1/employees/compliance-alerts?compliance_status[]=warning',
+        ] as $url) {
+            $response = $this->withToken($this->token)->getJson($url);
+
+            $response->assertStatus(422)
+                ->assertJsonValidationErrors(['compliance_status']);
+        }
     });
 
     test('compliance alerts endpoint paginates results and respects per_page', function (): void {


### PR DESCRIPTION
## Problem

`IndexEmployeeRequest` accepted `compliance_status` for both employee collection routes, but `EmployeeController::index` did not consume it. As a result, `GET /v1/employees?compliance_status=warning` returned HTTP 200 with an unfiltered collection even though the contracts repository exposes that filter only for `GET /employees/compliance-alerts`.

The original behavior was reproduced with a route-level regression test that failed because the standard collection returned HTTP 200 instead of the expected HTTP 422. A second regression test demonstrated the same contract gap for an explicitly empty query parameter.

## Changes

- Require `compliance_status` to be absent from the standard employee collection request, including when the supplied value is empty.
- Add a dedicated compliance-alert collection request that preserves validation against the shared alert-status constants.
- Use the route-specific request in `EmployeeController::complianceAlerts`.
- Cover the supported compliance-alert filter, invalid values, unsupported standard-route values, and empty standard-route values.
- Document the behavior change in `CHANGELOG.md`.

## Validation

- `php artisan test tests/Feature/Controllers/EmployeeControllerTest.php` — 101 tests passed, 404 assertions
- Compliance-focused employee route tests — 7 tests passed, 27 assertions
- `vendor/bin/pint --dirty`
- `composer analyse`
- `reuse lint`
- Contracts verified-endpoint guard — 33 operations verified
- Contracts compliance-filter guard tests — 6 tests passed
- `git diff --check`
- Commit signature verified locally as a valid SSH signature

## Readiness

No in-scope dependency or unresolved local check remains. The pull request remains a draft pending the required final self-review in the pull request view and repository-hosted checks, which have not been inspected as part of this publication step.

Closes #1337
