### PR TITLE
Make onboarding file upload retries idempotent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Made onboarding file upload retries idempotent with tenant-scoped keys and
+  exact payload matching so interrupted Android requests cannot create
+  duplicate encrypted blobs (issue #1422).
+
 - restored explicit final-layer modes for the root-owned production PHP
   configuration, FrankenPHP Caddyfile, and live-healthcheck script so the
   rootless runtime can load both configurations and execute its healthcheck

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,8 +123,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Made onboarding file upload retries idempotent with tenant-scoped keys and
-  exact payload matching so interrupted Android requests cannot create
-  duplicate encrypted blobs (issue #1422).
+  exact original-filename and payload matching plus operation-scoped blind
+  fingerprints so interrupted Android requests cannot create duplicate
+  encrypted blobs or expose equal-content upload relationships (issue #1422).
 
 - restored explicit final-layer modes for the root-owned production PHP
   configuration, FrankenPHP Caddyfile, and live-healthcheck script so the

--- a/app/Http/Controllers/Api/V1/OnboardingController.php
+++ b/app/Http/Controllers/Api/V1/OnboardingController.php
@@ -22,7 +22,7 @@ use App\Services\OnboardingCompletionService;
 use App\Services\OnboardingFormDataSchemaValidationService;
 use App\Services\OnboardingResidentialAddressHistorySyncService;
 use App\Services\OnboardingSchemaLocalizationService;
-use App\Services\OnboardingSubmissionFileStorageService;
+use App\Services\OnboardingSubmissionFileUploadService;
 use App\Services\OnboardingTaxIdentificationSyncService;
 use Illuminate\Auth\Events\Verified;
 use Illuminate\Http\JsonResponse;
@@ -77,7 +77,7 @@ class OnboardingController extends Controller
     ];
 
     public function __construct(
-        private readonly OnboardingSubmissionFileStorageService $submissionFileStorageService,
+        private readonly OnboardingSubmissionFileUploadService $submissionFileUploadService,
         private readonly OnboardingSchemaLocalizationService $onboardingSchemaLocalizationService,
         private readonly OnboardingFormDataSchemaValidationService $onboardingFormDataSchemaValidationService,
         private readonly OnboardingCompletionService $onboardingCompletionService,
@@ -915,12 +915,6 @@ class OnboardingController extends Controller
     {
         $this->authorize('uploadFile', $submission);
 
-        if (! in_array($submission->status, ['draft', 'rejected'], true)) {
-            throw ValidationException::withMessages([
-                'status' => __('Files can only be uploaded while the onboarding submission is editable'),
-            ]);
-        }
-
         /** @var array<string, mixed> $validated */
         $validated = $request->validated();
 
@@ -930,36 +924,39 @@ class OnboardingController extends Controller
         /** @var \App\Models\User $user */
         $user = $request->user();
 
-        $storedFilePath = null;
-
-        try {
-            $storedFile = $this->submissionFileStorageService->store($file, $submission);
-            $storedFilePath = $storedFile['file_path'];
-
-            $uploadedFile = DB::transaction(fn () => OnboardingSubmissionFile::create([
-                'onboarding_form_submission_id' => $submission->id,
-                'uploaded_by' => $user->id,
-                'document_type' => $validated['document_type'],
-                'document_subtype' => $validated['document_subtype'] ?? null,
-                'file_path' => $storedFile['file_path'],
-                'file_name' => $storedFile['file_name'],
-                'mime_type' => $storedFile['mime_type'],
-                'file_size' => $storedFile['file_size'],
-            ]));
-        } catch (\Throwable $e) {
-            if ($storedFilePath !== null) {
-                Storage::disk('local')->delete($storedFilePath);
-            }
-
-            throw $e;
+        $uploadResult = $this->submissionFileUploadService->upload(
+            $file,
+            $submission,
+            $user->id,
+            $validated,
+        );
+        if ($uploadResult['conflict']) {
+            return response()->json([
+                'message' => __('The upload idempotency key was already used for a different upload.'),
+            ], Response::HTTP_CONFLICT);
         }
 
+        $uploadedFile = $uploadResult['file'];
+        if ($uploadedFile === null) {
+            throw new \LogicException('Onboarding upload completed without a file result');
+        }
+
+        return $this->submissionFileUploadResponse(
+            $uploadedFile,
+            $uploadResult['replayed'] ? Response::HTTP_OK : Response::HTTP_CREATED,
+        );
+    }
+
+    private function submissionFileUploadResponse(
+        OnboardingSubmissionFile $uploadedFile,
+        int $status
+    ): JsonResponse {
         return response()->json([
             'data' => [
                 'id' => $uploadedFile->id,
                 'filename' => $uploadedFile->file_name,
             ],
-        ], Response::HTTP_CREATED);
+        ], $status);
     }
 
     /**

--- a/app/Http/Requests/UploadOnboardingSubmissionFileRequest.php
+++ b/app/Http/Requests/UploadOnboardingSubmissionFileRequest.php
@@ -31,6 +31,7 @@ class UploadOnboardingSubmissionFileRequest extends FormRequest
 
         return [
             'file' => ['bail', 'required', 'file', "max:{$maxKilobytes}", 'mimes:pdf,jpg,jpeg,png', 'mimetypes:application/pdf,image/jpeg,image/png'],
+            'idempotency_key' => ['nullable', 'string', 'min:32', 'max:64', 'regex:/\A[A-Za-z0-9_-]+\z/'],
             'document_type' => ['required', Rule::in([
                 'contract',
                 'id_document',

--- a/app/Models/OnboardingSubmissionFile.php
+++ b/app/Models/OnboardingSubmissionFile.php
@@ -16,10 +16,13 @@ class OnboardingSubmissionFile extends Model
     use SoftDeletes;
 
     protected $fillable = [
+        'tenant_id',
         'onboarding_form_submission_id',
         'uploaded_by',
         'document_type',
         'document_subtype',
+        'idempotency_key',
+        'content_fingerprint',
         'file_path',
         'file_name',
         'mime_type',

--- a/app/Repositories/OnboardingSubmissionFileRepository.php
+++ b/app/Repositories/OnboardingSubmissionFileRepository.php
@@ -1,0 +1,40 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+
+declare(strict_types=1);
+
+namespace App\Repositories;
+
+use App\Models\OnboardingFormSubmission;
+use App\Models\OnboardingSubmissionFile;
+
+class OnboardingSubmissionFileRepository
+{
+    public function tenantId(OnboardingFormSubmission $submission): int
+    {
+        $employee = $submission->employee;
+        if ($employee === null) {
+            throw new \RuntimeException('Onboarding submission is missing its employee relation');
+        }
+
+        return (int) $employee->tenant_id;
+    }
+
+    public function findForTenantAndIdempotencyKey(
+        int $tenantId,
+        string $idempotencyKey,
+    ): ?OnboardingSubmissionFile {
+        return OnboardingSubmissionFile::withTrashed()
+            ->where('tenant_id', $tenantId)
+            ->where('idempotency_key', $idempotencyKey)
+            ->first();
+    }
+
+    /** @param array<string, mixed> $attributes */
+    public function create(array $attributes): OnboardingSubmissionFile
+    {
+        return OnboardingSubmissionFile::query()->create($attributes);
+    }
+}

--- a/app/Services/OnboardingSubmissionFileStorageService.php
+++ b/app/Services/OnboardingSubmissionFileStorageService.php
@@ -6,6 +6,7 @@
 namespace App\Services;
 
 use App\Models\OnboardingFormSubmission;
+use App\Models\TenantKey;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
@@ -13,23 +14,15 @@ use Illuminate\Support\Str;
 class OnboardingSubmissionFileStorageService
 {
     /**
-     * @return array{file_path: string, file_name: string, mime_type: string, file_size: int}
+     * @return array{file_path: string, file_name: string, mime_type: string, file_size: int, blob: string}
      */
-    public function store(UploadedFile $file, OnboardingFormSubmission $submission): array
+    public function prepare(UploadedFile $file, OnboardingFormSubmission $submission): array
     {
-        $content = file_get_contents($file->getRealPath());
-        if ($content === false) {
-            throw new \RuntimeException('Failed to read uploaded onboarding submission file');
-        }
-
+        $content = $this->readContent($file);
+        $tenant = $this->resolveTenant($submission);
         $employee = $submission->employee;
         if ($employee === null) {
             throw new \RuntimeException('Onboarding submission is missing its employee relation');
-        }
-
-        $tenant = $employee->tenant;
-        if ($tenant === null) {
-            throw new \RuntimeException('Onboarding submission employee must belong to a tenant');
         }
 
         $mimeType = $file->getMimeType();
@@ -50,17 +43,61 @@ class OnboardingSubmissionFileStorageService
             'nonce' => base64_encode($encrypted['nonce']),
         ], JSON_THROW_ON_ERROR);
 
-        $stored = Storage::disk('local')->put($path, $blob);
-        if ($stored === false) {
-            throw new \RuntimeException('Failed to store encrypted onboarding submission file blob');
-        }
-
         return [
             'file_path' => $path,
-            'file_name' => $this->sanitizeFilename($file->getClientOriginalName()),
+            'file_name' => $this->sanitizedFilename($file),
             'mime_type' => $mimeType,
             'file_size' => $fileSize,
+            'blob' => $blob,
         ];
+    }
+
+    /**
+     * @param  array{file_path: string, file_name: string, mime_type: string, file_size: int, blob: string}  $preparedFile
+     */
+    public function persist(array $preparedFile): void
+    {
+        if (Storage::disk('local')->put($preparedFile['file_path'], $preparedFile['blob']) === false) {
+            throw new \RuntimeException('Failed to store encrypted onboarding submission file blob');
+        }
+    }
+
+    public function fingerprint(UploadedFile $file, OnboardingFormSubmission $submission): string
+    {
+        $content = $this->readContent($file);
+        $tenant = $this->resolveTenant($submission);
+
+        return bin2hex($tenant->generateBlindIndex($content));
+    }
+
+    public function sanitizedFilename(UploadedFile $file): string
+    {
+        return $this->sanitizeFilename($file->getClientOriginalName());
+    }
+
+    private function readContent(UploadedFile $file): string
+    {
+        $content = file_get_contents($file->getRealPath());
+        if ($content === false) {
+            throw new \RuntimeException('Failed to read uploaded onboarding submission file');
+        }
+
+        return $content;
+    }
+
+    private function resolveTenant(OnboardingFormSubmission $submission): TenantKey
+    {
+        $employee = $submission->employee;
+        if ($employee === null) {
+            throw new \RuntimeException('Onboarding submission is missing its employee relation');
+        }
+
+        $tenant = $employee->tenant;
+        if ($tenant === null) {
+            throw new \RuntimeException('Onboarding submission employee must belong to a tenant');
+        }
+
+        return $tenant;
     }
 
     private function sanitizeFilename(string $fileName): string

--- a/app/Services/OnboardingSubmissionFileStorageService.php
+++ b/app/Services/OnboardingSubmissionFileStorageService.php
@@ -62,12 +62,21 @@ class OnboardingSubmissionFileStorageService
         }
     }
 
-    public function fingerprint(UploadedFile $file, OnboardingFormSubmission $submission): string
-    {
-        $content = $this->readContent($file);
+    public function fingerprint(
+        UploadedFile $file,
+        OnboardingFormSubmission $submission,
+        string $idempotencyKey,
+    ): string {
+        $fingerprintPayload = $this->encodeFingerprintComponents([
+            'onboarding-submission-file:v1',
+            (string) $submission->id,
+            $idempotencyKey,
+            $file->getClientOriginalName(),
+            $this->readContent($file),
+        ]);
         $tenant = $this->resolveTenant($submission);
 
-        return bin2hex($tenant->generateBlindIndex($content));
+        return bin2hex($tenant->generateBlindIndex($fingerprintPayload));
     }
 
     public function sanitizedFilename(UploadedFile $file): string
@@ -83,6 +92,20 @@ class OnboardingSubmissionFileStorageService
         }
 
         return $content;
+    }
+
+    /**
+     * @param  list<string>  $components
+     */
+    private function encodeFingerprintComponents(array $components): string
+    {
+        $payload = '';
+
+        foreach ($components as $component) {
+            $payload .= strlen($component).':'.$component;
+        }
+
+        return $payload;
     }
 
     private function resolveTenant(OnboardingFormSubmission $submission): TenantKey

--- a/app/Services/OnboardingSubmissionFileUploadService.php
+++ b/app/Services/OnboardingSubmissionFileUploadService.php
@@ -1,0 +1,173 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+
+namespace App\Services;
+
+use App\Models\OnboardingFormSubmission;
+use App\Models\OnboardingSubmissionFile;
+use App\Repositories\OnboardingSubmissionFileRepository;
+use Illuminate\Database\QueryException;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Validation\ValidationException;
+
+class OnboardingSubmissionFileUploadService
+{
+    public function __construct(
+        private readonly OnboardingSubmissionFileStorageService $storageService,
+        private readonly OnboardingSubmissionFileRepository $submissionFileRepository,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $validated
+     * @return array{file: OnboardingSubmissionFile|null, replayed: bool, conflict: bool}
+     */
+    public function upload(
+        UploadedFile $file,
+        OnboardingFormSubmission $submission,
+        string|int $uploadedBy,
+        array $validated,
+    ): array {
+        $idempotencyKey = $validated['idempotency_key'] ?? null;
+        $tenantId = $this->submissionFileRepository->tenantId($submission);
+        $contentFingerprint = is_string($idempotencyKey)
+            ? $this->storageService->fingerprint($file, $submission)
+            : null;
+        $fileName = is_string($idempotencyKey)
+            ? $this->storageService->sanitizedFilename($file)
+            : null;
+
+        if (is_string($idempotencyKey)) {
+            $existingUpload = $this->submissionFileRepository
+                ->findForTenantAndIdempotencyKey($tenantId, $idempotencyKey);
+            if ($existingUpload !== null) {
+                return $this->resolveExistingUpload(
+                    $existingUpload,
+                    $submission,
+                    $validated,
+                    $contentFingerprint,
+                    $fileName,
+                );
+            }
+        }
+
+        if (! in_array($submission->status, ['draft', 'rejected'], true)) {
+            throw ValidationException::withMessages([
+                'status' => __('Files can only be uploaded while the onboarding submission is editable'),
+            ]);
+        }
+
+        $storedFilePath = null;
+
+        try {
+            $preparedFile = $this->storageService->prepare($file, $submission);
+
+            $uploadedFile = DB::transaction(function () use (
+                $contentFingerprint,
+                $idempotencyKey,
+                $preparedFile,
+                $submission,
+                $tenantId,
+                $uploadedBy,
+                $validated,
+                &$storedFilePath,
+            ): OnboardingSubmissionFile {
+                $uploadedFile = $this->submissionFileRepository->create([
+                    'tenant_id' => $tenantId,
+                    'onboarding_form_submission_id' => $submission->id,
+                    'uploaded_by' => $uploadedBy,
+                    'document_type' => $validated['document_type'],
+                    'document_subtype' => $validated['document_subtype'] ?? null,
+                    'idempotency_key' => $idempotencyKey,
+                    'content_fingerprint' => $contentFingerprint,
+                    'file_path' => $preparedFile['file_path'],
+                    'file_name' => $preparedFile['file_name'],
+                    'mime_type' => $preparedFile['mime_type'],
+                    'file_size' => $preparedFile['file_size'],
+                ]);
+
+                $storedFilePath = $preparedFile['file_path'];
+                $this->storageService->persist($preparedFile);
+
+                return $uploadedFile;
+            });
+        } catch (QueryException $exception) {
+            $this->deleteStoredFile($storedFilePath, $exception);
+
+            if (
+                is_string($idempotencyKey)
+                && $this->isIdempotencyUniqueViolation($exception)
+            ) {
+                $existingUpload = $this->submissionFileRepository
+                    ->findForTenantAndIdempotencyKey($tenantId, $idempotencyKey);
+                if ($existingUpload !== null) {
+                    return $this->resolveExistingUpload(
+                        $existingUpload,
+                        $submission,
+                        $validated,
+                        $contentFingerprint,
+                        $fileName,
+                    );
+                }
+            }
+
+            throw $exception;
+        } catch (\Throwable $exception) {
+            $this->deleteStoredFile($storedFilePath, $exception);
+
+            throw $exception;
+        }
+
+        return ['file' => $uploadedFile, 'replayed' => false, 'conflict' => false];
+    }
+
+    /**
+     * @param  array<string, mixed>  $validated
+     * @return array{file: OnboardingSubmissionFile|null, replayed: bool, conflict: bool}
+     */
+    private function resolveExistingUpload(
+        OnboardingSubmissionFile $uploadedFile,
+        OnboardingFormSubmission $submission,
+        array $validated,
+        ?string $contentFingerprint,
+        ?string $fileName,
+    ): array {
+        $conflict = $contentFingerprint === null
+            || $fileName === null
+            || $uploadedFile->trashed()
+            || $uploadedFile->onboarding_form_submission_id !== $submission->id
+            || ! hash_equals((string) $uploadedFile->content_fingerprint, $contentFingerprint)
+            || ! hash_equals((string) $uploadedFile->file_name, $fileName)
+            || $uploadedFile->document_type !== $validated['document_type']
+            || $uploadedFile->document_subtype !== ($validated['document_subtype'] ?? null);
+
+        return $conflict
+            ? ['file' => null, 'replayed' => false, 'conflict' => true]
+            : ['file' => $uploadedFile, 'replayed' => true, 'conflict' => false];
+    }
+
+    private function deleteStoredFile(?string $storedFilePath, \Throwable $previous): void
+    {
+        if (
+            $storedFilePath !== null
+            && Storage::disk('local')->delete($storedFilePath) === false
+        ) {
+            throw new \RuntimeException(
+                'Failed to delete stored onboarding submission file after upload failure',
+                previous: $previous,
+            );
+        }
+    }
+
+    private function isIdempotencyUniqueViolation(QueryException $exception): bool
+    {
+        return (string) $exception->getCode() === '23505'
+            && str_contains(
+                $exception->getMessage(),
+                'onboarding_submission_files_idempotency_unique',
+            );
+    }
+}

--- a/app/Services/OnboardingSubmissionFileUploadService.php
+++ b/app/Services/OnboardingSubmissionFileUploadService.php
@@ -34,7 +34,7 @@ class OnboardingSubmissionFileUploadService
         $idempotencyKey = $validated['idempotency_key'] ?? null;
         $tenantId = $this->submissionFileRepository->tenantId($submission);
         $contentFingerprint = is_string($idempotencyKey)
-            ? $this->storageService->fingerprint($file, $submission)
+            ? $this->storageService->fingerprint($file, $submission, $idempotencyKey)
             : null;
         $fileName = is_string($idempotencyKey)
             ? $this->storageService->sanitizedFilename($file)

--- a/database/migrations/2026_08_14_120000_add_idempotency_to_onboarding_submission_files_table.php
+++ b/database/migrations/2026_08_14_120000_add_idempotency_to_onboarding_submission_files_table.php
@@ -32,17 +32,20 @@ return new class extends Migration
                 ->references('id')
                 ->on('tenant_keys')
                 ->cascadeOnDelete();
-            $table->unique(
-                ['tenant_id', 'idempotency_key'],
-                'onboarding_submission_files_idempotency_unique'
-            );
         });
+
+        DB::statement(<<<'SQL'
+            CREATE UNIQUE INDEX onboarding_submission_files_idempotency_unique
+            ON onboarding_submission_files (tenant_id, idempotency_key)
+            WHERE idempotency_key IS NOT NULL
+            SQL);
     }
 
     public function down(): void
     {
+        DB::statement('DROP INDEX IF EXISTS onboarding_submission_files_idempotency_unique');
+
         Schema::table('onboarding_submission_files', function (Blueprint $table): void {
-            $table->dropUnique('onboarding_submission_files_idempotency_unique');
             $table->dropForeign(['tenant_id']);
             $table->dropColumn(['tenant_id', 'idempotency_key', 'content_fingerprint']);
         });

--- a/database/migrations/2026_08_14_120000_add_idempotency_to_onboarding_submission_files_table.php
+++ b/database/migrations/2026_08_14_120000_add_idempotency_to_onboarding_submission_files_table.php
@@ -1,0 +1,50 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('onboarding_submission_files', function (Blueprint $table): void {
+            $table->unsignedBigInteger('tenant_id')->nullable()->after('onboarding_form_submission_id');
+            $table->string('idempotency_key', 64)->nullable()->after('document_subtype');
+            $table->char('content_fingerprint', 64)->nullable()->after('idempotency_key');
+        });
+
+        DB::statement(<<<'SQL'
+            UPDATE onboarding_submission_files AS files
+            SET tenant_id = employees.tenant_id
+            FROM onboarding_form_submissions AS submissions
+            INNER JOIN employees ON employees.id = submissions.employee_id
+            WHERE submissions.id = files.onboarding_form_submission_id
+            SQL);
+        DB::statement('ALTER TABLE onboarding_submission_files ALTER COLUMN tenant_id SET NOT NULL');
+
+        Schema::table('onboarding_submission_files', function (Blueprint $table): void {
+            $table->foreign('tenant_id')
+                ->references('id')
+                ->on('tenant_keys')
+                ->cascadeOnDelete();
+            $table->unique(
+                ['tenant_id', 'idempotency_key'],
+                'onboarding_submission_files_idempotency_unique'
+            );
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('onboarding_submission_files', function (Blueprint $table): void {
+            $table->dropUnique('onboarding_submission_files_idempotency_unique');
+            $table->dropForeign(['tenant_id']);
+            $table->dropColumn(['tenant_id', 'idempotency_key', 'content_fingerprint']);
+        });
+    }
+};

--- a/tests/Feature/Commands/DeleteExpiredEmployeesCommandTest.php
+++ b/tests/Feature/Commands/DeleteExpiredEmployeesCommandTest.php
@@ -72,6 +72,7 @@ test('it deletes expired terminated employees, removes local files, and anonymiz
     ]);
 
     $submissionFile = OnboardingSubmissionFile::create([
+        'tenant_id' => $employee->tenant_id,
         'onboarding_form_submission_id' => $submission->id,
         'uploaded_by' => $user->id,
         'document_type' => 'contract',

--- a/tests/Feature/Controllers/OnboardingControllerTest.php
+++ b/tests/Feature/Controllers/OnboardingControllerTest.php
@@ -1124,6 +1124,7 @@ describe('POST /v1/onboarding/submissions', function () {
         ]);
 
         OnboardingSubmissionFile::create([
+            'tenant_id' => $this->tenant->id,
             'onboarding_form_submission_id' => $submission->id,
             'uploaded_by' => $this->user->id,
             'document_type' => 'id_document',
@@ -2429,6 +2430,186 @@ describe('POST /v1/onboarding/submissions/{submission}/files', function () {
         $this->assertNotEmpty($decoded['nonce']);
     });
 
+    test('returns the original upload when an idempotency key is retried', function (): void {
+        Storage::fake('local');
+        givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.write');
+
+        $submission = OnboardingFormSubmission::factory()->create([
+            'employee_id' => $this->employee->id,
+            'form_template_id' => $this->template->id,
+            'status' => 'draft',
+        ]);
+        $idempotencyKey = str_repeat('a', 32);
+        $payload = [
+            'file' => UploadedFile::fake()->createWithContent('contract.pdf', 'same-contract'),
+            'document_type' => 'contract',
+            'idempotency_key' => $idempotencyKey,
+        ];
+
+        $first = $this->withToken($this->token)
+            ->withHeaders(['Accept' => 'application/json'])
+            ->post("/v1/onboarding/submissions/{$submission->id}/files", $payload);
+        $retry = $this->withToken($this->token)
+            ->withHeaders(['Accept' => 'application/json'])
+            ->post("/v1/onboarding/submissions/{$submission->id}/files", [
+                ...$payload,
+                'file' => UploadedFile::fake()->createWithContent('contract.pdf', 'same-contract'),
+            ]);
+
+        $first->assertCreated();
+        $retry->assertOk()->assertJsonPath('data.id', $first->json('data.id'));
+        expect(OnboardingSubmissionFile::query()->count())->toBe(1);
+        expect(Storage::disk('local')->allFiles())->toHaveCount(1);
+        $storedFile = OnboardingSubmissionFile::query()->sole();
+        expect($storedFile->content_fingerprint)
+            ->toBeString()
+            ->toHaveLength(64)
+            ->not->toBe(hash('sha256', 'same-contract'));
+    });
+
+    test('returns the original upload when a retry arrives after the submission is no longer editable', function (): void {
+        Storage::fake('local');
+        givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.write');
+
+        $submission = OnboardingFormSubmission::factory()->create([
+            'employee_id' => $this->employee->id,
+            'form_template_id' => $this->template->id,
+            'status' => 'draft',
+        ]);
+        $idempotencyKey = str_repeat('b', 32);
+
+        $first = $this->withToken($this->token)
+            ->withHeaders(['Accept' => 'application/json'])
+            ->post("/v1/onboarding/submissions/{$submission->id}/files", [
+                'file' => UploadedFile::fake()->createWithContent('contract.pdf', 'same-contract'),
+                'document_type' => 'contract',
+                'idempotency_key' => $idempotencyKey,
+            ]);
+
+        $submission->update(['status' => 'submitted']);
+
+        $this->withToken($this->token)
+            ->withHeaders(['Accept' => 'application/json'])
+            ->post("/v1/onboarding/submissions/{$submission->id}/files", [
+                'file' => UploadedFile::fake()->createWithContent('contract.pdf', 'same-contract'),
+                'document_type' => 'contract',
+                'idempotency_key' => $idempotencyKey,
+            ])
+            ->assertOk()
+            ->assertJsonPath('data.id', $first->json('data.id'));
+
+        expect(OnboardingSubmissionFile::query()->count())->toBe(1);
+        expect(Storage::disk('local')->allFiles())->toHaveCount(1);
+    });
+
+    test('rejects reuse of an idempotency key for a different upload', function (): void {
+        Storage::fake('local');
+        givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.write');
+
+        $submission = OnboardingFormSubmission::factory()->create([
+            'employee_id' => $this->employee->id,
+            'form_template_id' => $this->template->id,
+            'status' => 'draft',
+        ]);
+        $idempotencyKey = (string) Str::uuid();
+
+        $this->withToken($this->token)
+            ->withHeaders(['Accept' => 'application/json'])
+            ->post("/v1/onboarding/submissions/{$submission->id}/files", [
+                'file' => UploadedFile::fake()->createWithContent('contract.pdf', 'first-contract'),
+                'document_type' => 'contract',
+                'idempotency_key' => $idempotencyKey,
+            ])
+            ->assertCreated();
+
+        $this->withToken($this->token)
+            ->withHeaders(['Accept' => 'application/json'])
+            ->post("/v1/onboarding/submissions/{$submission->id}/files", [
+                'file' => UploadedFile::fake()->createWithContent('contract.pdf', 'different-contract'),
+                'document_type' => 'contract',
+                'idempotency_key' => $idempotencyKey,
+            ])
+            ->assertStatus(409)
+            ->assertJsonPath('message', 'The upload idempotency key was already used for a different upload.');
+
+        expect(OnboardingSubmissionFile::query()->count())->toBe(1);
+        expect(Storage::disk('local')->allFiles())->toHaveCount(1);
+    });
+
+    test('rejects reuse of an idempotency key for a differently named upload', function (): void {
+        Storage::fake('local');
+        givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.write');
+
+        $submission = OnboardingFormSubmission::factory()->create([
+            'employee_id' => $this->employee->id,
+            'form_template_id' => $this->template->id,
+            'status' => 'draft',
+        ]);
+        $idempotencyKey = str_repeat('c', 32);
+
+        $this->withToken($this->token)
+            ->withHeaders(['Accept' => 'application/json'])
+            ->post("/v1/onboarding/submissions/{$submission->id}/files", [
+                'file' => UploadedFile::fake()->createWithContent('contract.pdf', 'same-contract'),
+                'document_type' => 'contract',
+                'idempotency_key' => $idempotencyKey,
+            ])
+            ->assertCreated();
+
+        $this->withToken($this->token)
+            ->withHeaders(['Accept' => 'application/json'])
+            ->post("/v1/onboarding/submissions/{$submission->id}/files", [
+                'file' => UploadedFile::fake()->createWithContent('renamed.pdf', 'same-contract'),
+                'document_type' => 'contract',
+                'idempotency_key' => $idempotencyKey,
+            ])
+            ->assertStatus(409);
+
+        expect(OnboardingSubmissionFile::query()->count())->toBe(1);
+        expect(Storage::disk('local')->allFiles())->toHaveCount(1);
+    });
+
+    test('rejects reuse of an idempotency key for a different submission in the same tenant', function (): void {
+        Storage::fake('local');
+        givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.write');
+
+        $firstSubmission = OnboardingFormSubmission::factory()->create([
+            'employee_id' => $this->employee->id,
+            'form_template_id' => $this->template->id,
+            'status' => 'draft',
+        ]);
+        $secondTemplate = OnboardingFormTemplate::factory()->create([
+            'tenant_id' => $this->tenant->id,
+        ]);
+        $secondSubmission = OnboardingFormSubmission::factory()->create([
+            'employee_id' => $this->employee->id,
+            'form_template_id' => $secondTemplate->id,
+            'status' => 'draft',
+        ]);
+        $idempotencyKey = str_repeat('d', 32);
+
+        $this->withToken($this->token)
+            ->withHeaders(['Accept' => 'application/json'])
+            ->post("/v1/onboarding/submissions/{$firstSubmission->id}/files", [
+                'file' => UploadedFile::fake()->createWithContent('contract.pdf', 'same-contract'),
+                'document_type' => 'contract',
+                'idempotency_key' => $idempotencyKey,
+            ])
+            ->assertCreated();
+
+        $this->withToken($this->token)
+            ->withHeaders(['Accept' => 'application/json'])
+            ->post("/v1/onboarding/submissions/{$secondSubmission->id}/files", [
+                'file' => UploadedFile::fake()->createWithContent('contract.pdf', 'same-contract'),
+                'document_type' => 'contract',
+                'idempotency_key' => $idempotencyKey,
+            ])
+            ->assertStatus(409);
+
+        expect(OnboardingSubmissionFile::query()->count())->toBe(1);
+        expect(Storage::disk('local')->allFiles())->toHaveCount(1);
+    });
+
     test('requires a document_subtype when uploading id_document files', function (): void {
         Storage::fake('local');
         givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.write');
@@ -2577,6 +2758,7 @@ describe('DELETE /v1/onboarding/submissions/{submission}/files/{file}', function
         Storage::disk('local')->put($path, '{"ciphertext":"abc","nonce":"def"}');
 
         $uploadedFile = OnboardingSubmissionFile::create([
+            'tenant_id' => $this->tenant->id,
             'onboarding_form_submission_id' => $submission->id,
             'uploaded_by' => $this->user->id,
             'document_type' => 'id_document',
@@ -2614,6 +2796,7 @@ describe('DELETE /v1/onboarding/submissions/{submission}/files/{file}', function
         ]);
 
         $uploadedFile = OnboardingSubmissionFile::create([
+            'tenant_id' => $this->tenant->id,
             'onboarding_form_submission_id' => $otherSubmission->id,
             'uploaded_by' => $this->user->id,
             'document_type' => 'id_document',

--- a/tests/Feature/Controllers/OnboardingControllerTest.php
+++ b/tests/Feature/Controllers/OnboardingControllerTest.php
@@ -2502,6 +2502,45 @@ describe('POST /v1/onboarding/submissions/{submission}/files', function () {
         expect(Storage::disk('local')->allFiles())->toHaveCount(1);
     });
 
+    test('rejects reuse of an idempotency key after the original upload is deleted', function (): void {
+        Storage::fake('local');
+        givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.write');
+
+        $submission = OnboardingFormSubmission::factory()->create([
+            'employee_id' => $this->employee->id,
+            'form_template_id' => $this->template->id,
+            'status' => 'draft',
+        ]);
+        $idempotencyKey = str_repeat('e', 32);
+        $payload = [
+            'file' => UploadedFile::fake()->createWithContent('contract.pdf', 'same-contract'),
+            'document_type' => 'contract',
+            'idempotency_key' => $idempotencyKey,
+        ];
+
+        $first = $this->withToken($this->token)
+            ->withHeaders(['Accept' => 'application/json'])
+            ->post("/v1/onboarding/submissions/{$submission->id}/files", $payload)
+            ->assertCreated();
+
+        $this->withToken($this->token)
+            ->delete("/v1/onboarding/submissions/{$submission->id}/files/{$first->json('data.id')}")
+            ->assertNoContent();
+
+        $this->withToken($this->token)
+            ->withHeaders(['Accept' => 'application/json'])
+            ->post("/v1/onboarding/submissions/{$submission->id}/files", [
+                ...$payload,
+                'file' => UploadedFile::fake()->createWithContent('contract.pdf', 'same-contract'),
+            ])
+            ->assertStatus(409)
+            ->assertJsonPath('message', 'The upload idempotency key was already used for a different upload.');
+
+        expect(OnboardingSubmissionFile::query()->count())->toBe(0)
+            ->and(OnboardingSubmissionFile::withTrashed()->count())->toBe(1)
+            ->and(Storage::disk('local')->allFiles())->toHaveCount(0);
+    });
+
     test('rejects reuse of an idempotency key for a different upload', function (): void {
         Storage::fake('local');
         givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.write');

--- a/tests/Feature/Controllers/OnboardingControllerTest.php
+++ b/tests/Feature/Controllers/OnboardingControllerTest.php
@@ -2467,6 +2467,35 @@ describe('POST /v1/onboarding/submissions/{submission}/files', function () {
             ->not->toBe(hash('sha256', 'same-contract'));
     });
 
+    test('does not expose equal content fingerprints across distinct upload operations', function (): void {
+        Storage::fake('local');
+        givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.write');
+
+        $submission = OnboardingFormSubmission::factory()->create([
+            'employee_id' => $this->employee->id,
+            'form_template_id' => $this->template->id,
+            'status' => 'draft',
+        ]);
+
+        foreach ([str_repeat('f', 32), str_repeat('g', 32)] as $idempotencyKey) {
+            $this->withToken($this->token)
+                ->withHeaders(['Accept' => 'application/json'])
+                ->post("/v1/onboarding/submissions/{$submission->id}/files", [
+                    'file' => UploadedFile::fake()->createWithContent('contract.pdf', 'same-contract'),
+                    'document_type' => 'contract',
+                    'idempotency_key' => $idempotencyKey,
+                ])
+                ->assertCreated();
+        }
+
+        $fingerprints = OnboardingSubmissionFile::query()
+            ->orderBy('created_at')
+            ->pluck('content_fingerprint');
+
+        expect($fingerprints)->toHaveCount(2)
+            ->and($fingerprints->unique())->toHaveCount(2);
+    });
+
     test('returns the original upload when a retry arrives after the submission is no longer editable', function (): void {
         Storage::fake('local');
         givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.write');
@@ -2603,6 +2632,41 @@ describe('POST /v1/onboarding/submissions/{submission}/files', function () {
                 'idempotency_key' => $idempotencyKey,
             ])
             ->assertStatus(409);
+
+        expect(OnboardingSubmissionFile::query()->count())->toBe(1);
+        expect(Storage::disk('local')->allFiles())->toHaveCount(1);
+    });
+
+    test('rejects reuse of an idempotency key when distinct original filenames sanitize identically', function (): void {
+        Storage::fake('local');
+        givePermissionWithTenant($this->user, $this->tenant->id, 'onboarding.write');
+
+        $submission = OnboardingFormSubmission::factory()->create([
+            'employee_id' => $this->employee->id,
+            'form_template_id' => $this->template->id,
+            'status' => 'draft',
+        ]);
+        $idempotencyKey = str_repeat('h', 32);
+        $sharedPrefix = str_repeat('a', 251);
+
+        $this->withToken($this->token)
+            ->withHeaders(['Accept' => 'application/json'])
+            ->post("/v1/onboarding/submissions/{$submission->id}/files", [
+                'file' => UploadedFile::fake()->createWithContent($sharedPrefix.'first.pdf', 'same-contract'),
+                'document_type' => 'contract',
+                'idempotency_key' => $idempotencyKey,
+            ])
+            ->assertCreated();
+
+        $this->withToken($this->token)
+            ->withHeaders(['Accept' => 'application/json'])
+            ->post("/v1/onboarding/submissions/{$submission->id}/files", [
+                'file' => UploadedFile::fake()->createWithContent($sharedPrefix.'second.pdf', 'same-contract'),
+                'document_type' => 'contract',
+                'idempotency_key' => $idempotencyKey,
+            ])
+            ->assertStatus(409)
+            ->assertJsonPath('message', 'The upload idempotency key was already used for a different upload.');
 
         expect(OnboardingSubmissionFile::query()->count())->toBe(1);
         expect(Storage::disk('local')->allFiles())->toHaveCount(1);

--- a/tests/Feature/Migrations/EmployeeAddressesTableMigrationTest.php
+++ b/tests/Feature/Migrations/EmployeeAddressesTableMigrationTest.php
@@ -28,6 +28,11 @@ function loadDropLegacyEmployeeAddressColumnsMigration(): object
     return require database_path('migrations/2026_05_10_120001_drop_legacy_employee_address_columns_from_employees_table.php');
 }
 
+function loadLegalEntityDomainMigration(): object
+{
+    return require database_path('migrations/2026_07_17_120000_create_legal_entity_domain_model.php');
+}
+
 function encryptLegacyAddressValue(int $tenantId, ?string $value): ?string
 {
     if ($value === null) {
@@ -99,7 +104,7 @@ test('the breaking legal entity migration prevents rollback into an unsupported 
     expect(Schema::hasColumn('employees', 'birth_state'))->toBeFalse();
     expect(Schema::hasColumn('employee_addresses', 'state'))->toBeFalse();
 
-    expect(fn () => $this->artisan('migrate:rollback', ['--step' => 1]))
+    expect(fn () => loadLegalEntityDomainMigration()->down())
         ->toThrow(RuntimeException::class, 'intentionally irreversible');
 });
 

--- a/tests/Feature/Migrations/OnboardingSubmissionFileIdempotencyMigrationTest.php
+++ b/tests/Feature/Migrations/OnboardingSubmissionFileIdempotencyMigrationTest.php
@@ -1,0 +1,26 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+
+uses(RefreshDatabase::class);
+
+test('onboarding upload idempotency uniqueness excludes uploads without a key', function (): void {
+    $indexDefinitions = array_map(
+        static fn (object $row): string => (string) $row->indexdef,
+        DB::select(<<<'SQL'
+            SELECT indexdef
+            FROM pg_indexes
+            WHERE schemaname = current_schema()
+              AND tablename = 'onboarding_submission_files'
+              AND indexname = 'onboarding_submission_files_idempotency_unique'
+            SQL),
+    );
+
+    expect($indexDefinitions)->toHaveCount(1)
+        ->and(strtolower($indexDefinitions[0]))
+        ->toContain('where (idempotency_key is not null)');
+});

--- a/tests/Feature/Services/EmployeeLifecycleServiceTest.php
+++ b/tests/Feature/Services/EmployeeLifecycleServiceTest.php
@@ -425,6 +425,7 @@ test('employee lifecycle service deletes a linked user while preserving employee
     ]);
 
     $submissionFile = OnboardingSubmissionFile::create([
+        'tenant_id' => $this->tenant->id,
         'onboarding_form_submission_id' => $submission->id,
         'uploaded_by' => $linkedUser->id,
         'document_type' => 'contract',

--- a/tests/Unit/Services/OnboardingSubmissionFileUploadServiceTest.php
+++ b/tests/Unit/Services/OnboardingSubmissionFileUploadServiceTest.php
@@ -1,0 +1,160 @@
+<?php
+
+// SPDX-FileCopyrightText: 2026 SecPal Contributors
+// SPDX-License-Identifier: AGPL-3.0-or-later AND LicenseRef-SecPal-Attribution
+
+use App\Models\OnboardingFormSubmission;
+use App\Models\OnboardingSubmissionFile;
+use App\Repositories\OnboardingSubmissionFileRepository;
+use App\Services\OnboardingSubmissionFileStorageService;
+use App\Services\OnboardingSubmissionFileUploadService;
+use Illuminate\Database\QueryException;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+
+uses()->group('unit', 'services', 'onboarding');
+
+function onboardingUploadQueryException(string $sqlState, string $constraint): QueryException
+{
+    $previous = new PDOException("SQLSTATE[{$sqlState}]: {$constraint}", (int) $sqlState);
+    $previous->errorInfo = [$sqlState, 7, $constraint];
+
+    return new QueryException('pgsql', 'insert into onboarding_submission_files', [], $previous);
+}
+
+test('resolves the winning upload when the tenant idempotency constraint loses a race', function (): void {
+    $submission = new OnboardingFormSubmission([
+        'status' => 'draft',
+    ]);
+    $submission->id = 'submission-1';
+    $file = UploadedFile::fake()->createWithContent('contract.pdf', 'same-contract');
+    $existingUpload = new OnboardingSubmissionFile([
+        'tenant_id' => 7,
+        'onboarding_form_submission_id' => $submission->id,
+        'document_type' => 'contract',
+        'document_subtype' => null,
+        'idempotency_key' => str_repeat('a', 32),
+        'content_fingerprint' => str_repeat('f', 64),
+        'file_name' => 'contract.pdf',
+    ]);
+
+    $storageService = Mockery::mock(OnboardingSubmissionFileStorageService::class);
+    $storageService->shouldReceive('fingerprint')->once()->andReturn(str_repeat('f', 64));
+    $storageService->shouldReceive('sanitizedFilename')->once()->andReturn('contract.pdf');
+    $storageService->shouldReceive('prepare')->once()->andReturn([
+        'file_path' => 'employees/employee-1/onboarding-submissions/submission-1/file.enc',
+        'file_name' => 'contract.pdf',
+        'mime_type' => 'application/pdf',
+        'file_size' => 13,
+        'blob' => 'encrypted',
+    ]);
+    $storageService->shouldNotReceive('persist');
+
+    $repository = Mockery::mock(OnboardingSubmissionFileRepository::class);
+    $repository->shouldReceive('tenantId')->once()->with($submission)->andReturn(7);
+    $repository->shouldReceive('findForTenantAndIdempotencyKey')
+        ->twice()
+        ->with(7, str_repeat('a', 32))
+        ->andReturn(null, $existingUpload);
+    $repository->shouldReceive('create')
+        ->once()
+        ->andThrow(onboardingUploadQueryException(
+            '23505',
+            'onboarding_submission_files_idempotency_unique',
+        ));
+
+    $result = (new OnboardingSubmissionFileUploadService($storageService, $repository))->upload(
+        $file,
+        $submission,
+        'user-1',
+        [
+            'document_type' => 'contract',
+            'idempotency_key' => str_repeat('a', 32),
+        ],
+    );
+
+    expect($result)->toMatchArray([
+        'file' => $existingUpload,
+        'replayed' => true,
+        'conflict' => false,
+    ]);
+});
+
+test('fails instead of reporting success when a persisted blob cannot be cleaned up', function (): void {
+    $submission = new OnboardingFormSubmission(['status' => 'draft']);
+    $submission->id = 'submission-1';
+    $file = UploadedFile::fake()->createWithContent('contract.pdf', 'same-contract');
+    $storedPath = 'employees/employee-1/onboarding-submissions/submission-1/file.enc';
+
+    $storageService = Mockery::mock(OnboardingSubmissionFileStorageService::class);
+    $storageService->shouldReceive('fingerprint')->once()->andReturn(str_repeat('f', 64));
+    $storageService->shouldReceive('sanitizedFilename')->once()->andReturn('contract.pdf');
+    $storageService->shouldReceive('prepare')->once()->andReturn([
+        'file_path' => $storedPath,
+        'file_name' => 'contract.pdf',
+        'mime_type' => 'application/pdf',
+        'file_size' => 13,
+        'blob' => 'encrypted',
+    ]);
+    $storageService->shouldReceive('persist')->once();
+
+    $uploadedFile = new OnboardingSubmissionFile;
+    $repository = Mockery::mock(OnboardingSubmissionFileRepository::class);
+    $repository->shouldReceive('tenantId')->once()->andReturn(7);
+    $repository->shouldReceive('findForTenantAndIdempotencyKey')->once()->andReturnNull();
+    $repository->shouldReceive('create')->once()->andReturn($uploadedFile);
+
+    DB::shouldReceive('transaction')->once()->andReturnUsing(function (callable $callback): never {
+        $callback();
+
+        throw onboardingUploadQueryException('40001', 'serialization_failure');
+    });
+    $disk = Mockery::mock();
+    $disk->shouldReceive('delete')->once()->with($storedPath)->andReturnFalse();
+    Storage::shouldReceive('disk')->once()->with('local')->andReturn($disk);
+
+    expect(fn () => (new OnboardingSubmissionFileUploadService($storageService, $repository))->upload(
+        $file,
+        $submission,
+        'user-1',
+        [
+            'document_type' => 'contract',
+            'idempotency_key' => str_repeat('a', 32),
+        ],
+    ))->toThrow(RuntimeException::class, 'Failed to delete stored onboarding submission file');
+});
+
+test('does not treat unrelated database failures as upload races', function (): void {
+    $submission = new OnboardingFormSubmission(['status' => 'draft']);
+    $submission->id = 'submission-1';
+    $file = UploadedFile::fake()->createWithContent('contract.pdf', 'same-contract');
+    $exception = onboardingUploadQueryException('23505', 'other_unique_constraint');
+
+    $storageService = Mockery::mock(OnboardingSubmissionFileStorageService::class);
+    $storageService->shouldReceive('fingerprint')->once()->andReturn(str_repeat('f', 64));
+    $storageService->shouldReceive('sanitizedFilename')->once()->andReturn('contract.pdf');
+    $storageService->shouldReceive('prepare')->once()->andReturn([
+        'file_path' => 'employees/employee-1/onboarding-submissions/submission-1/file.enc',
+        'file_name' => 'contract.pdf',
+        'mime_type' => 'application/pdf',
+        'file_size' => 13,
+        'blob' => 'encrypted',
+    ]);
+    $storageService->shouldNotReceive('persist');
+
+    $repository = Mockery::mock(OnboardingSubmissionFileRepository::class);
+    $repository->shouldReceive('tenantId')->once()->andReturn(7);
+    $repository->shouldReceive('findForTenantAndIdempotencyKey')->once()->andReturnNull();
+    $repository->shouldReceive('create')->once()->andThrow($exception);
+
+    expect(fn () => (new OnboardingSubmissionFileUploadService($storageService, $repository))->upload(
+        $file,
+        $submission,
+        'user-1',
+        [
+            'document_type' => 'contract',
+            'idempotency_key' => str_repeat('a', 32),
+        ],
+    ))->toThrow($exception);
+});

--- a/tests/Unit/Services/OnboardingSubmissionFileUploadServiceTest.php
+++ b/tests/Unit/Services/OnboardingSubmissionFileUploadServiceTest.php
@@ -40,7 +40,10 @@ test('resolves the winning upload when the tenant idempotency constraint loses a
     ]);
 
     $storageService = Mockery::mock(OnboardingSubmissionFileStorageService::class);
-    $storageService->shouldReceive('fingerprint')->once()->andReturn(str_repeat('f', 64));
+    $storageService->shouldReceive('fingerprint')
+        ->once()
+        ->with($file, $submission, str_repeat('a', 32))
+        ->andReturn(str_repeat('f', 64));
     $storageService->shouldReceive('sanitizedFilename')->once()->andReturn('contract.pdf');
     $storageService->shouldReceive('prepare')->once()->andReturn([
         'file_path' => 'employees/employee-1/onboarding-submissions/submission-1/file.enc',
@@ -88,7 +91,10 @@ test('fails instead of reporting success when a persisted blob cannot be cleaned
     $storedPath = 'employees/employee-1/onboarding-submissions/submission-1/file.enc';
 
     $storageService = Mockery::mock(OnboardingSubmissionFileStorageService::class);
-    $storageService->shouldReceive('fingerprint')->once()->andReturn(str_repeat('f', 64));
+    $storageService->shouldReceive('fingerprint')
+        ->once()
+        ->with($file, $submission, str_repeat('a', 32))
+        ->andReturn(str_repeat('f', 64));
     $storageService->shouldReceive('sanitizedFilename')->once()->andReturn('contract.pdf');
     $storageService->shouldReceive('prepare')->once()->andReturn([
         'file_path' => $storedPath,
@@ -132,7 +138,10 @@ test('does not treat unrelated database failures as upload races', function (): 
     $exception = onboardingUploadQueryException('23505', 'other_unique_constraint');
 
     $storageService = Mockery::mock(OnboardingSubmissionFileStorageService::class);
-    $storageService->shouldReceive('fingerprint')->once()->andReturn(str_repeat('f', 64));
+    $storageService->shouldReceive('fingerprint')
+        ->once()
+        ->with($file, $submission, str_repeat('a', 32))
+        ->andReturn(str_repeat('f', 64));
     $storageService->shouldReceive('sanitizedFilename')->once()->andReturn('contract.pdf');
     $storageService->shouldReceive('prepare')->once()->andReturn([
         'file_path' => 'employees/employee-1/onboarding-submissions/submission-1/file.enc',


### PR DESCRIPTION
## Summary

Related to #1422.

Android can cancel authenticated upload transport after an onboarding file has committed but before it receives the response. Retrying the selected file previously created another encrypted blob and database row.

This change adds an optional bounded `idempotency_key` to onboarding file uploads. It records a tenant-scoped key and encrypted content fingerprint, replays the original resource for an exact retry (including after the submission becomes non-editable), returns `409 Conflict` when the same key represents different content, metadata, or submission, and resolves unique-constraint races without leaving a duplicate blob. The migration backfills tenant ownership and adds the database constraint.

The tests cover exact retries, retries after submission state changes, conflicting content, filename, and submission reuse, plus database-race and cleanup failure paths.

## Validation

- `php artisan test tests/Unit/Services/OnboardingSubmissionFileUploadServiceTest.php tests/Feature/Controllers/OnboardingControllerTest.php tests/Feature/Migrations/EmployeeAddressesTableMigrationTest.php tests/Feature/Commands/DeleteExpiredEmployeesCommandTest.php tests/Feature/Services/EmployeeLifecycleServiceTest.php` — 162 passed, 1,063 assertions
- `vendor/bin/pint --dirty`
- `composer run analyse`
- `reuse lint`
- `git diff --check`
- Commit hooks (REUSE, markdownlint, Laravel Pint, and repository hygiene checks)

## Readiness

This PR remains draft because #1422 also requires an OpenAPI contract update, but the repository has no OpenAPI source artifact. That gap is tracked in #1423. No hosted CI status has been inspected.
